### PR TITLE
Users should be able to register error handlers for both sync and async constructors

### DIFF
--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -23,7 +23,7 @@ use crate::web::call_graph::{application_state_call_graph, handler_call_graph};
 use crate::web::call_graph::{ApplicationStateCallGraph, CallGraph};
 use crate::web::constructors::{Constructor, ConstructorValidationError};
 use crate::web::diagnostic::{
-    get_registration_location, CompilerDiagnosticBuilder, OptionalSourceSpanExt, ParsedSourceFile,
+    get_registration_location, CompilerDiagnosticBuilder, LocationExt, OptionalSourceSpanExt,
     SourceSpanExt,
 };
 use crate::web::error_handlers::ErrorHandler;
@@ -86,11 +86,7 @@ impl App {
                     Err(e) => {
                         let location =
                             get_registration_location(&app_blueprint, e.raw_identifiers()).unwrap();
-                        let source = ParsedSourceFile::new(
-                            location.file.as_str().into(),
-                            &package_graph.workspace(),
-                        )
-                        .map_err(miette::MietteError::IoError)?;
+                        let source = location.source_file(&package_graph)?;
                         let source_span =
                             diagnostic::get_f_macro_invocation_span(&source, location);
                         let diagnostic = match e {
@@ -182,11 +178,7 @@ impl App {
                                 .next()
                                 .unwrap();
                             let location = &app_blueprint.constructor_locations[raw_identifier];
-                            let source = ParsedSourceFile::new(
-                                location.file.as_str().into(),
-                                &package_graph.workspace(),
-                            )
-                            .map_err(miette::MietteError::IoError)?;
+                            let source = location.source_file(&package_graph)?;
                             let label = diagnostic::get_f_macro_invocation_span(&source, location)
                                 .map(|s| s.labeled("The constructor was registered here".into()));
                             let diagnostic = CompilerDiagnosticBuilder::new(source, e)

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -23,8 +23,8 @@ use crate::web::call_graph::{application_state_call_graph, handler_call_graph};
 use crate::web::call_graph::{ApplicationStateCallGraph, CallGraph};
 use crate::web::constructors::{Constructor, ConstructorValidationError};
 use crate::web::diagnostic::{
-    get_registration_location, CompilerDiagnosticBuilder, LocationExt, OptionalSourceSpanExt,
-    SourceSpanExt,
+    get_registration_location, get_request_handler_location, CompilerDiagnosticBuilder,
+    LocationExt, OptionalSourceSpanExt, SourceSpanExt,
 };
 use crate::web::error_handlers::ErrorHandler;
 use crate::web::generated_app::GeneratedApp;
@@ -244,13 +244,12 @@ impl App {
                 return Err(e.into_diagnostic(
                     &resolved_paths2identifiers,
                     |identifiers| {
-                        app_blueprint.request_handler_locations[identifiers]
-                            .first()
+                        get_request_handler_location(&app_blueprint, identifiers)
                             .unwrap()
-                            .clone()
+                            .to_owned()
                     },
                     &package_graph,
-                    CallableType::Handler,
+                    CallableType::RequestHandler,
                 )?);
             }
         };

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -198,7 +198,7 @@ impl App {
                 Err(e) => {
                     return Err(e.into_diagnostic(
                         &resolved_paths2identifiers,
-                        |identifiers| app_blueprint.constructor_locations[identifiers].clone(),
+                        |identifiers| app_blueprint.error_handler_locations[identifiers].clone(),
                         &package_graph,
                         CallableType::ErrorHandler,
                     )?);

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -89,21 +89,21 @@ impl App {
                         let source = location.source_file(&package_graph)?;
                         let source_span =
                             diagnostic::get_f_macro_invocation_span(&source, location);
-                        let diagnostic = match e {
+                        let (label, help) = match e {
                             ParseError::InvalidPath(_) => {
-                                let label = source_span
-                                    .labeled("The invalid import path was registered here".into());
-                                CompilerDiagnosticBuilder::new(source, e)
-                                    .optional_label(label)
+                                ("The invalid import path was registered here", None)
                             }
                             ParseError::PathMustBeAbsolute(_) => {
-                                let label = source_span
-                                    .labeled("The relative import path was registered here".into());
-                                CompilerDiagnosticBuilder::new(source, e)
-                                    .optional_label(label)
-                                    .help("If it is a local import, the path must start with `crate::`.\nIf it is an import from a dependency, the path must start with the dependency name (e.g. `dependency::`).".into())
+                                ("The relative import path was registered here",
+                                 Some("If it is a local import, the path must start with `crate::`.\n\
+                                    If it is an import from a dependency, the path must start with \
+                                    the dependency name (e.g. `dependency::`)."))
                             }
-                        }.build();
+                        };
+                        let diagnostic = CompilerDiagnosticBuilder::new(source, e)
+                            .optional_label(source_span.labeled(label.into()))
+                            .optional_help(help.map(ToOwned::to_owned))
+                            .build();
                         return Err(diagnostic.into());
                     }
                 }

--- a/libs/pavex/src/web/diagnostic.rs
+++ b/libs/pavex/src/web/diagnostic.rs
@@ -1,7 +1,10 @@
 use std::fmt::Display;
 use std::path::Path;
 
-use miette::{Diagnostic, LabeledSpan, NamedSource, SourceCode, SourceOffset, SourceSpan};
+use guppy::graph::PackageGraph;
+use miette::{
+    Diagnostic, LabeledSpan, MietteError, NamedSource, SourceCode, SourceOffset, SourceSpan,
+};
 use syn::spanned::Spanned;
 use syn::visit::Visit;
 use syn::{ExprMethodCall, Stmt};
@@ -296,6 +299,17 @@ impl From<ParsedSourceFile> for NamedSource {
     fn from(f: ParsedSourceFile) -> Self {
         let file_name = f.path.to_string_lossy();
         NamedSource::new(file_name, f.contents)
+    }
+}
+
+pub(crate) trait LocationExt {
+    fn source_file(&self, package_graph: &PackageGraph) -> Result<ParsedSourceFile, MietteError>;
+}
+
+impl LocationExt for Location {
+    fn source_file(&self, package_graph: &PackageGraph) -> Result<ParsedSourceFile, MietteError> {
+        ParsedSourceFile::new(self.file.as_str().into(), &package_graph.workspace())
+            .map_err(MietteError::IoError)
     }
 }
 

--- a/libs/pavex/src/web/diagnostic.rs
+++ b/libs/pavex/src/web/diagnostic.rs
@@ -316,6 +316,9 @@ pub fn read_source_file(
 }
 
 /// Given a callable identifier, return the location where it was registered.
+///
+/// The same request handlers can be registered multiple times: this function returns the location
+/// of the first registration.
 pub fn get_registration_location<'a>(
     bp: &'a AppBlueprint,
     identifiers: &RawCallableIdentifiers,

--- a/libs/pavex/src/web/diagnostic.rs
+++ b/libs/pavex/src/web/diagnostic.rs
@@ -333,16 +333,25 @@ pub fn read_source_file(
 ///
 /// The same request handlers can be registered multiple times: this function returns the location
 /// of the first registration.
-pub fn get_registration_location<'a>(
+pub(crate) fn get_registration_location<'a>(
     bp: &'a AppBlueprint,
     identifiers: &RawCallableIdentifiers,
 ) -> Option<&'a Location> {
     bp.constructor_locations
         .get(identifiers)
-        .or_else(|| {
-            bp.request_handler_locations
-                .get(identifiers)
-                .and_then(|v| v.first())
-        })
+        .or_else(|| get_request_handler_location(bp, identifiers))
         .or_else(|| bp.error_handler_locations.get(identifiers))
+}
+
+/// Given the callable identifiers for a request handler, return the location where it was registered.
+///
+/// The same request handlers can be registered multiple times: this function returns the location
+/// of the first registration.
+pub(crate) fn get_request_handler_location<'a>(
+    bp: &'a AppBlueprint,
+    identifiers: &RawCallableIdentifiers,
+) -> Option<&'a Location> {
+    bp.request_handler_locations
+        .get(identifiers)
+        .and_then(|v| v.first())
 }

--- a/libs/pavex/src/web/resolvers.rs
+++ b/libs/pavex/src/web/resolvers.rs
@@ -22,8 +22,8 @@ use crate::rustdoc::{CannotGetCrateData, RustdocKindExt};
 use crate::rustdoc::{CrateCollection, ResolvedItem};
 use crate::web::diagnostic;
 use crate::web::diagnostic::{
-    convert_rustdoc_span, convert_span, read_source_file, CompilerDiagnosticBuilder,
-    OptionalSourceSpanExt, ParsedSourceFile, SourceSpanExt,
+    convert_rustdoc_span, convert_span, read_source_file, CompilerDiagnosticBuilder, LocationExt,
+    OptionalSourceSpanExt, SourceSpanExt,
 };
 
 /// Extract the input type paths, the output type path and the callable path for each
@@ -323,11 +323,7 @@ impl CallableResolutionError {
                 let type_path = &e.0;
                 let raw_identifier = resolved_paths2identifiers[type_path].iter().next().unwrap();
                 let location = identifiers2location(raw_identifier);
-                let source = ParsedSourceFile::new(
-                    location.file.as_str().into(),
-                    &package_graph.workspace(),
-                )
-                .map_err(miette::MietteError::IoError)?;
+                let source = location.source_file(&package_graph)?;
                 let label = diagnostic::get_f_macro_invocation_span(&source, &location)
                     .map(|s| s.labeled(format!("The {callable_type} that we cannot resolve")));
                 let diagnostic = CompilerDiagnosticBuilder::new(source, e)
@@ -400,11 +396,7 @@ impl CallableResolutionError {
                     .next()
                     .unwrap();
                 let location = identifiers2location(raw_identifier);
-                let source = ParsedSourceFile::new(
-                    location.file.as_str().into(),
-                    &package_graph.workspace(),
-                )
-                .map_err(miette::MietteError::IoError)?;
+                let source = location.source_file(&package_graph)?;
                 let label = diagnostic::get_f_macro_invocation_span(&source, &location)
                     .map(|s| s.labeled(format!("The {callable_type} was registered here")));
                 let diagnostic = CompilerDiagnosticBuilder::new(source, e)
@@ -417,11 +409,7 @@ impl CallableResolutionError {
                 let type_path = &e.import_path;
                 let raw_identifier = resolved_paths2identifiers[type_path].iter().next().unwrap();
                 let location = identifiers2location(raw_identifier);
-                let source = ParsedSourceFile::new(
-                    location.file.as_str().into(),
-                    &package_graph.workspace(),
-                )
-                .map_err(miette::MietteError::IoError)?;
+                let source = location.source_file(&package_graph)?;
                 let label = diagnostic::get_f_macro_invocation_span(&source, &location)
                     .map(|s| s.labeled(format!("It was registered as a {callable_type} here")));
                 let diagnostic = CompilerDiagnosticBuilder::new(source, e)
@@ -491,11 +479,7 @@ impl CallableResolutionError {
                     .next()
                     .unwrap();
                 let location = identifiers2location(raw_identifier);
-                let source = ParsedSourceFile::new(
-                    location.file.as_str().into(),
-                    &package_graph.workspace(),
-                )
-                .map_err(miette::MietteError::IoError)?;
+                let source = location.source_file(&package_graph)?;
                 let label = diagnostic::get_f_macro_invocation_span(&source, &location)
                     .map(|s| s.labeled(format!("The {callable_type} was registered here")));
                 let diagnostic = CompilerDiagnosticBuilder::new(source, e)

--- a/libs/pavex/src/web/resolvers.rs
+++ b/libs/pavex/src/web/resolvers.rs
@@ -328,12 +328,8 @@ impl CallableResolutionError {
                     &package_graph.workspace(),
                 )
                 .map_err(miette::MietteError::IoError)?;
-                let label = diagnostic::get_f_macro_invocation_span(
-                    &source.contents,
-                    &source.parsed,
-                    &location,
-                )
-                .map(|s| s.labeled(format!("The {callable_type} that we cannot resolve")));
+                let label = diagnostic::get_f_macro_invocation_span(&source, &location)
+                    .map(|s| s.labeled(format!("The {callable_type} that we cannot resolve")));
                 let diagnostic = CompilerDiagnosticBuilder::new(source, e)
                     .optional_label(label)
                     .help("This is most likely a bug in `pavex` or `rustdoc`.\nPlease file a GitHub issue!".into())
@@ -409,12 +405,8 @@ impl CallableResolutionError {
                     &package_graph.workspace(),
                 )
                 .map_err(miette::MietteError::IoError)?;
-                let label = diagnostic::get_f_macro_invocation_span(
-                    &source.contents,
-                    &source.parsed,
-                    &location,
-                )
-                .map(|s| s.labeled(format!("The {callable_type} was registered here")));
+                let label = diagnostic::get_f_macro_invocation_span(&source, &location)
+                    .map(|s| s.labeled(format!("The {callable_type} was registered here")));
                 let diagnostic = CompilerDiagnosticBuilder::new(source, e)
                     .optional_label(label)
                     .optional_related_error(sub_diagnostic)
@@ -430,12 +422,8 @@ impl CallableResolutionError {
                     &package_graph.workspace(),
                 )
                 .map_err(miette::MietteError::IoError)?;
-                let label = diagnostic::get_f_macro_invocation_span(
-                    &source.contents,
-                    &source.parsed,
-                    &location,
-                )
-                .map(|s| s.labeled(format!("It was registered as a {callable_type} here")));
+                let label = diagnostic::get_f_macro_invocation_span(&source, &location)
+                    .map(|s| s.labeled(format!("It was registered as a {callable_type} here")));
                 let diagnostic = CompilerDiagnosticBuilder::new(source, e)
                     .optional_label(label)
                     .build();
@@ -508,12 +496,8 @@ impl CallableResolutionError {
                     &package_graph.workspace(),
                 )
                 .map_err(miette::MietteError::IoError)?;
-                let label = diagnostic::get_f_macro_invocation_span(
-                    &source.contents,
-                    &source.parsed,
-                    &location,
-                )
-                .map(|s| s.labeled(format!("The {callable_type} was registered here")));
+                let label = diagnostic::get_f_macro_invocation_span(&source, &location)
+                    .map(|s| s.labeled(format!("The {callable_type} was registered here")));
                 let diagnostic = CompilerDiagnosticBuilder::new(source, e)
                     .optional_label(label)
                     .optional_related_error(sub_diagnostic)

--- a/libs/pavex/src/web/resolvers.rs
+++ b/libs/pavex/src/web/resolvers.rs
@@ -288,7 +288,7 @@ pub(crate) enum CallableResolutionError {
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum CallableType {
-    Handler,
+    RequestHandler,
     Constructor,
     ErrorHandler,
 }
@@ -296,7 +296,7 @@ pub(crate) enum CallableType {
 impl Display for CallableType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            CallableType::Handler => "handler",
+            CallableType::RequestHandler => "request handler",
             CallableType::Constructor => "constructor",
             CallableType::ErrorHandler => "error handler",
         };

--- a/libs/pavex/src/web/traits.rs
+++ b/libs/pavex/src/web/traits.rs
@@ -12,7 +12,7 @@ use pavex_builder::RawCallableIdentifiers;
 use crate::language::{Callable, ResolvedPath, ResolvedType};
 use crate::rustdoc::CrateCollection;
 use crate::web::constructors::Constructor;
-use crate::web::diagnostic::{CompilerDiagnosticBuilder, ParsedSourceFile, SourceSpanExt};
+use crate::web::diagnostic::{CompilerDiagnosticBuilder, LocationExt, SourceSpanExt};
 use crate::web::resolvers::resolve_type;
 use crate::web::{diagnostic, CompilerDiagnostic};
 
@@ -262,9 +262,7 @@ impl MissingTraitImplementationError {
             .next()
             .unwrap();
         let location = &constructor_locations[raw_identifier];
-        let source =
-            ParsedSourceFile::new(location.file.as_str().into(), &package_graph.workspace())
-                .map_err(miette::MietteError::IoError)?;
+        let source = location.source_file(&package_graph)?;
         let label = diagnostic::get_f_macro_invocation_span(&source, location)
             .map(|s| s.labeled("The constructor was registered here".into()));
         let diagnostic = CompilerDiagnosticBuilder::new(source, self)

--- a/libs/pavex/src/web/traits.rs
+++ b/libs/pavex/src/web/traits.rs
@@ -265,9 +265,8 @@ impl MissingTraitImplementationError {
         let source =
             ParsedSourceFile::new(location.file.as_str().into(), &package_graph.workspace())
                 .map_err(miette::MietteError::IoError)?;
-        let label =
-            diagnostic::get_f_macro_invocation_span(&source.contents, &source.parsed, location)
-                .map(|s| s.labeled("The constructor was registered here".into()));
+        let label = diagnostic::get_f_macro_invocation_span(&source, location)
+            .map(|s| s.labeled("The constructor was registered here".into()));
         let diagnostic = CompilerDiagnosticBuilder::new(source, self)
             .optional_label(label)
             .optional_help(help)

--- a/libs/pavex_cli/tests/ui_tests/app_builder/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/app_builder/expectations/app.rs
@@ -68,7 +68,7 @@ pub async fn route_handler_0(
     v0: app::HttpClient,
     v1: http::Request<hyper::Body>,
 ) -> pavex_runtime::response::Response {
-    let v2 = app::extract_path(v1);
+    let v2 = app::extract_path(v1).await;
     match v2 {
         Err(v3) => {
             let v5 = {

--- a/libs/pavex_cli/tests/ui_tests/app_builder/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/app_builder/lib.rs
@@ -5,7 +5,7 @@ use pavex_runtime::response::Response;
 
 pub struct Logger;
 
-pub fn extract_path(
+pub async fn extract_path(
     _inner: pavex_runtime::http::Request<pavex_runtime::hyper::body::Body>,
 ) -> Result<PathBuf, ExtractPathError<String>> {
     todo!()

--- a/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_a_sync_infallible_constructor/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_a_sync_infallible_constructor/expectations/stderr.txt
@@ -1,0 +1,12 @@
+Error: 
+  × You registered an error handler for a constructor that does not return
+  │ a `Result`.
+    ╭─[src/lib.rs:22:1]
+ 22 │     bp.constructor(f!(crate::infallible_constructor), Lifecycle::RequestScoped)
+ 23 │         .error_handler(f!(crate::error_handler));
+    ·                        ────────────┬───────────
+    ·                                    ╰── The unnecessary error handler was registered here
+ 24 │     bp.route(f!(crate::request_handler), "/home");
+    ╰────
+  help: Remove the error handler, it is not needed. The constructor is
+        infallible!

--- a/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_a_sync_infallible_constructor/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_a_sync_infallible_constructor/lib.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use pavex_builder::{f, AppBlueprint, Lifecycle};
+
+pub fn infallible_constructor() -> PathBuf {
+    todo!()
+}
+
+#[derive(Debug)]
+pub struct ExtractPathError;
+
+pub fn error_handler(_e: &ExtractPathError) -> pavex_runtime::response::Response {
+    todo!()
+}
+
+pub fn request_handler(_inner: PathBuf) -> pavex_runtime::response::Response {
+    todo!()
+}
+
+pub fn blueprint() -> AppBlueprint {
+    let mut bp = AppBlueprint::new();
+    bp.constructor(f!(crate::infallible_constructor), Lifecycle::RequestScoped)
+        .error_handler(f!(crate::error_handler));
+    bp.route(f!(crate::request_handler), "/home");
+    bp
+}

--- a/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_a_sync_infallible_constructor/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_a_sync_infallible_constructor/test_config.toml
@@ -1,0 +1,4 @@
+description = "Pavex returns an error if you register an error handler for an infallible sync constructor"
+
+[expectations]
+codegen = "fail"

--- a/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_an_async_infallible_constructor/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_an_async_infallible_constructor/expectations/stderr.txt
@@ -1,0 +1,12 @@
+Error: 
+  × You registered an error handler for a constructor that does not return
+  │ a `Result`.
+    ╭─[src/lib.rs:22:1]
+ 22 │     bp.constructor(f!(crate::infallible_constructor), Lifecycle::RequestScoped)
+ 23 │         .error_handler(f!(crate::error_handler));
+    ·                        ────────────┬───────────
+    ·                                    ╰── The unnecessary error handler was registered here
+ 24 │     bp.route(f!(crate::request_handler), "/home");
+    ╰────
+  help: Remove the error handler, it is not needed. The constructor is
+        infallible!

--- a/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_an_async_infallible_constructor/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_an_async_infallible_constructor/lib.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use pavex_builder::{f, AppBlueprint, Lifecycle};
+
+pub async fn infallible_constructor() -> PathBuf {
+    todo!()
+}
+
+#[derive(Debug)]
+pub struct ExtractPathError;
+
+pub fn error_handler(_e: &ExtractPathError) -> pavex_runtime::response::Response {
+    todo!()
+}
+
+pub fn request_handler(_inner: PathBuf) -> pavex_runtime::response::Response {
+    todo!()
+}
+
+pub fn blueprint() -> AppBlueprint {
+    let mut bp = AppBlueprint::new();
+    bp.constructor(f!(crate::infallible_constructor), Lifecycle::RequestScoped)
+        .error_handler(f!(crate::error_handler));
+    bp.route(f!(crate::request_handler), "/home");
+    bp
+}

--- a/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_an_async_infallible_constructor/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/cannot_register_an_error_handler_for_an_async_infallible_constructor/test_config.toml
@@ -1,0 +1,4 @@
+description = "Pavex returns an error if you register an error handler for an infallible async constructor"
+
+[expectations]
+codegen = "fail"

--- a/libs/pavex_cli/tests/ui_tests/constructors_can_fail/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/constructors_can_fail/lib.rs
@@ -10,6 +10,7 @@ pub fn extract_path(
     todo!()
 }
 
+#[derive(Debug)]
 pub struct ExtractPathError<T>(T);
 
 pub fn handle_extract_path_error(
@@ -23,6 +24,7 @@ pub fn logger() -> Result<Logger, LoggerError> {
     todo!()
 }
 
+#[derive(Debug)]
 pub struct LoggerError;
 
 pub fn handle_logger_error(_e: &LoggerError) -> pavex_runtime::response::Response {
@@ -47,6 +49,7 @@ pub fn config() -> Config {
 #[derive(Clone)]
 pub struct HttpClient;
 
+#[derive(Debug)]
 pub struct HttpClientError;
 
 pub fn http_client(_config: Config) -> Result<HttpClient, HttpClientError> {

--- a/libs/pavex_cli/tests/ui_tests/constructors_cannot_return_the_unit_type/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/constructors_cannot_return_the_unit_type/test_config.toml
@@ -2,7 +2,3 @@ description = "pavex expectes all constructors to _construct something_! They ca
 
 [expectations]
 codegen = "fail"
-
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/generic_handlers_are_not_supported/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/generic_handlers_are_not_supported/expectations/stderr.txt
@@ -5,7 +5,7 @@ Error:
   8 │     let mut bp = AppBlueprint::new();
   9 │     bp.route(f!(crate::stream_file::<std::path::PathBuf>), "/home");
     ·              ──────────────────────┬─────────────────────
-    ·                                    ╰── The handler was registered here
+    ·                                    ╰── The request handler was registered here
  10 │     bp
     ╰────
 

--- a/libs/pavex_cli/tests/ui_tests/generic_handlers_are_not_supported/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/generic_handlers_are_not_supported/test_config.toml
@@ -2,7 +2,3 @@ description = "pavex does not support generic functions as handlers (yet)"
 
 [expectations]
 codegen = "fail"
-
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/invalid_callable_path/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/invalid_callable_path/test_config.toml
@@ -2,7 +2,3 @@ description = "Verify the quality of the compiler error when an invalid path is 
 
 [expectations]
 codegen = "fail"
-
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/local_callable_paths_must_be_prefixed_with_crate/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/local_callable_paths_must_be_prefixed_with_crate/test_config.toml
@@ -2,7 +2,3 @@ description = "pavex cannot resolve relative callable paths, even if they are lo
 
 [expectations]
 codegen = "fail"
-
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/missing_handler_dependency/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/missing_handler_dependency/test_config.toml
@@ -2,7 +2,3 @@ description = "Verify the error returned by pavex when a handler depends on a no
 
 [expectations]
 codegen = "fail"
-
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/non_static_methods_are_not_supported/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/non_static_methods_are_not_supported/expectations/stderr.txt
@@ -5,7 +5,7 @@ Error:
  12 │     let mut bp = AppBlueprint::new();
  13 │     bp.route(f!(crate::Streamer::stream_file), "/home");
     ·              ────────────────┬───────────────
-    ·                              ╰── The handler was registered here
+    ·                              ╰── The request handler was registered here
  14 │     bp
     ╰────
 

--- a/libs/pavex_cli/tests/ui_tests/non_static_methods_are_not_supported/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/non_static_methods_are_not_supported/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex does not support generic functions as handlers (yet)"
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/expectations/stderr.txt
@@ -4,7 +4,7 @@ Error:
   8 │     let mut bp = AppBlueprint::new();
   9 │     bp.route(f!(crate::c), "/home");
     ·              ──────┬─────
-    ·                    ╰── The handler was registered here
+    ·                    ╰── The request handler was registered here
  10 │     bp
     ╰────
 

--- a/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/output_parameter_cannot_be_handled/test_config.toml
@@ -3,6 +3,4 @@ description = "Checking the error message returne by `pavex` when it cannot reso
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/pattern_bindings_in_input_parameters_are_supported/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/pattern_bindings_in_input_parameters_are_supported/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex supports pattern bindings for input parameters"
 [expectations]
 codegen = "pass"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/references_to_constructible_types_are_allowed/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/references_to_constructible_types_are_allowed/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex knows how to deal with shared references, no matter the lif
 [expectations]
 codegen = "pass"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/remote_callable_paths_must_be_absolute/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/remote_callable_paths_must_be_absolute/test_config.toml
@@ -6,6 +6,4 @@ codegen = "fail"
 [ephemeral_dependencies]
 dep = { path = "dep.rs" }
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/runtime_singletons_must_be_clonable/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/runtime_singletons_must_be_clonable/test_config.toml
@@ -3,6 +3,4 @@ description = "Singletons must implement Clone"
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/runtime_singletons_must_be_send/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/runtime_singletons_must_be_send/test_config.toml
@@ -3,6 +3,4 @@ description = "Singletons must implement Send"
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/runtime_singletons_must_be_sync/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/runtime_singletons_must_be_sync/test_config.toml
@@ -3,6 +3,4 @@ description = "Singletons need to implement Sync"
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/static_methods_are_supported/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/static_methods_are_supported/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex supports static methods as handlers"
 [expectations]
 codegen = "pass"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/expectations/stderr.txt
@@ -9,9 +9,9 @@ error[E0277]: the trait bound `Streamer: Callable<_>` is not satisfied
     |        required by a bound introduced by this call
     |
 note: required by a bound in `AppBlueprint::route`
-   --> /Users/luca/code/pavex/libs/pavex_builder/src/app.rs:138:12
+   --> /Users/luca/code/pavex/libs/pavex_builder/src/app.rs:136:12
     |
-138 |         F: Callable<HandlerInputs>,
+136 |         F: Callable<HandlerInputs>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AppBlueprint::route`
 
 For more information about this error, try `rustc --explain E0277`.

--- a/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/structs_cannot_be_registered_as_handlers/test_config.toml
@@ -3,6 +3,4 @@ description = "A struct type can't be used directly as a constructor"
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/the_latest_registered_constructor_takes_precedence/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/the_latest_registered_constructor_takes_precedence/test_config.toml
@@ -6,6 +6,3 @@ codegen = "pass"
 [ephemeral_dependencies]
 dep = { path = "dep.rs" }
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }

--- a/libs/pavex_cli/tests/ui_tests/the_path_for_generic_arguments_must_be_absolute/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/the_path_for_generic_arguments_must_be_absolute/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex cannot resolve concrete generic parameters if they are not 
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/the_same_constructor_can_be_registered_multiple_times_using_the_same_lifecycle/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/the_same_constructor_can_be_registered_multiple_times_using_the_same_lifecycle/test_config.toml
@@ -1,5 +1,3 @@
 description = "The same constructor can be registered multiple times and later registrations override previous ones"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/trait_methods_are_supported/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/trait_methods_are_supported/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex supports trait methods as constructors"
 [expectations]
 codegen = "pass"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/trait_methods_with_non_local_generics_are_not_supported/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/trait_methods_with_non_local_generics_are_not_supported/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex does not yet support trait methods that rely on non-local g
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled/expectations/stderr.txt
@@ -5,7 +5,7 @@ Error:
   8 │     let mut bp = AppBlueprint::new();
   9 │     bp.route(f!(crate::stream_file), "/home");
     ·              ───────────┬──────────
-    ·                         ╰── The handler was registered here
+    ·                         ╰── The request handler was registered here
  10 │     bp
     ╰────
 

--- a/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex does not tuple types as input parameters (yet)"
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+

--- a/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/tuple_input_parameters_are_not_handled_by_constructors/test_config.toml
@@ -3,6 +3,4 @@ description = "pavex does not accept tuple types as input parameters for constru
 [expectations]
 codegen = "fail"
 
-[dependencies]
-http = "0.2"
-hyper = { version = "0.14", features = ["server", "http1", "http2"] }
+


### PR DESCRIPTION
## The problem

The changes in #12 included a `Constructor<'a, Output>` struct which allowed the user to call `error_handler` if and only if `Output` was a `Result<_, _>`. This did not work if the handler was asynchronous - `Output` was set to `impl Future<Output=Result<T, E>>` and the user could not call `error_handler` on the resulting `Constructor`.

## Limitations

Unfortunately, there is no reliable way to correctly extract output type for both synchronous and asynchronous callables (i.e. get `Result<T, E>` as `Output` for an async function instead of `impl Future<Output=Result<T, E>>`).  
I considered having two different registration methods (e.g. `sync_constructor` and `async_constructor`), but there is no way to enforce that a method is **not** async (negative bounds when?).

## The solution

Remove the `Output` type from `Constructor` and always allow the user to register an error handler.
If an error handler is registered for an infallible constructor, return an error when generating the application code.

It is not as early of a feedback as I would have hoped, but it's at least a very clear error message.

---
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
