### PR TITLE
Verify that the output type of error handlers and request handlers implements `IntoResponse`

### DIFF
--- a/examples/generated_app/src/lib.rs
+++ b/examples/generated_app/src/lib.rs
@@ -8,9 +8,7 @@ struct ServerState {
 pub struct ApplicationState {
     s0: app_blueprint::HttpClient,
 }
-pub async fn build_application_state(
-    v0: app_blueprint::Config,
-) -> crate::ApplicationState {
+pub async fn build_application_state(v0: app_blueprint::Config) -> crate::ApplicationState {
     let v1 = app_blueprint::http_client(v0);
     crate::ApplicationState { s0: v1 }
 }
@@ -27,28 +25,25 @@ pub async fn run(
     let make_service = pavex_runtime::hyper::service::make_service_fn(move |_| {
         let server_state = server_state.clone();
         async move {
-            Ok::<
-                _,
-                pavex_runtime::hyper::Error,
-            >(
-                pavex_runtime::hyper::service::service_fn(move |request| {
+            Ok::<_, pavex_runtime::hyper::Error>(pavex_runtime::hyper::service::service_fn(
+                move |request| {
                     let server_state = server_state.clone();
                     async move {
-                        Ok::<
-                            _,
-                            pavex_runtime::hyper::Error,
-                        >(route_request(request, server_state).await)
+                        Ok::<_, pavex_runtime::hyper::Error>(
+                            route_request(request, server_state).await,
+                        )
                     }
-                }),
-            )
+                },
+            ))
         }
     });
-    server_builder.serve(make_service).await.map_err(pavex_runtime::Error::new)
+    server_builder
+        .serve(make_service)
+        .await
+        .map_err(pavex_runtime::Error::new)
 }
-fn build_router() -> Result<
-    pavex_runtime::routing::Router<u32>,
-    pavex_runtime::routing::InsertError,
-> {
+fn build_router() -> Result<pavex_runtime::routing::Router<u32>, pavex_runtime::routing::InsertError>
+{
     let mut router = pavex_runtime::routing::Router::new();
     router.insert("/home", 0u32)?;
     Ok(router)
@@ -75,7 +70,5 @@ pub async fn route_handler_0(
         let v3 = app_blueprint::logger();
         app_blueprint::stream_file(v2, v3, v0)
     };
-    <pavex_runtime::response::Response as pavex_runtime::response::IntoResponse>::into_response(
-        v4,
-    )
+    <pavex_runtime::response::Response as pavex_runtime::response::IntoResponse>::into_response(v4)
 }

--- a/libs/pavex/src/web/app.rs
+++ b/libs/pavex/src/web/app.rs
@@ -16,7 +16,7 @@ use pavex_builder::Lifecycle;
 use pavex_builder::RawCallableIdentifiers;
 
 use crate::diagnostic;
-use crate::diagnostic::CompilerDiagnostic;
+use crate::diagnostic::{get_registration_location, CompilerDiagnostic};
 use crate::diagnostic::{
     get_registration_location_for_a_request_handler, LocationExt, SourceSpanExt,
 };
@@ -32,7 +32,7 @@ use crate::web::generated_app::GeneratedApp;
 use crate::web::resolvers::{
     resolve_callable, resolve_type_path, CallableResolutionError, CallableType,
 };
-use crate::web::traits::assert_trait_is_implemented;
+use crate::web::traits::{assert_trait_is_implemented, MissingTraitImplementationError};
 use crate::web::{codegen, resolvers, utils};
 
 pub(crate) const GENERATED_APP_PACKAGE_ID: &str = "crate";
@@ -204,7 +204,7 @@ impl App {
             }
         }
 
-        let (error_handler_callable_resolver, errors) =
+        let (error_handler_path2callable, error_handler_callable2paths, errors) =
             resolvers::resolve_error_handlers(&error_handler_paths, &mut krate_collection);
         for e in errors {
             diagnostics.push(
@@ -218,7 +218,7 @@ impl App {
             );
         }
 
-        let (handler_resolver, handlers, errors) =
+        let (handler_path2callable, handler_callable2paths, handlers, errors) =
             resolvers::resolve_request_handlers(&request_handler_paths, &mut krate_collection);
         for e in errors {
             diagnostics.push(
@@ -276,9 +276,14 @@ impl App {
                 &krate_collection,
             );
             let into_response_path = into_response.resolved_path();
-            for callable in handlers
+            for (callable, callable_type) in handlers
                 .iter()
-                .chain(error_handler_callable_resolver.values())
+                .map(|h| (h, CallableType::RequestHandler))
+                .chain(
+                    error_handler_path2callable
+                        .values()
+                        .map(|e| (e, CallableType::ErrorHandler)),
+                )
             {
                 if let Some(output) = &callable.output {
                     // TODO: only the Ok variant must implement IntoResponse if output is a result
@@ -290,11 +295,16 @@ impl App {
                     if let Err(e) =
                         assert_trait_is_implemented(&krate_collection, output, &into_response)
                     {
-                        // TODO: remove panic
-                        panic!(
-                            "All handler output types must implement `IntoResponse`: {:?}\n{}",
-                            e, e
-                        );
+                        let diagnostic = OutputCannotBeConvertedIntoAResponse {
+                            identifiers: (),
+                            output_type: output.to_owned(),
+                            callable_type,
+                            source: e,
+                        }
+                        .into_diagnostic(&app_blueprint, &package_graph)
+                        .to_miette();
+                        diagnostics.push(diagnostic);
+                        continue;
                     }
                     let output_path = output.resolved_path();
                     let mut transformer_segments = into_response_path.segments.clone();
@@ -324,7 +334,7 @@ impl App {
         let mut router = BTreeMap::new();
         for (route, callable_identifiers) in app_blueprint.router {
             let callable_path = &identifiers2path[&callable_identifiers];
-            router.insert(route, handler_resolver[callable_path].to_owned());
+            router.insert(route, handler_path2callable[callable_path].to_owned());
         }
 
         let component2lifecycle = {
@@ -370,7 +380,7 @@ impl App {
                         let error_handler_id =
                             &app_blueprint.constructor_error_handlers[constructor_id];
                         let error_handler_path = &identifiers2path[error_handler_id];
-                        let error_handler = error_handler_callable_resolver
+                        let error_handler = error_handler_path2callable
                             .get(error_handler_path)
                             // TODO: return an error asking for an error handler to be registered
                             .unwrap()
@@ -688,6 +698,37 @@ impl ResultExt for Result<CompilerDiagnostic, miette::Error> {
             Ok(e) => e.into(),
             Err(e) => e,
         }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("I cannot use the type returned by this {callable_type} to create an HTTP response.")]
+pub(crate) struct OutputCannotBeConvertedIntoAResponse {
+    identifiers: RawCallableIdentifiers,
+    output_type: ResolvedType,
+    callable_type: CallableType,
+    #[source]
+    source: MissingTraitImplementationError,
+}
+
+impl OutputCannotBeConvertedIntoAResponse {
+    pub fn into_diagnostic(
+        self,
+        app_blueprint: &AppBlueprint,
+        package_graph: &PackageGraph,
+    ) -> Result<CompilerDiagnostic, miette::Error> {
+        let location = get_registration_location(app_blueprint, &self.identifiers).unwrap();
+        let source = location.source_file(&package_graph)?;
+        let label = diagnostic::get_f_macro_invocation_span(&source, location)
+            .map(|s| s.labeled(format!("The {} was registered here", self.callable_type)));
+        let diagnostic = CompilerDiagnostic::builder(source, self)
+            .optional_label(label)
+            .help(format!(
+                "Implement `pavex_runtime::response::IntoResponse` for {:?}.",
+                self.output_type
+            ))
+            .build();
+        Ok(diagnostic)
     }
 }
 

--- a/libs/pavex/src/web/resolvers.rs
+++ b/libs/pavex/src/web/resolvers.rs
@@ -67,9 +67,9 @@ pub(crate) fn resolve_error_handlers(
     for path in paths {
         match resolve_callable(krate_collection, path) {
             Ok(callable) => {
-                resolution_map.insert(path.to_owned(), callable);
+                resolution_map.insert(path.to_owned(), callable.clone());
                 reverse_map
-                    .entry(callable.clone())
+                    .entry(callable)
                     .or_default()
                     .insert(path.to_owned());
             }
@@ -98,9 +98,9 @@ pub(crate) fn resolve_request_handlers(
         match resolve_callable(krate_collection, callable_path) {
             Ok(handler) => {
                 handlers.insert(handler.clone());
-                handler_resolver.insert(callable_path.to_owned(), handler);
+                handler_resolver.insert(callable_path.to_owned(), handler.clone());
                 reverse_map
-                    .entry(handler.clone())
+                    .entry(handler)
                     .or_default()
                     .insert(callable_path.to_owned());
             }

--- a/libs/pavex/src/web/traits.rs
+++ b/libs/pavex/src/web/traits.rs
@@ -209,7 +209,7 @@ pub(crate) fn implements_trait(
     false
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct MissingTraitImplementationError {
     pub type_: ResolvedType,
     pub trait_: ResolvedType,

--- a/libs/pavex_cli/tests/ui_tests/output_type_must_implement_into_response/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/output_type_must_implement_into_response/expectations/stderr.txt
@@ -1,0 +1,28 @@
+[31m[1mERROR[0m[39m: 
+  × I cannot use the type returned by this request handler to create an HTTP
+  │ response.
+  │ It does not implement `pavex_runtime::response::IntoResponse`.
+    ╭─[src/lib.rs:24:1]
+ 24 │         .error_handler(f!(crate::error_handler));
+ 25 │     bp.route(f!(crate::handler), "/home");
+    ·              ─────────┬────────
+    ·                       ╰── The request handler was registered here
+ 26 │     bp
+    ╰────
+  help: Implement `pavex_runtime::response::IntoResponse` for
+        `core::prelude::rust_2015::v1::Result<app::MyCustomOutputType,
+        app::ErrorType>`.
+
+[31m[1mERROR[0m[39m: 
+  × I cannot use the type returned by this error handler to create an HTTP
+  │ response.
+  │ It does not implement `pavex_runtime::response::IntoResponse`.
+    ╭─[src/lib.rs:23:1]
+ 23 │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
+ 24 │         .error_handler(f!(crate::error_handler));
+    ·                        ────────────┬───────────
+    ·                                    ╰── The error handler was registered here
+ 25 │     bp.route(f!(crate::handler), "/home");
+    ╰────
+  help: Implement `pavex_runtime::response::IntoResponse` for
+        `app::MyCustomOutputType`.

--- a/libs/pavex_cli/tests/ui_tests/output_type_must_implement_into_response/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/output_type_must_implement_into_response/lib.rs
@@ -1,0 +1,27 @@
+use pavex_builder::{f, AppBlueprint, Lifecycle};
+
+pub fn request_scoped() -> Result<String, ErrorType> {
+    todo!()
+}
+
+#[derive(Debug)]
+pub struct ErrorType;
+
+// It does not implement IntoResponse!
+pub struct MyCustomOutputType;
+
+pub fn handler(_s: String) -> Result<MyCustomOutputType, ErrorType> {
+    todo!()
+}
+
+pub fn error_handler(e: &ErrorType) -> MyCustomOutputType {
+    todo!()
+}
+
+pub fn blueprint() -> AppBlueprint {
+    let mut bp = AppBlueprint::new();
+    bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
+        .error_handler(f!(crate::error_handler));
+    bp.route(f!(crate::handler), "/home");
+    bp
+}

--- a/libs/pavex_cli/tests/ui_tests/output_type_must_implement_into_response/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/output_type_must_implement_into_response/test_config.toml
@@ -1,0 +1,4 @@
+description = "pavex expectes all (success) output types to implement IntoResponse"
+
+[expectations]
+codegen = "fail"


### PR DESCRIPTION
`pavex` would previously panic if the return type of error handlers/request handlers did not implement `IntoResponse`.
We now handle this case gracefully and return an appropriate error + suggestion.

Implementation hurdles: we had to add reverse maps for both request and error handlers In order to retrieve the callable identifiers starting from a callable object.
This whole "reverse walking" should probably be generalised, since we'll need it for every single diagnostic.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
