### PR TITLE
Test the error message when there are multiple underconstrained generic parameters

### DIFF
--- a/libs/pavex_cli/tests/ui_tests/constructors_input_parameters_cannot_be_generic/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/constructors_input_parameters_cannot_be_generic/expectations/stderr.txt
@@ -5,19 +5,87 @@
   [31m│[0m in the output type returned by the constructor. This is not the case for
   [31m│[0m `T`, since it is only used in the input parameters.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:14:1]
-  [31m│[0m  [2m14[0m │     let mut bp = Blueprint::new();
-  [31m│[0m  [2m15[0m │     bp.constructor(f!(crate::generic_constructor), Lifecycle::RequestScoped);
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:26:1]
+  [31m│[0m  [2m26[0m │     let mut bp = Blueprint::new();
+  [31m│[0m  [2m27[0m │     bp.constructor(f!(crate::generic_constructor), Lifecycle::RequestScoped);
   [31m│[0m     · [35;1m                   ───────────────┬──────────────[0m
   [31m│[0m     ·                                   [35;1m╰── [35;1mThe constructor was registered here[0m[0m
-  [31m│[0m  [2m16[0m │     bp.route(GET, "/home", f!(crate::handler));
+  [31m│[0m  [2m28[0m │     bp.constructor(
   [31m│[0m     ╰────
   [31m│[0m   [31m×[0m 
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn generic_constructor<T>(generic_input: GenericType<T>) -> u8 {
-  [31m│[0m    · [35;1m                           ┬[0m
-  [31m│[0m    ·                            [35;1m╰── [35;1mI can't infer this[0m[0m
+  [31m│[0m    · [35;1m                           ┬[0m[33;1m                                    ─┬[0m
+  [31m│[0m    ·                            [35;1m│[0m                                     [33;1m╰── [33;1m..because it is not used here[0m[0m
+  [31m│[0m    ·                            [35;1m╰── [35;1mI can't infer this..[0m[0m
   [31m│[0m  [2m2[0m │     todo!()
+  [31m│[0m    ╰────
+  [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic
+  [31m│[0m         parameter(s) when registering the constructor against the blueprint:
+  [31m│[0m         |  bp.constructor(
+  [31m│[0m         |    f!(my_crate::my_constructor::<ConcreteType>),
+  [31m│[0m         |    ..
+  [31m│[0m         |  )
+
+[31m[1mERROR[0m[39m: 
+  [31m×[0m I am not smart enough to figure out the concrete type for all the generic
+  [31m│[0m parameters in `app::doubly_generic_constructor`.
+  [31m│[0m I can only infer the type of an unassigned generic parameter if it appears
+  [31m│[0m in the output type returned by the constructor. This is not the case for
+  [31m│[0m `T`, and `S`, since they are only used in the input parameters.
+  [31m│[0m
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:28:1]
+  [31m│[0m  [2m28[0m │     bp.constructor(
+  [31m│[0m  [2m29[0m │         f!(crate::doubly_generic_constructor),
+  [31m│[0m     · [35;1m        ──────────────────┬──────────────────[0m
+  [31m│[0m     ·                           [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m  [2m30[0m │         Lifecycle::RequestScoped,
+  [31m│[0m     ╰────
+  [31m│[0m   [31m×[0m 
+  [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
+  [31m│[0m  [2m1[0m │ pub fn doubly_generic_constructor<T, S>(i1: GenericType<T>, i2: GenericType<S>) -> u16 {
+  [31m│[0m    · [35;1m                                  ┬[0m[33;1m  ┬[0m[32;1m                                             ─┬─[0m
+  [31m│[0m    ·                                   [35;1m│[0m  [33;1m│[0m                                              [32;1m╰── [32;1m..because they are not used here[0m[0m
+  [31m│[0m    ·                                   [35;1m│[0m  [33;1m╰── [33;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                                   [35;1m╰── [35;1mI can't infer this..[0m[0m
+  [31m│[0m  [2m2[0m │     todo!()
+  [31m│[0m    ╰────
+  [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic
+  [31m│[0m         parameter(s) when registering the constructor against the blueprint:
+  [31m│[0m         |  bp.constructor(
+  [31m│[0m         |    f!(my_crate::my_constructor::<ConcreteType>),
+  [31m│[0m         |    ..
+  [31m│[0m         |  )
+
+[31m[1mERROR[0m[39m: 
+  [31m×[0m I am not smart enough to figure out the concrete type for all the generic
+  [31m│[0m parameters in `app::triply_generic_constructor`.
+  [31m│[0m I can only infer the type of an unassigned generic parameter if it appears
+  [31m│[0m in the output type returned by the constructor. This is not the case for
+  [31m│[0m `T`, `S`, and `U`, since they are only used in the input parameters.
+  [31m│[0m
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:32:1]
+  [31m│[0m  [2m32[0m │     bp.constructor(
+  [31m│[0m  [2m33[0m │         f!(crate::triply_generic_constructor),
+  [31m│[0m     · [35;1m        ──────────────────┬──────────────────[0m
+  [31m│[0m     ·                           [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m  [2m34[0m │         Lifecycle::RequestScoped,
+  [31m│[0m     ╰────
+  [31m│[0m   [31m×[0m 
+  [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
+  [31m│[0m  [2m1[0m │ pub fn triply_generic_constructor<T, S, U>(
+  [31m│[0m    · [35;1m                                  ┬[0m[33;1m  ┬[0m[32;1m  ┬[0m
+  [31m│[0m    ·                                   [35;1m│[0m  [33;1m│[0m  [32;1m╰── [32;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                                   [35;1m│[0m  [33;1m╰── [33;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                                   [35;1m╰── [35;1mI can't infer this..[0m[0m
+  [31m│[0m  [2m2[0m │     i1: GenericType<T>,
+  [31m│[0m    ╰────
+  [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:4:1]
+  [31m│[0m  [2m4[0m │     i3: GenericType<U>,
+  [31m│[0m  [2m5[0m │ ) -> u32 {
+  [31m│[0m    · [35;1m     ─┬─[0m
+  [31m│[0m    ·       [35;1m╰── [35;1m..because they are not used here[0m[0m
+  [31m│[0m  [2m6[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic
   [31m│[0m         parameter(s) when registering the constructor against the blueprint:

--- a/libs/pavex_cli/tests/ui_tests/constructors_input_parameters_cannot_be_generic/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/constructors_input_parameters_cannot_be_generic/lib.rs
@@ -6,13 +6,33 @@ pub fn generic_constructor<T>(generic_input: GenericType<T>) -> u8 {
     todo!()
 }
 
-pub fn handler(size: u8) -> pavex_runtime::response::Response {
+pub fn doubly_generic_constructor<T, S>(i1: GenericType<T>, i2: GenericType<S>) -> u16 {
+    todo!()
+}
+
+pub fn triply_generic_constructor<T, S, U>(
+    i1: GenericType<T>,
+    i2: GenericType<S>,
+    i3: GenericType<U>,
+) -> u32 {
+    todo!()
+}
+
+pub fn handler(i: u8, j: u16, k: u32) -> pavex_runtime::response::Response {
     todo!()
 }
 
 pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
     bp.constructor(f!(crate::generic_constructor), Lifecycle::RequestScoped);
+    bp.constructor(
+        f!(crate::doubly_generic_constructor),
+        Lifecycle::RequestScoped,
+    );
+    bp.constructor(
+        f!(crate::triply_generic_constructor),
+        Lifecycle::RequestScoped,
+    );
     bp.route(GET, "/home", f!(crate::handler));
     bp
 }


### PR DESCRIPTION
We also add a label under the output type.
