### PR TITLE
Process constructors errors

### DIFF
--- a/libs/pavex/src/language/resolved_path.rs
+++ b/libs/pavex/src/language/resolved_path.rs
@@ -263,6 +263,15 @@ pub(crate) enum ParseError {
     PathMustBeAbsolute(#[from] PathMustBeAbsolute),
 }
 
+impl ParseError {
+    pub(crate) fn raw_identifiers(&self) -> &RawCallableIdentifiers {
+        match self {
+            ParseError::InvalidPath(e) => &e.raw_identifiers,
+            ParseError::PathMustBeAbsolute(e) => &e.raw_identifiers,
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) struct PathMustBeAbsolute {
     pub raw_identifiers: RawCallableIdentifiers,

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -246,18 +246,14 @@ impl App {
             match resolve_constructors(&constructor_paths, &mut krate_collection, &package_graph) {
                 Ok((resolver, constructors)) => (resolver, constructors),
                 Err(e) => {
-                    return match e {
-                        ConstructorResolutionError::CallableResolutionError(e) => Err(e
-                            .into_diagnostic(
-                                &resolved_paths2identifiers,
-                                |identifiers| {
-                                    app_blueprint.constructor_locations[identifiers].clone()
-                                },
-                                &package_graph,
-                                CallableType::Constructor,
-                            )?
-                            .into()),
-                    };
+                    return Err(e
+                        .into_diagnostic(
+                            &resolved_paths2identifiers,
+                            |identifiers| app_blueprint.constructor_locations[identifiers].clone(),
+                            &package_graph,
+                            CallableType::Constructor,
+                        )?
+                        .into());
                 }
             };
 
@@ -560,7 +556,7 @@ fn resolve_constructors(
         BiHashMap<ResolvedPath, Callable>,
         IndexMap<ResolvedType, Callable>,
     ),
-    ConstructorResolutionError,
+    CallableResolutionError,
 > {
     let mut resolution_map = BiHashMap::with_capacity(constructor_paths.len());
     let mut constructors = IndexMap::with_capacity(constructor_paths.len());
@@ -769,12 +765,6 @@ fn resolve_callable(
         callable_fq_path: callable_path.to_owned(),
         inputs: parameter_paths,
     })
-}
-
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum ConstructorResolutionError {
-    #[error(transparent)]
-    CallableResolutionError(#[from] CallableResolutionError),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -315,7 +315,7 @@ impl App {
                             &source.parsed,
                             location,
                         )
-                        .map(|s| s.labeled("The callable we cannot resolve".into()));
+                        .map(|s| s.labeled("The handler that we cannot resolve".into()));
                         let diagnostic = CompilerDiagnosticBuilder::new(source, e)
                             .optional_label(label)
                             .help("This is most likely a bug in `pavex` or `rustdoc`.\nPlease file a GitHub issue!".into())
@@ -402,7 +402,7 @@ impl App {
                             &source.parsed,
                             location,
                         )
-                        .map(|s| s.labeled("The callable was registered here".into()));
+                        .map(|s| s.labeled("The handler was registered here".into()));
                         let diagnostic = CompilerDiagnosticBuilder::new(source, e)
                             .optional_label(label)
                             .optional_related_error(sub_diagnostic)

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -174,7 +174,7 @@ impl App {
                             &package_graph.workspace(),
                         )
                         .map_err(miette::MietteError::IoError)?;
-                        let label = diagnostic::get_callable_invocation_span(
+                        let label = diagnostic::get_f_macro_invocation_span(
                             &source.contents,
                             &source.parsed,
                             location,
@@ -196,7 +196,7 @@ impl App {
                             &package_graph.workspace(),
                         )
                         .map_err(miette::MietteError::IoError)?;
-                        let label = diagnostic::get_callable_invocation_span(
+                        let label = diagnostic::get_f_macro_invocation_span(
                             &source.contents,
                             &source.parsed,
                             location,
@@ -258,7 +258,13 @@ impl App {
                 Ok((resolver, constructors)) => (resolver, constructors),
                 Err(e) => {
                     return match e {
-                        ConstructorResolutionError::CallableResolutionError(_) => Err(miette!(e)),
+                        ConstructorResolutionError::CallableResolutionError(e) => match e {
+                            CallableResolutionError::UnsupportedCallableKind(_)
+                            | CallableResolutionError::UnknownCallable(_)
+                            | CallableResolutionError::ParameterResolutionError(_)
+                            | CallableResolutionError::OutputTypeResolutionError(_)
+                            | CallableResolutionError::CannotGetCrateData(_) => Err(miette!(e)),
+                        },
                         ConstructorResolutionError::ConstructorsCannotReturnTheUnitType(
                             ref constructor_path,
                         ) => {
@@ -272,7 +278,7 @@ impl App {
                                 &package_graph.workspace(),
                             )
                             .map_err(miette::MietteError::IoError)?;
-                            let label = diagnostic::get_callable_invocation_span(
+                            let label = diagnostic::get_f_macro_invocation_span(
                                 &source.contents,
                                 &source.parsed,
                                 location,
@@ -310,7 +316,7 @@ impl App {
                             &package_graph.workspace(),
                         )
                         .map_err(miette::MietteError::IoError)?;
-                        let label = diagnostic::get_callable_invocation_span(
+                        let label = diagnostic::get_f_macro_invocation_span(
                             &source.contents,
                             &source.parsed,
                             location,
@@ -397,7 +403,7 @@ impl App {
                             &package_graph.workspace(),
                         )
                         .map_err(miette::MietteError::IoError)?;
-                        let label = diagnostic::get_callable_invocation_span(
+                        let label = diagnostic::get_f_macro_invocation_span(
                             &source.contents,
                             &source.parsed,
                             location,

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -164,10 +164,7 @@ impl App {
                         map.entry(p).or_default().insert(raw_identifier.to_owned());
                     }
                     Err(e) => {
-                        let identifiers = match &e {
-                            ParseError::InvalidPath(e) => &e.raw_identifiers,
-                            ParseError::PathMustBeAbsolute(e) => &e.raw_identifiers,
-                        };
+                        let identifiers = e.raw_identifiers();
                         let location = app_blueprint
                             .constructor_locations
                             .get(identifiers)
@@ -183,18 +180,17 @@ impl App {
                             &source.parsed,
                             location,
                         );
-                        let diagnostic_builder = CompilerDiagnosticBuilder::new(source, e);
                         let diagnostic = match e {
                             ParseError::InvalidPath(_) => {
                                 let label = source_span
                                     .labeled("The invalid import path was registered here".into());
-                                diagnostic_builder
+                                CompilerDiagnosticBuilder::new(source, e)
                                     .optional_label(label)
                             }
                             ParseError::PathMustBeAbsolute(_) => {
                                 let label = source_span
                                     .labeled("The relative import path was registered here".into());
-                                diagnostic_builder
+                                CompilerDiagnosticBuilder::new(source, e)
                                     .optional_label(label)
                                     .help("If it is a local import, the path must start with `crate::`.\nIf it is an import from a dependency, the path must start with the dependency name (e.g. `dependency::`).".into())
                             }

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -512,7 +512,7 @@ impl App {
                             .build();
                         Err(diagnostic.into())
                     }
-                    CallableResolutionError::CannotGetCrateData(_) => Err(miette!(e)),
+                    CallableResolutionError::CannotGetCrateData(e) => Err(miette!(e)),
                 };
             }
         };

--- a/libs/pavex/src/web/diagnostic.rs
+++ b/libs/pavex/src/web/diagnostic.rs
@@ -157,7 +157,7 @@ pub fn get_f_macro_invocation_span(
         node: Option<&'a ExprMethodCall>,
     }
 
-    impl<'a> syn::visit::Visit<'a> for CallableLocator<'a> {
+    impl<'a> Visit<'a> for CallableLocator<'a> {
         fn visit_expr_method_call(&mut self, node: &'a ExprMethodCall) {
             if node.span().contains(self.location) {
                 self.node = Some(node);
@@ -190,11 +190,27 @@ pub fn get_f_macro_invocation_span(
 /// Helper methods to reduce boilerplate when working with [`miette::SourceSpan`]s.  
 /// We might eventually want to upstream them.
 pub trait SourceSpanExt {
-    fn labeled(self, label_msg: String) -> miette::LabeledSpan;
-    fn unlabeled(self) -> miette::LabeledSpan;
+    fn labeled(self, label_msg: String) -> LabeledSpan;
+    fn unlabeled(self) -> LabeledSpan;
 }
 
-impl SourceSpanExt for miette::SourceSpan {
+/// Helper methods to reduce boilerplate when working with an optional [`miette::SourceSpan`].  
+pub trait OptionalSourceSpanExt {
+    fn labeled(self, label_msg: String) -> Option<LabeledSpan>;
+    fn unlabeled(self) -> Option<LabeledSpan>;
+}
+
+impl OptionalSourceSpanExt for Option<SourceSpan> {
+    fn labeled(self, label_msg: String) -> Option<LabeledSpan> {
+        self.map(|s| s.labeled(label_msg))
+    }
+
+    fn unlabeled(self) -> Option<LabeledSpan> {
+        self.map(|s| s.unlabeled())
+    }
+}
+
+impl SourceSpanExt for SourceSpan {
     fn labeled(self, label_msg: String) -> LabeledSpan {
         LabeledSpan::new_with_span(Some(label_msg), self)
     }
@@ -227,7 +243,7 @@ impl ProcMacroSpanExt for proc_macro2::Span {
     }
 }
 
-pub fn convert_span(source: &str, span: proc_macro2::Span) -> miette::SourceSpan {
+pub fn convert_span(source: &str, span: proc_macro2::Span) -> SourceSpan {
     // No idea why the +1 is required, but I kept getting labeled spans that were _consistently_
     // shifted by one character. So...
     let start = SourceOffset::from_location(source, span.start().line, span.start().column + 1);
@@ -236,7 +252,7 @@ pub fn convert_span(source: &str, span: proc_macro2::Span) -> miette::SourceSpan
     SourceSpan::from((start.offset(), len))
 }
 
-pub fn convert_rustdoc_span(source: &str, span: rustdoc_types::Span) -> miette::SourceSpan {
+pub fn convert_rustdoc_span(source: &str, span: rustdoc_types::Span) -> SourceSpan {
     // No idea why the +1 is required, but I kept getting labeled spans that were _consistently_
     // shifted by one character. So...
     let start = SourceOffset::from_location(source, span.begin.0, span.begin.1 + 1);

--- a/libs/pavex/src/web/diagnostic.rs
+++ b/libs/pavex/src/web/diagnostic.rs
@@ -147,7 +147,7 @@ impl miette::Diagnostic for CompilerDiagnostic {
 /// There are going to be multiple nodes that match if we are dealing with chained method calls.
 /// Luckily enough, the visit is pre-order, therefore the latest node that contains `location`
 /// is also the smallest node that contains it - exactly what we are looking for.
-pub fn get_callable_invocation_span(
+pub fn get_f_macro_invocation_span(
     raw_source: &str,
     parsed_source: &syn::File,
     location: &Location,

--- a/libs/pavex/src/web/diagnostic.rs
+++ b/libs/pavex/src/web/diagnostic.rs
@@ -132,7 +132,7 @@ impl miette::Diagnostic for CompilerDiagnostic {
 /// ```rust,ignore
 /// App::builder()
 ///   .route(f!(crate::stream_file::<std::path::PathBuf>), "/home")
-/// //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 /// //       We want a SourceSpan that points at this!
 /// ```
 ///

--- a/libs/pavex_cli/tests/ui_tests/constructors_cannot_return_the_unit_type/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/constructors_cannot_return_the_unit_type/expectations/stderr.txt
@@ -1,0 +1,10 @@
+Error: 
+  × I expect all constructors to return *something*.
+  │ This constructor doesn't, it returns the unit type - `()`.
+    ╭─[src/lib.rs:12:1]
+ 12 │     AppBlueprint::new()
+ 13 │         .constructor(f!(crate::bogus_constructor), Lifecycle::Singleton)
+    ·                      ──────────────┬─────────────
+    ·                                    ╰── The constructor was registered here
+ 14 │         .route(f!(crate::handler), "/home")
+    ╰────

--- a/libs/pavex_cli/tests/ui_tests/constructors_cannot_return_the_unit_type/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/constructors_cannot_return_the_unit_type/lib.rs
@@ -1,0 +1,15 @@
+use pavex_builder::{f, AppBlueprint, Lifecycle};
+
+pub fn bogus_constructor() {
+    todo!()
+}
+
+pub fn handler() -> http::Response<hyper::body::Body> {
+    todo!()
+}
+
+pub fn blueprint() -> AppBlueprint {
+    AppBlueprint::new()
+        .constructor(f!(crate::bogus_constructor), Lifecycle::Singleton)
+        .route(f!(crate::handler), "/home")
+}

--- a/libs/pavex_cli/tests/ui_tests/constructors_cannot_return_the_unit_type/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/constructors_cannot_return_the_unit_type/test_config.toml
@@ -1,0 +1,8 @@
+description = "pavex expectes all constructors to _construct something_! They cannot return the unit type."
+
+[expectations]
+codegen = "fail"
+
+[dependencies]
+http = "0.2"
+hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/generic_handlers_are_not_supported/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/generic_handlers_are_not_supported/expectations/stderr.txt
@@ -5,7 +5,7 @@ Error:
  7 │ pub fn blueprint() -> AppBlueprint {
  8 │     AppBlueprint::new().route(f!(crate::stream_file::<std::path::PathBuf>), "/home")
    ·                               ──────────────────────┬─────────────────────
-   ·                                                     ╰── The callable was registered here
+   ·                                                     ╰── The handler was registered here
  9 │ }
    ╰────
 

--- a/libs/pavex_cli/tests/ui_tests/local_callable_paths_must_be_prefixed_with_crate/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/local_callable_paths_must_be_prefixed_with_crate/expectations/stderr.txt
@@ -4,7 +4,7 @@ Error:
  7 │ pub fn blueprint() -> AppBlueprint {
  8 │     AppBlueprint::new().route(f!(handler), "/home")
    ·                               ─────┬─────
-   ·                                    ╰── The invalid import path was registered here
+   ·                                    ╰── The relative import path was registered here
  9 │ }
    ╰────
   help: If it is a local import, the path must start with `crate::`.

--- a/libs/pavex_cli/tests/ui_tests/non_static_methods_are_not_supported/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/non_static_methods_are_not_supported/expectations/stderr.txt
@@ -5,7 +5,7 @@ Error:
  10 │ pub fn blueprint() -> AppBlueprint {
  11 │     AppBlueprint::new().route(f!(crate::Streamer::stream_file), "/home")
     ·                               ────────────────┬───────────────
-    ·                                               ╰── The callable was registered here
+    ·                                               ╰── The handler was registered here
  12 │ }
     ╰────
 

--- a/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/expectations/stderr.txt
@@ -1,0 +1,19 @@
+Error: 
+  × I do not know how to handle the type returned by `app::c`.
+   ╭─[src/lib.rs:7:1]
+ 7 │ pub fn blueprint() -> AppBlueprint {
+ 8 │     AppBlueprint::new().route(f!(crate::c), "/home")
+   ·                               ──────┬─────
+   ·                                     ╰── The handler was registered here
+ 9 │ }
+   ╰────
+
+Error: 
+  × 
+   ╭─[src/lib.rs:2:1]
+ 2 │ 
+ 3 │ pub fn c() -> (usize, usize) {
+   ·               ───────┬──────
+   ·                      ╰── The output type that I cannot handle
+ 4 │     todo!()
+   ╰────

--- a/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/lib.rs
@@ -1,0 +1,9 @@
+use pavex_builder::{f, AppBlueprint};
+
+pub fn c() -> (usize, usize) {
+    todo!()
+}
+
+pub fn blueprint() -> AppBlueprint {
+    AppBlueprint::new().route(f!(crate::c), "/home")
+}

--- a/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/test_config.toml
@@ -1,0 +1,8 @@
+description = "Checking the error message returne by `pavex` when it cannot resolve the output parameter of a constructor"
+
+[expectations]
+codegen = "fail"
+
+[dependencies]
+http = "0.2"
+hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/remote_callable_paths_must_be_absolute/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/remote_callable_paths_must_be_absolute/expectations/stderr.txt
@@ -4,7 +4,7 @@ Error:
   9 │     AppBlueprint::new()
  10 │         .constructor(f!(new_logger), Lifecycle::Singleton)
     ·                      ───────┬──────
-    ·                             ╰── The invalid import path was registered here
+    ·                             ╰── The relative import path was registered here
  11 │         .route(f!(crate::handler), "/home")
     ╰────
   help: If it is a local import, the path must start with `crate::`.

--- a/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/expectations/stderr.txt
@@ -1,0 +1,11 @@
+Error: 
+  × I can work with functions and static methods, but `app::Streamer` is
+  │ neither.
+  │ It is a struct and I do not know how to handle it here.
+   ╭─[src/lib.rs:5:1]
+ 5 │ pub fn blueprint() -> AppBlueprint {
+ 6 │     AppBlueprint::new().route(f!(crate::Streamer), "/home")
+   ·                               ─────────┬─────────
+   ·                                        ╰── It was registered as a handler here
+ 7 │ }
+   ╰────

--- a/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/lib.rs
@@ -1,0 +1,7 @@
+use pavex_builder::{f, AppBlueprint};
+
+pub struct Streamer;
+
+pub fn blueprint() -> AppBlueprint {
+    AppBlueprint::new().route(f!(crate::Streamer), "/home")
+}

--- a/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/test_config.toml
@@ -1,0 +1,8 @@
+description = "A struct type can't be used directly as a constructor"
+
+[expectations]
+codegen = "fail"
+
+[dependencies]
+http = "0.2"
+hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/the_path_for_generic_arguments_must_be_absolute/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/the_path_for_generic_arguments_must_be_absolute/expectations/stderr.txt
@@ -4,7 +4,7 @@ Error:
  14 │     AppBlueprint::new()
  15 │         .constructor(f!(crate::new_logger::<String>), Lifecycle::Singleton)
     ·                      ───────────────┬───────────────
-    ·                                     ╰── The invalid import path was registered here
+    ·                                     ╰── The relative import path was registered here
  16 │         .route(f!(crate::handler::<std::string::String>), "/home")
     ╰────
   help: If it is a local import, the path must start with `crate::`.

--- a/libs/pavex_cli/tests/ui_tests/the_path_for_generic_arguments_must_be_absolute/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/the_path_for_generic_arguments_must_be_absolute/expectations/stderr.txt
@@ -1,11 +1,11 @@
 Error: 
-  × `new_logger` is not a fully-qualified import path.
-    ╭─[src/lib.rs:9:1]
-  9 │     AppBlueprint::new()
- 10 │         .constructor(f!(new_logger), Lifecycle::Singleton)
-    ·                      ───────┬──────
-    ·                             ╰── The invalid import path was registered here
- 11 │         .route(f!(crate::handler), "/home")
+  × `String` is not a fully-qualified import path.
+    ╭─[src/lib.rs:14:1]
+ 14 │     AppBlueprint::new()
+ 15 │         .constructor(f!(crate::new_logger::<String>), Lifecycle::Singleton)
+    ·                      ───────────────┬───────────────
+    ·                                     ╰── The invalid import path was registered here
+ 16 │         .route(f!(crate::handler::<std::string::String>), "/home")
     ╰────
   help: If it is a local import, the path must start with `crate::`.
         If it is an import from a dependency, the path must start with the

--- a/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled/expectations/stderr.txt
@@ -5,7 +5,7 @@ Error:
  7 │ pub fn blueprint() -> AppBlueprint {
  8 │     AppBlueprint::new().route(f!(crate::stream_file), "/home")
    ·                               ───────────┬──────────
-   ·                                          ╰── The callable was registered here
+   ·                                          ╰── The handler was registered here
  9 │ }
    ╰────
 

--- a/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/expectations/stderr.txt
@@ -1,20 +1,20 @@
 Error: 
   × One of the input parameters for `app::stream_file` has a type that I
   │ cannot handle.
-   ╭─[src/lib.rs:7:1]
- 7 │ pub fn blueprint() -> AppBlueprint {
- 8 │     AppBlueprint::new().constructor(f!(crate::stream_file), Lifecycle::Singleton)
-   ·                                     ───────────┬──────────
-   ·                                                ╰── The constructor was registered here
- 9 │ }
-   ╰────
+    ╭─[src/lib.rs:9:1]
+  9 │ pub fn blueprint() -> AppBlueprint {
+ 10 │     AppBlueprint::new().constructor(f!(crate::stream_file), Lifecycle::Singleton)
+    ·                                     ───────────┬──────────
+    ·                                                ╰── The constructor was registered here
+ 11 │ }
+    ╰────
 
 Error: 
   × 
-   ╭─[src/lib.rs:2:1]
- 2 │ 
- 3 │ pub fn stream_file(input: (usize, isize)) -> http::Response<hyper::body::Body> {
+   ╭─[src/lib.rs:4:1]
+ 4 │ 
+ 5 │ pub fn stream_file(input: (usize, isize)) -> Logger {
    ·                           ───────┬──────
    ·                                  ╰── The parameter type that I cannot handle
- 4 │     todo!()
+ 6 │     todo!()
    ╰────

--- a/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/expectations/stderr.txt
@@ -1,0 +1,20 @@
+Error: 
+  × One of the input parameters for `app::stream_file` has a type that I
+  │ cannot handle.
+   ╭─[src/lib.rs:7:1]
+ 7 │ pub fn blueprint() -> AppBlueprint {
+ 8 │     AppBlueprint::new().constructor(f!(crate::stream_file), Lifecycle::Singleton)
+   ·                                     ───────────┬──────────
+   ·                                                ╰── The constructor was registered here
+ 9 │ }
+   ╰────
+
+Error: 
+  × 
+   ╭─[src/lib.rs:2:1]
+ 2 │ 
+ 3 │ pub fn stream_file(input: (usize, isize)) -> http::Response<hyper::body::Body> {
+   ·                           ───────┬──────
+   ·                                  ╰── The parameter type that I cannot handle
+ 4 │     todo!()
+   ╰────

--- a/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/lib.rs
@@ -1,0 +1,11 @@
+use pavex_builder::{f, AppBlueprint, Lifecycle};
+
+pub struct Logger;
+
+pub fn stream_file(input: (usize, isize)) -> Logger {
+    todo!()
+}
+
+pub fn blueprint() -> AppBlueprint {
+    AppBlueprint::new().constructor(f!(crate::stream_file), Lifecycle::Singleton)
+}

--- a/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/test_config.toml
@@ -1,0 +1,8 @@
+description = "pavex does not accept tuple types as input parameters for constructors (yet)"
+
+[expectations]
+codegen = "fail"
+
+[dependencies]
+http = "0.2"
+hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_test_runner/src/main.rs
+++ b/libs/pavex_test_runner/src/main.rs
@@ -23,7 +23,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(expected_filename) = file_name.strip_suffix(".snap") {
                 let actual_snapshot = fs_err::read_to_string(file.path())?;
                 let expected_path = expectations_dir.join(expected_filename);
-                let expected_snapshot = fs_err::read_to_string(&expected_path)?;
+                let expected_snapshot = match fs_err::read_to_string(&expected_path) {
+                    Ok(s) => s,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => "".to_string(),
+                    Err(e) => return Err(e.into()),
+                };
 
                 match review_snapshot(
                     &terminal,


### PR DESCRIPTION
Provide useful diagnostics when failing to resolve the information for a callable registered as a constructor.

We make sure to reuse the logic we built for handlers while tuning the error messages.