### PR TITLE
Rework the interface of CompilerDiagnostic

### DIFF
--- a/libs/pavex/src/diagnostic/mod.rs
+++ b/libs/pavex/src/diagnostic/mod.rs
@@ -1,7 +1,7 @@
 //! A toolkit to assemble and report errors and warnings to the user.
 use std::fmt::{Display, Formatter};
 
-pub(crate) use compiler_diagnostic::CompilerDiagnostic;
+pub(crate) use compiler_diagnostic::{AnnotatedSnippet, CompilerDiagnostic};
 pub(crate) use ordinals::ZeroBasedOrdinal;
 pub(crate) use proc_macro_utils::ProcMacroSpanExt;
 pub(crate) use registration_locations::get_f_macro_invocation_span;


### PR DESCRIPTION
Now it is aligned with how we expect related errors to be used: as additional annotated code snippets, not full-blown diagnostics.

This completes the miette-related work done in #17, at least for the time being.
