### PR TITLE
Detect at compile-time if T in RouteParams<T> tries to extract a non-existing route paremeter

### DIFF
--- a/examples/generated_app/src/lib.rs
+++ b/examples/generated_app/src/lib.rs
@@ -9,9 +9,7 @@ struct ServerState {
 pub struct ApplicationState {
     s0: app_blueprint::HttpClient,
 }
-pub async fn build_application_state(
-    v0: app_blueprint::Config,
-) -> crate::ApplicationState {
+pub async fn build_application_state(v0: app_blueprint::Config) -> crate::ApplicationState {
     let v1 = app_blueprint::http_client(v0);
     crate::ApplicationState { s0: v1 }
 }
@@ -28,28 +26,25 @@ pub async fn run(
     let make_service = pavex_runtime::hyper::service::make_service_fn(move |_| {
         let server_state = server_state.clone();
         async move {
-            Ok::<
-                _,
-                pavex_runtime::hyper::Error,
-            >(
-                pavex_runtime::hyper::service::service_fn(move |request| {
+            Ok::<_, pavex_runtime::hyper::Error>(pavex_runtime::hyper::service::service_fn(
+                move |request| {
                     let server_state = server_state.clone();
                     async move {
-                        Ok::<
-                            _,
-                            pavex_runtime::hyper::Error,
-                        >(route_request(request, server_state).await)
+                        Ok::<_, pavex_runtime::hyper::Error>(
+                            route_request(request, server_state).await,
+                        )
                     }
-                }),
-            )
+                },
+            ))
         }
     });
-    server_builder.serve(make_service).await.map_err(pavex_runtime::Error::new)
+    server_builder
+        .serve(make_service)
+        .await
+        .map_err(pavex_runtime::Error::new)
 }
-fn build_router() -> Result<
-    pavex_runtime::routing::Router<u32>,
-    pavex_runtime::routing::InsertError,
-> {
+fn build_router() -> Result<pavex_runtime::routing::Router<u32>, pavex_runtime::routing::InsertError>
+{
     let mut router = pavex_runtime::routing::Router::new();
     router.insert("/home", 0u32)?;
     Ok(router)
@@ -71,35 +66,26 @@ async fn route_request(
     #[allow(unused)]
     let url_params = matched_route.params;
     match route_id {
-        0u32 => {
-            match request.method() {
-                &pavex_runtime::http::Method::GET => {
-                    route_handler_0(server_state.application_state.s0.clone(), request)
-                        .await
-                }
-                _ => {
-                    pavex_runtime::response::Response::builder()
-                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
-                        .header(pavex_runtime::http::header::ALLOW, "GET")
-                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
-                        .unwrap()
-                }
+        0u32 => match request.method() {
+            &pavex_runtime::http::Method::GET => {
+                route_handler_0(server_state.application_state.s0.clone(), request).await
             }
-        }
-        _ => {
-            pavex_runtime::response::Response::builder()
-                .status(pavex_runtime::http::StatusCode::NOT_FOUND)
+            _ => pavex_runtime::response::Response::builder()
+                .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                .header(pavex_runtime::http::header::ALLOW, "GET")
                 .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
-                .unwrap()
-        }
+                .unwrap(),
+        },
+        _ => pavex_runtime::response::Response::builder()
+            .status(pavex_runtime::http::StatusCode::NOT_FOUND)
+            .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+            .unwrap(),
     }
 }
 pub async fn route_handler_0(
     v0: app_blueprint::HttpClient,
     v1: http::Request<hyper::Body>,
-) -> http::Response<
-    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
-> {
+) -> http::Response<http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>> {
     let v2 = app_blueprint::extract_path(v1);
     let v4 = {
         let v3 = app_blueprint::logger();

--- a/libs/pavex/src/compiler/analyses/components.rs
+++ b/libs/pavex/src/compiler/analyses/components.rs
@@ -1111,8 +1111,13 @@ impl ComponentDb {
                     format!("`{}`", &parameters[0])
                 } else {
                     let mut buffer = String::new();
-                    comma_separated_list(&mut buffer, parameters.iter(), |p| format!("`{}`", p))
-                        .unwrap();
+                    comma_separated_list(
+                        &mut buffer,
+                        parameters.iter(),
+                        |p| format!("`{}`", p),
+                        "and",
+                    )
+                    .unwrap();
                     buffer
                 };
                 let error = anyhow::anyhow!(e)
@@ -1295,8 +1300,13 @@ impl ComponentDb {
                     format!("`{}`", &parameters[0])
                 } else {
                     let mut buffer = String::new();
-                    comma_separated_list(&mut buffer, parameters.iter(), |p| format!("`{}`", p))
-                        .unwrap();
+                    comma_separated_list(
+                        &mut buffer,
+                        parameters.iter(),
+                        |p| format!("`{}`", p),
+                        "and",
+                    )
+                    .unwrap();
                     buffer
                 };
                 let verb = if parameters.len() == 1 { "does" } else { "do" };
@@ -1497,7 +1507,7 @@ impl ComponentDb {
                     format!("`{}`", &parameters[0])
                 } else {
                     let mut buffer = String::new();
-                    comma_separated_list(&mut buffer, parameters.iter(), |p| format!("`{}`", p)).unwrap();
+                    comma_separated_list(&mut buffer, parameters.iter(), |p| format!("`{}`", p), "and").unwrap();
                     buffer
                 };
                 let error = anyhow::anyhow!(e)

--- a/libs/pavex/src/compiler/route_parameter_validation.rs
+++ b/libs/pavex/src/compiler/route_parameter_validation.rs
@@ -1,13 +1,9 @@
-
-
 use anyhow::anyhow;
 use guppy::graph::PackageGraph;
 use indexmap::{IndexMap, IndexSet};
 use petgraph::Direction;
 
 use rustdoc_types::{ItemEnum, StructKind};
-
-
 
 use crate::compiler::analyses::call_graph::{CallGraph, CallGraphNode};
 use crate::compiler::analyses::components::{ComponentDb, HydratedComponent};

--- a/libs/pavex/src/compiler/route_parameter_validation.rs
+++ b/libs/pavex/src/compiler/route_parameter_validation.rs
@@ -1,20 +1,27 @@
+use std::fmt::Write;
+
 use anyhow::anyhow;
 use guppy::graph::PackageGraph;
 use indexmap::{IndexMap, IndexSet};
+use itertools::Itertools;
+use miette::Report;
+use petgraph::graph::NodeIndex;
 use petgraph::Direction;
-
 use rustdoc_types::{ItemEnum, StructKind};
 
 use crate::compiler::analyses::call_graph::{CallGraph, CallGraphNode};
-use crate::compiler::analyses::components::{ComponentDb, HydratedComponent};
+use crate::compiler::analyses::components::{ComponentDb, ComponentId, HydratedComponent};
 use crate::compiler::analyses::computations::ComputationDb;
-use crate::compiler::analyses::user_components::RouterKey;
+use crate::compiler::analyses::user_components::{RouterKey, UserComponentId};
 use crate::compiler::computation::{Computation, MatchResultVariant};
 use crate::compiler::constructors::Constructor;
+use crate::compiler::traits::implements_trait;
+use crate::compiler::utils::process_framework_path;
 use crate::diagnostic;
 use crate::diagnostic::{CompilerDiagnostic, LocationExt, OptionalSourceSpanExt};
 use crate::language::{GenericArgument, ResolvedType};
 use crate::rustdoc::{CrateCollection, GlobalItemId};
+use crate::utils::comma_separated_list;
 
 /// For each handler, check if route parameters are extracted from the URL of the incoming request.
 /// If so, check that the type of the route parameter is a struct with named fields and
@@ -27,7 +34,15 @@ pub(crate) fn verify_route_parameters(
     krate_collection: &CrateCollection,
     diagnostics: &mut Vec<miette::Error>,
 ) {
-    for (_router_key, call_graph) in handler_call_graphs {
+    let ResolvedType::ResolvedPath(structural_deserialize) = process_framework_path(
+        "pavex_runtime::serialization::StructuralDeserialize",
+        package_graph,
+        krate_collection,
+    ) else {
+        unreachable!()
+    };
+
+    for (router_key, call_graph) in handler_call_graphs {
         let Some((ok_route_params_node_id, ok_route_params_component_id, ty_)) = call_graph.call_graph.node_indices().find_map(|node_id| {
             let node = &call_graph.call_graph[node_id];
             let CallGraphNode::Compute { component_id, .. } = node else { return None; };
@@ -46,102 +61,301 @@ pub(crate) fn verify_route_parameters(
         }) else { continue; };
 
         let GenericArgument::TypeParameter(extracted_type) = &ty_.generic_arguments[0] else { unreachable!() };
-        let error_suffix = match extracted_type {
-            ResolvedType::ResolvedPath(t) => {
-                if let Some(item_id) = t.rustdoc_id.clone() {
-                    let item = krate_collection.get_type_by_global_type_id(&GlobalItemId {
-                        rustdoc_item_id: item_id,
-                        package_id: t.package_id.clone(),
-                    });
-                    match item.inner {
-                        ItemEnum::Union(_) => Some(format!("`{t:?}` is an union")),
-                        ItemEnum::Enum(_) => Some(format!("`{t:?}` is an enum")),
-                        ItemEnum::Struct(ref s) => match &s.kind {
-                            StructKind::Unit => Some(format!(
-                                "`{t:?}` is a struct with no fields (a.k.a. unit struct)"
-                            )),
-                            StructKind::Tuple(_) => Some(format!("`{t:?}` is a tuple struct")),
-                            StructKind::Plain { .. } => None,
-                        },
-                        _ => None,
-                    }
-                } else {
-                    None
-                }
-            }
-            ResolvedType::Reference(r) => Some(format!("`{r:?}` is a reference")),
-            ResolvedType::Tuple(t) => Some(format!("`{t:?}` is a tuple")),
-            ResolvedType::ScalarPrimitive(s) => Some(format!("`{s:?}` is a primitive")),
-            ResolvedType::Slice(s) => Some(format!("`{s:?}` is a slice")),
-            ResolvedType::Generic(_) => {
-                unreachable!()
-            }
+
+        let Ok(struct_item) = must_be_a_plain_struct(
+            component_db,
+            package_graph,
+            krate_collection,
+            diagnostics,
+            call_graph,
+            ok_route_params_node_id,
+            ok_route_params_component_id,
+            extracted_type,
+        ) else {
+            continue;
+        };
+        let ItemEnum::Struct(struct_inner_item) = &struct_item.inner else {
+            unreachable!()
         };
 
-        if let Some(error_suffix) = error_suffix {
-            // Find the compute nodes that consume the `RouteParams` extractor and report
-            // an error on each of them.
-            let mut affected_ids = IndexSet::new();
-            let mut descendant_ids = call_graph
-                .call_graph
-                .neighbors_directed(ok_route_params_node_id, Direction::Outgoing)
-                .collect::<IndexSet<_>>();
-            let borrow_component_id = component_db.borrow_id(*ok_route_params_component_id);
-            while let Some(descendant_id) = descendant_ids.pop() {
-                let descendant_node = &call_graph.call_graph[descendant_id];
-                if let CallGraphNode::Compute { component_id, .. } = descendant_node {
-                    if Some(component_id) == borrow_component_id.as_ref() {
-                        descendant_ids.extend(
-                            call_graph
-                                .call_graph
-                                .neighbors_directed(descendant_id, Direction::Outgoing),
-                        );
-                        continue;
-                    }
-                    if let Some(user_component_id) = component_db.user_component_id(*component_id) {
-                        affected_ids.insert(user_component_id);
-                    }
-                }
-            }
+        // We only want to check alignment between struct fields and the route parameters in the
+        // template if the struct implements `StructuralDeserialize`, our marker trait that stands
+        // for "this struct implements serde::Deserialize using a #[derive(serde::Deserialize)] with
+        // no customizations (e.g. renames)".
+        if !implements_trait(krate_collection, extracted_type, &structural_deserialize) {
+            continue;
+        }
 
-            for user_component_id in affected_ids {
-                let raw_identifiers = component_db
-                    .user_component_db
-                    .get_raw_callable_identifiers(user_component_id);
-                let callable_type =
-                    component_db.user_component_db[user_component_id].callable_type();
-                let location = component_db
-                    .user_component_db
-                    .get_location(user_component_id);
-                let source = match location.source_file(package_graph) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        diagnostics.push(e.into());
-                        return;
-                    }
-                };
-                let source_span = diagnostic::get_f_macro_invocation_span(&source, location);
-                let error = anyhow!(
-                    "Route parameters must be extracted using a plain struct with named fields, \
-                    where the name of each field matches one of the route parameters specified \
-                    in the route for the respective request handler.\n\
-                    `{}` is trying to extract `RouteParams<{extracted_type:?}>`, but \
-                    {error_suffix}, not a plain struct type. I don't support this: the extraction would \
-                    fail at runtime, when trying to process an incoming request.",
-                    raw_identifiers.fully_qualified_path().join("::")
+        let route_parameter_names = router_key
+            .path
+            .split('/')
+            // TODO: should we support catch all parameters?
+            .filter_map(|s| s.strip_prefix(':'))
+            .collect::<IndexSet<_>>();
+
+        let struct_field_names = {
+            let mut struct_field_names = IndexSet::new();
+            let ResolvedType::ResolvedPath(extracted_path_type) = &extracted_type else { unreachable!() };
+            let StructKind::Plain { fields: field_ids, .. } = &struct_inner_item.kind else {
+                unreachable!()
+            };
+            for field_id in field_ids {
+                let field_item = krate_collection.get_type_by_global_type_id(&GlobalItemId {
+                    rustdoc_item_id: field_id.clone(),
+                    package_id: extracted_path_type.package_id.clone(),
+                });
+                struct_field_names.insert(field_item.name.clone().unwrap());
+            }
+            struct_field_names
+        };
+
+        let non_existing_route_parameters = struct_field_names
+            .into_iter()
+            .filter(|f| !route_parameter_names.contains(f.as_str()))
+            .collect::<IndexSet<_>>();
+
+        if !non_existing_route_parameters.is_empty() {
+            report_non_existing_route_parameters(
+                component_db,
+                package_graph,
+                diagnostics,
+                router_key,
+                call_graph,
+                ok_route_params_node_id,
+                ok_route_params_component_id,
+                route_parameter_names,
+                non_existing_route_parameters,
+            )
+        }
+    }
+}
+
+/// Report an error on each compute node that consumes the `RouteParams` extractor
+/// while trying to extract one or more route parameters that are not present in
+/// the respective route template.
+fn report_non_existing_route_parameters(
+    component_db: &ComponentDb,
+    package_graph: &PackageGraph,
+    diagnostics: &mut Vec<Report>,
+    router_key: &RouterKey,
+    call_graph: &CallGraph,
+    ok_route_params_node_id: NodeIndex,
+    ok_route_params_component_id: &ComponentId,
+    route_parameter_names: IndexSet<&str>,
+    non_existing_route_parameters: IndexSet<String>,
+) {
+    assert!(non_existing_route_parameters.len() > 0);
+    // Find the compute nodes that consume the `RouteParams` extractor and report
+    // an error on each of them.
+    let consuming_ids = route_params_consumer_ids(
+        component_db,
+        call_graph,
+        ok_route_params_node_id,
+        ok_route_params_component_id,
+    );
+    for user_component_id in consuming_ids {
+        let raw_identifiers = component_db
+            .user_component_db
+            .get_raw_callable_identifiers(user_component_id);
+        let callable_type = component_db.user_component_db[user_component_id].callable_type();
+        let location = component_db
+            .user_component_db
+            .get_location(user_component_id);
+        let source = match location.source_file(package_graph) {
+            Ok(s) => s,
+            Err(e) => {
+                diagnostics.push(e.into());
+                continue;
+            }
+        };
+        let source_span = diagnostic::get_f_macro_invocation_span(&source, location);
+        if route_parameter_names.is_empty() {
+            let error = anyhow!(
+                    "`{}` is trying to extract route parameters using `RouteParams<{extracted_type:?}>`.\n\
+                    But there are no route parameters in `{}`, the corresponding route template!",
+                    raw_identifiers.fully_qualified_path().join("::"),
+                    router_key.path,
                 );
-                let d = CompilerDiagnostic::builder(source, error)
-                    .optional_label(source_span.labeled(format!(
-                        "The {callable_type} asking for `RouteParams<{extracted_type:?}>`"
-                    )))
-                    .help(
-                        "Use a plain struct with named fields to extract route parameters.\n\
-                        Check out `RouteParams`' documentation for all the details!"
-                            .into(),
-                    )
-                    .build();
-                diagnostics.push(d.into());
+            let d = CompilerDiagnostic::builder(source, error)
+                .optional_label(source_span.labeled(format!(
+                    "The {callable_type} asking for `RouteParams<{extracted_type:?}>`"
+                )))
+                .help(
+                    "Stop trying to extract route parameters, or add them to the route template!"
+                        .into(),
+                )
+                .build();
+            diagnostics.push(d.into());
+        } else {
+            let missing_msg = if non_existing_route_parameters.len() == 1 {
+                let name = non_existing_route_parameters.first().unwrap();
+                format!(
+                    "There is no route parameter named `{name}`, but there is a struct field named `{name}` \
+                    in `{extracted_type:?}`"
+                )
+            } else {
+                let mut msg = "There are no route parameters named ".to_string();
+                comma_separated_list(
+                    &mut msg,
+                    non_existing_route_parameters.iter(),
+                    |p| format!("`{p}`"),
+                    "or",
+                )
+                .unwrap();
+                write!(
+                    &mut msg,
+                    ", but they appear as field names in `{extracted_type:?}`"
+                )
+                .unwrap();
+                msg
+            };
+            let route_parameters = route_parameter_names
+                .iter()
+                .map(|p| format!("- `{}`", p))
+                .join("\n");
+            let error = anyhow!(
+                    "`{}` is trying to extract route parameters using `RouteParams<{extracted_type:?}>`.\n\
+                    Every struct field in `{extracted_type:?}` must be named after one of the route \
+                    parameters that appear in `{}`:\n{route_parameters}\n\n\
+                    {missing_msg}. This is going to cause a runtime error!",
+                    raw_identifiers.fully_qualified_path().join("::"),
+                    router_key.path,
+                );
+            let d = CompilerDiagnostic::builder(source, error)
+                .optional_label(source_span.labeled(format!(
+                    "The {callable_type} asking for `RouteParams<{extracted_type:?}>`"
+                )))
+                .help(
+                    "Remove or rename the fields that do not map to a valid route parameter."
+                        .into(),
+                )
+                .build();
+            diagnostics.push(d.into());
+        }
+    }
+}
+
+/// Checks that the type of the route parameter is a struct with named fields.
+/// If it is, returns the rustdoc item for the type.  
+/// If it isn't, reports an error diagnostic on each compute node that consumes the
+/// `RouteParams` extractor.
+fn must_be_a_plain_struct(
+    component_db: &ComponentDb,
+    package_graph: &PackageGraph,
+    krate_collection: &CrateCollection,
+    diagnostics: &mut Vec<Report>,
+    call_graph: &CallGraph,
+    ok_route_params_node_id: NodeIndex,
+    ok_route_params_component_id: &ComponentId,
+    extracted_type: &ResolvedType,
+) -> Result<rustdoc_types::Item, ()> {
+    let error_suffix = match extracted_type {
+        ResolvedType::ResolvedPath(t) => {
+            let Some(item_id) = t.rustdoc_id.clone() else { unreachable!() };
+            let item = krate_collection.get_type_by_global_type_id(&GlobalItemId {
+                rustdoc_item_id: item_id,
+                package_id: t.package_id.clone(),
+            });
+            match item.inner {
+                ItemEnum::Union(_) => format!("`{t:?}` is an union"),
+                ItemEnum::Enum(_) => format!("`{t:?}` is an enum"),
+                ItemEnum::Struct(ref s) => match &s.kind {
+                    StructKind::Unit => {
+                        format!("`{t:?}` is a struct with no fields (a.k.a. unit struct)")
+                    }
+                    StructKind::Tuple(_) => format!("`{t:?}` is a tuple struct"),
+                    StructKind::Plain { .. } => return Ok(item.clone()),
+                },
+                _ => unreachable!(),
+            }
+        }
+        ResolvedType::Reference(r) => format!("`{r:?}` is a reference"),
+        ResolvedType::Tuple(t) => format!("`{t:?}` is a tuple"),
+        ResolvedType::ScalarPrimitive(s) => format!("`{s:?}` is a primitive"),
+        ResolvedType::Slice(s) => format!("`{s:?}` is a slice"),
+        ResolvedType::Generic(_) => {
+            unreachable!()
+        }
+    };
+
+    // Find the compute nodes that consume the `RouteParams` extractor and report
+    // an error on each of them.
+    let consuming_ids = route_params_consumer_ids(
+        component_db,
+        call_graph,
+        ok_route_params_node_id,
+        ok_route_params_component_id,
+    );
+
+    for user_component_id in consuming_ids {
+        let raw_identifiers = component_db
+            .user_component_db
+            .get_raw_callable_identifiers(user_component_id);
+        let callable_type = component_db.user_component_db[user_component_id].callable_type();
+        let location = component_db
+            .user_component_db
+            .get_location(user_component_id);
+        let source = match location.source_file(package_graph) {
+            Ok(s) => s,
+            Err(e) => {
+                diagnostics.push(e.into());
+                continue;
+            }
+        };
+        let source_span = diagnostic::get_f_macro_invocation_span(&source, location);
+        let error = anyhow!(
+            "Route parameters must be extracted using a plain struct with named fields, \
+            where the name of each field matches one of the route parameters specified \
+            in the route for the respective request handler.\n\
+            `{}` is trying to extract `RouteParams<{extracted_type:?}>`, but \
+            {error_suffix}, not a plain struct type. I don't support this: the extraction would \
+            fail at runtime, when trying to process an incoming request.",
+            raw_identifiers.fully_qualified_path().join("::")
+        );
+        let d = CompilerDiagnostic::builder(source, error)
+            .optional_label(source_span.labeled(format!(
+                "The {callable_type} asking for `RouteParams<{extracted_type:?}>`"
+            )))
+            .help(
+                "Use a plain struct with named fields to extract route parameters.\n\
+                Check out `RouteParams`' documentation for all the details!"
+                    .into(),
+            )
+            .build();
+        diagnostics.push(d.into());
+    }
+    Err(())
+}
+
+/// Return the set of user component ids that consume a certain instance of the `RouteParams` extractor
+/// as input parameter.
+fn route_params_consumer_ids(
+    component_db: &ComponentDb,
+    call_graph: &CallGraph,
+    ok_route_params_node_id: NodeIndex,
+    ok_route_params_component_id: &ComponentId,
+) -> IndexSet<UserComponentId> {
+    let mut consumer_ids = IndexSet::new();
+    let mut descendant_ids = call_graph
+        .call_graph
+        .neighbors_directed(ok_route_params_node_id, Direction::Outgoing)
+        .collect::<IndexSet<_>>();
+    let borrow_component_id = component_db.borrow_id(*ok_route_params_component_id);
+    while let Some(descendant_id) = descendant_ids.pop() {
+        let descendant_node = &call_graph.call_graph[descendant_id];
+        if let CallGraphNode::Compute { component_id, .. } = descendant_node {
+            if Some(component_id) == borrow_component_id.as_ref() {
+                descendant_ids.extend(
+                    call_graph
+                        .call_graph
+                        .neighbors_directed(descendant_id, Direction::Outgoing),
+                );
+                continue;
+            }
+            if let Some(user_component_id) = component_db.user_component_id(*component_id) {
+                consumer_ids.insert(user_component_id);
             }
         }
     }
+    consumer_ids
 }

--- a/libs/pavex/src/utils.rs
+++ b/libs/pavex/src/utils.rs
@@ -7,6 +7,7 @@ pub(crate) fn comma_separated_list<'a, T, I>(
     mut buffer: impl Write,
     iter: I,
     f: impl Fn(&'a T) -> String,
+    conjunction: &str,
 ) -> Result<(), std::fmt::Error>
 where
     T: 'a,
@@ -15,7 +16,7 @@ where
     let length = iter.len();
     for (i, item) in iter.enumerate() {
         if i == length.saturating_sub(1) {
-            write!(buffer, " and ")?;
+            write!(buffer, " {conjunction} ")?;
         }
         write!(buffer, "{}", &f(item))?;
         if i < length.saturating_sub(2) {

--- a/libs/pavex_cli/tests/ui_tests/app_builder/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/app_builder/expectations/app.rs
@@ -67,7 +67,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/async_callable_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/async_callable_are_supported/expectations/app.rs
@@ -67,7 +67,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/common_response_types_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/common_response_types_are_supported/expectations/app.rs
@@ -76,7 +76,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/constructors_and_handlers_can_fail/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/constructors_and_handlers_can_fail/expectations/app.rs
@@ -82,7 +82,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/generic_handlers_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/generic_handlers_are_supported/expectations/app.rs
@@ -64,7 +64,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/http_method_routing_variants/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/http_method_routing_variants/expectations/app.rs
@@ -74,7 +74,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => route_handler_0().await,
         1u32 => {

--- a/libs/pavex_cli/tests/ui_tests/multiple_versions_for_the_same_crate_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/multiple_versions_for_the_same_crate_are_supported/expectations/app.rs
@@ -64,7 +64,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/non_static_methods_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/non_static_methods_are_supported/expectations/app.rs
@@ -67,7 +67,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/output_type_of_constructors_can_contain_generic_parameters/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/output_type_of_constructors_can_contain_generic_parameters/expectations/app.rs
@@ -64,7 +64,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/pattern_bindings_in_input_parameters_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/pattern_bindings_in_input_parameters_are_supported/expectations/app.rs
@@ -67,7 +67,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/references_to_constructible_types_are_allowed/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/references_to_constructible_types_are_allowed/expectations/app.rs
@@ -67,7 +67,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_happy_path/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_happy_path/lib.rs
@@ -1,7 +1,7 @@
 use pavex_builder::{f, router::GET, Blueprint, Lifecycle};
 use pavex_runtime::extract::route::RouteParams;
 
-#[derive(serde::Deserialize)]
+#[RouteParams]
 pub struct HomeRouteParams {
     pub home_id: u32,
 }
@@ -10,7 +10,7 @@ pub fn get_home(RouteParams(HomeRouteParams { home_id }): RouteParams<HomeRouteP
     format!("{}", home_id)
 }
 
-#[derive(serde::Deserialize)]
+#[RouteParams]
 pub struct RoomRouteParams {
     pub home_id: u32,
     // This is not a valid type for a route parameter

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_non_existing_fields/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_non_existing_fields/expectations/stderr.txt
@@ -1,0 +1,59 @@
+[31m[1mERROR[0m[39m: 
+  [31m×[0m `app::missing_one` is trying to extract route parameters using
+  [31m│[0m `RouteParams<app::MissingOne>`.
+  [31m│[0m Every struct field in `app::MissingOne` must be named after one of the
+  [31m│[0m route parameters that appear in `a/:x`:
+  [31m│[0m - `x`
+  [31m│[0m 
+  [31m│[0m There is no route parameter named `y`, but there is a struct field named
+  [31m│[0m `y` in `app::MissingOne`. This is going to cause a runtime error!
+  [31m│[0m
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:43:1]
+  [31m│[0m  [2m43[0m │     ));
+  [31m│[0m  [2m44[0m │     bp.route(GET, "a/:x", f!(crate::missing_one));
+  [31m│[0m     · [35;1m                          ───────────┬──────────[0m
+  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MissingOne>`[0m[0m
+  [31m│[0m  [2m45[0m │     bp.route(GET, "b/:x", f!(crate::missing_two));
+  [31m│[0m     ╰────
+  [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
+  [31m│[0m         parameter.
+
+[31m[1mERROR[0m[39m: 
+  [31m×[0m `app::missing_two` is trying to extract route parameters using
+  [31m│[0m `RouteParams<app::MissingTwo>`.
+  [31m│[0m Every struct field in `app::MissingTwo` must be named after one of the
+  [31m│[0m route parameters that appear in `b/:x`:
+  [31m│[0m - `x`
+  [31m│[0m 
+  [31m│[0m There are no route parameters named ``y`, `z``, but they appear as field
+  [31m│[0m names in `app::MissingTwo`. This is going to cause a runtime error!
+  [31m│[0m
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:44:1]
+  [31m│[0m  [2m44[0m │     bp.route(GET, "a/:x", f!(crate::missing_one));
+  [31m│[0m  [2m45[0m │     bp.route(GET, "b/:x", f!(crate::missing_two));
+  [31m│[0m     · [35;1m                          ───────────┬──────────[0m
+  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MissingTwo>`[0m[0m
+  [31m│[0m  [2m46[0m │     bp.route(GET, "c", f!(crate::no_route_params));
+  [31m│[0m     ╰────
+  [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
+  [31m│[0m         parameter.
+
+[31m[1mERROR[0m[39m: 
+  [31m×[0m `app::no_route_params` is trying to extract route parameters using
+  [31m│[0m `RouteParams<app::NoRouteParams>`.
+  [31m│[0m Every struct field in `app::NoRouteParams` must be named after one of the
+  [31m│[0m route parameters that appear in `c`:
+  [31m│[0m 
+  [31m│[0m 
+  [31m│[0m There are no route parameters named ``x`, `y``, but they appear as field
+  [31m│[0m names in `app::NoRouteParams`. This is going to cause a runtime error!
+  [31m│[0m
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:45:1]
+  [31m│[0m  [2m45[0m │     bp.route(GET, "b/:x", f!(crate::missing_two));
+  [31m│[0m  [2m46[0m │     bp.route(GET, "c", f!(crate::no_route_params));
+  [31m│[0m     · [35;1m                       ─────────────┬────────────[0m
+  [31m│[0m     ·                                     [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::NoRouteParams>`[0m[0m
+  [31m│[0m  [2m47[0m │     bp
+  [31m│[0m     ╰────
+  [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
+  [31m│[0m         parameter.

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_non_existing_fields/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_non_existing_fields/lib.rs
@@ -1,0 +1,48 @@
+use pavex_builder::{f, router::GET, Blueprint, Lifecycle};
+use pavex_runtime::extract::route::RouteParams;
+
+#[RouteParams]
+pub struct MissingOne {
+    x: u32,
+    y: u32,
+}
+
+pub fn missing_one(params: RouteParams<MissingOne>) -> String {
+    todo!()
+}
+
+#[RouteParams]
+pub struct MissingTwo {
+    x: u32,
+    y: u32,
+    z: u32,
+}
+
+pub fn missing_two(params: RouteParams<MissingTwo>) -> String {
+    todo!()
+}
+
+#[RouteParams]
+pub struct NoRouteParams {
+    x: u32,
+    y: u32,
+}
+
+pub fn no_route_params(params: RouteParams<NoRouteParams>) -> String {
+    todo!()
+}
+
+pub fn blueprint() -> Blueprint {
+    let mut bp = Blueprint::new();
+    bp.constructor(
+        f!(pavex_runtime::extract::route::RouteParams::extract),
+        Lifecycle::RequestScoped,
+    )
+    .error_handler(f!(
+        pavex_runtime::extract::route::errors::ExtractRouteParamsError::into_response
+    ));
+    bp.route(GET, "/a/:x", f!(crate::missing_one));
+    bp.route(GET, "/b/:x", f!(crate::missing_two));
+    bp.route(GET, "/c", f!(crate::no_route_params));
+    bp
+}

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_non_existing_fields/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_non_existing_fields/test_config.toml
@@ -1,0 +1,7 @@
+description = "Pavex will detect at compile-time if you are trying to extract a route parameter that does not exist in the route definition."
+
+[expectations]
+codegen = "fail"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_unsupported_types/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_unsupported_types/expectations/stderr.txt
@@ -6,12 +6,12 @@
   [31m│[0m primitive, not a plain struct type. I don't support this: the extraction
   [31m│[0m would fail at runtime, when trying to process an incoming request.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:55:1]
-  [31m│[0m  [2m55[0m │     ));
-  [31m│[0m  [2m56[0m │     bp.route(GET, "a/:x", f!(crate::primitive));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:59:1]
+  [31m│[0m  [2m59[0m │     ));
+  [31m│[0m  [2m60[0m │     bp.route(GET, "a/:x", f!(crate::primitive));
   [31m│[0m     · [35;1m                          ──────────┬─────────[0m
   [31m│[0m     ·                                     [35;1m╰── [35;1mThe request handler asking for `RouteParams<u32>`[0m[0m
-  [31m│[0m  [2m57[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
+  [31m│[0m  [2m61[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -25,12 +25,12 @@
   [31m│[0m extraction would fail at runtime, when trying to process an incoming
   [31m│[0m request.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:56:1]
-  [31m│[0m  [2m56[0m │     bp.route(GET, "a/:x", f!(crate::primitive));
-  [31m│[0m  [2m57[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:60:1]
+  [31m│[0m  [2m60[0m │     bp.route(GET, "a/:x", f!(crate::primitive));
+  [31m│[0m  [2m61[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
   [31m│[0m     · [35;1m                             ────────┬───────[0m
   [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<(u32, u32)>`[0m[0m
-  [31m│[0m  [2m58[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
+  [31m│[0m  [2m62[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -44,12 +44,12 @@
   [31m│[0m extraction would fail at runtime, when trying to process an incoming
   [31m│[0m request.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:57:1]
-  [31m│[0m  [2m57[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
-  [31m│[0m  [2m58[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:61:1]
+  [31m│[0m  [2m61[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
+  [31m│[0m  [2m62[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
   [31m│[0m     · [35;1m                             ──────────┬─────────[0m
   [31m│[0m     ·                                        [35;1m╰── [35;1mThe request handler asking for `RouteParams<&[u32]>`[0m[0m
-  [31m│[0m  [2m59[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
+  [31m│[0m  [2m63[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -63,12 +63,12 @@
   [31m│[0m a plain struct type. I don't support this: the extraction would fail at
   [31m│[0m runtime, when trying to process an incoming request.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:58:1]
-  [31m│[0m  [2m58[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
-  [31m│[0m  [2m59[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:62:1]
+  [31m│[0m  [2m62[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
+  [31m│[0m  [2m63[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m     · [35;1m                             ───────────────────┬───────────────────[0m
   [31m│[0m     ·                                                 [35;1m╰── [35;1mThe request handler asking for `RouteParams<&app::MyStruct>`[0m[0m
-  [31m│[0m  [2m60[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
+  [31m│[0m  [2m64[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -82,12 +82,12 @@
   [31m│[0m the extraction would fail at runtime, when trying to process an incoming
   [31m│[0m request.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:59:1]
-  [31m│[0m  [2m59[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
-  [31m│[0m  [2m60[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:63:1]
+  [31m│[0m  [2m63[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
+  [31m│[0m  [2m64[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
   [31m│[0m     · [35;1m                             ────────┬───────[0m
   [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MyEnum>`[0m[0m
-  [31m│[0m  [2m61[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
+  [31m│[0m  [2m65[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -101,12 +101,12 @@
   [31m│[0m support this: the extraction would fail at runtime, when trying to process
   [31m│[0m an incoming request.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:60:1]
-  [31m│[0m  [2m60[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
-  [31m│[0m  [2m61[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:64:1]
+  [31m│[0m  [2m64[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
+  [31m│[0m  [2m65[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m     · [35;1m                             ───────────┬───────────[0m
   [31m│[0m     ·                                         [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::TupleStruct>`[0m[0m
-  [31m│[0m  [2m62[0m │     bp.route(GET, "g/:x/:y", f!(crate::unit_struct));
+  [31m│[0m  [2m66[0m │     bp.route(GET, "g/:x/:y", f!(crate::unit_struct));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -120,12 +120,12 @@
   [31m│[0m a plain struct type. I don't support this: the extraction would fail at
   [31m│[0m runtime, when trying to process an incoming request.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:61:1]
-  [31m│[0m  [2m61[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
-  [31m│[0m  [2m62[0m │     bp.route(GET, "g/:x/:y", f!(crate::unit_struct));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:65:1]
+  [31m│[0m  [2m65[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
+  [31m│[0m  [2m66[0m │     bp.route(GET, "g/:x/:y", f!(crate::unit_struct));
   [31m│[0m     · [35;1m                             ───────────┬──────────[0m
   [31m│[0m     ·                                         [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::UnitStruct>`[0m[0m
-  [31m│[0m  [2m63[0m │     bp
+  [31m│[0m  [2m67[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_unsupported_types/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_unsupported_types/lib.rs
@@ -13,6 +13,7 @@ pub fn slice_ref(params: RouteParams<&[u32]>) -> String {
     todo!()
 }
 
+#[RouteParams]
 pub struct MyStruct {
     x: u32,
     y: u32,
@@ -22,6 +23,7 @@ pub fn reference<T>(params: RouteParams<&T>) -> String {
     todo!()
 }
 
+#[RouteParams]
 pub enum MyEnum {
     A(u32),
     B,
@@ -32,12 +34,14 @@ pub fn enum_(params: RouteParams<MyEnum>) -> String {
     todo!()
 }
 
+#[RouteParams]
 pub struct UnitStruct;
 
 pub fn unit_struct(params: RouteParams<UnitStruct>) -> String {
     todo!()
 }
 
+#[RouteParams]
 pub struct TupleStruct(u32, u32);
 
 pub fn tuple_struct(params: RouteParams<TupleStruct>) -> String {
@@ -53,12 +57,12 @@ pub fn blueprint() -> Blueprint {
     .error_handler(f!(
         pavex_runtime::extract::route::errors::ExtractRouteParamsError::into_response
     ));
-    bp.route(GET, "a/:x", f!(crate::primitive));
-    bp.route(GET, "b/:x/:y", f!(crate::tuple));
-    bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
-    bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
-    bp.route(GET, "e/:x/:y", f!(crate::enum_));
-    bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
-    bp.route(GET, "g/:x/:y", f!(crate::unit_struct));
+    bp.route(GET, "/a/:x", f!(crate::primitive));
+    bp.route(GET, "/b/:x/:y", f!(crate::tuple));
+    bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
+    bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
+    bp.route(GET, "/e/:x/:y", f!(crate::enum_));
+    bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
+    bp.route(GET, "/g/:x/:y", f!(crate::unit_struct));
     bp
 }

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_unsupported_types/test_config.toml
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_unsupported_types/test_config.toml
@@ -2,3 +2,6 @@ description = "Pavex can only extract route parameters using a struct with named
 
 [expectations]
 codegen = "fail"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/libs/pavex_cli/tests/ui_tests/static_methods_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/static_methods_are_supported/expectations/app.rs
@@ -64,7 +64,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/static_references_are_valid_singletons/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/static_references_are_valid_singletons/expectations/app.rs
@@ -67,7 +67,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/the_latest_registered_constructor_takes_precedence/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/the_latest_registered_constructor_takes_precedence/expectations/app.rs
@@ -64,7 +64,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/the_same_constructor_can_be_registered_multiple_times_using_the_same_lifecycle/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/the_same_constructor_can_be_registered_multiple_times_using_the_same_lifecycle/expectations/app.rs
@@ -64,7 +64,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/trait_methods_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/trait_methods_are_supported/expectations/app.rs
@@ -64,7 +64,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/trait_methods_with_non_local_generics_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/trait_methods_with_non_local_generics_are_supported/expectations/app.rs
@@ -64,7 +64,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/tuples_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/tuples_are_supported/expectations/app.rs
@@ -67,7 +67,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_cli/tests/ui_tests/type_alias_are_supported/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/type_alias_are_supported/expectations/app.rs
@@ -67,7 +67,9 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params = matched_route.params;
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
         0u32 => {
             match request.method() {

--- a/libs/pavex_macros/Cargo.toml
+++ b/libs/pavex_macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pavex_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "2.0"
+
+[dev-dependencies]
+trybuild = "1.0"
+pavex_runtime = { path = "../pavex_runtime" }
+serde = { version = "1.0", features = ["derive"] }

--- a/libs/pavex_macros/src/lib.rs
+++ b/libs/pavex_macros/src/lib.rs
@@ -1,0 +1,108 @@
+use proc_macro::TokenStream;
+
+use quote::quote;
+use syn::punctuated::Punctuated;
+use syn::{parse_macro_input, Attribute, Data, DeriveInput, Error, GenericParam, Token};
+
+#[allow(non_snake_case)]
+#[proc_macro_attribute]
+pub fn RouteParams(_metadata: TokenStream, input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    if let Err(mut e) = reject_serde_attributes(&ast) {
+        // We emit both the error AND the original struct.
+        // This is useful to avoid spurious "the type doesn't exist anymore" additional errors
+        e.extend(vec![TokenStream::from(quote! { #ast })]);
+        return e;
+    }
+
+    let generics_with_bounds = &ast.generics;
+    let generics_without_bounds = &ast
+        .generics
+        .params
+        .iter()
+        .map(|p| match p {
+            GenericParam::Lifetime(l) => {
+                let l = &l.lifetime;
+                quote! { #l }
+            }
+            GenericParam::Type(t) => {
+                let i = &t.ident;
+                quote! { #i }
+            }
+            GenericParam::Const(c) => {
+                let i = &c.ident;
+                quote! { #i }
+            }
+        })
+        .collect::<Punctuated<_, Token![,]>>();
+    let mut attrs = ast.attrs.clone();
+    attrs.push(syn::parse_quote!(#[derive(serde::Serialize, serde::Deserialize)]));
+    let struct_name = &ast.ident;
+    let expanded = quote! {
+        #(#attrs)*
+        #ast
+
+        impl #generics_with_bounds pavex_runtime::serialization::StructuralDeserialize for #struct_name < #generics_without_bounds > {}
+    };
+
+    TokenStream::from(expanded)
+}
+
+fn reject_serde_attributes(ast: &DeriveInput) -> Result<(), TokenStream> {
+    for attr in &ast.attrs {
+        reject_serde_attribute(attr)?;
+    }
+    match &ast.data {
+        Data::Struct(data) => {
+            for field in &data.fields {
+                for attr in &field.attrs {
+                    reject_serde_attribute(attr)?;
+                }
+            }
+        }
+        Data::Enum(data) => {
+            for variant in &data.variants {
+                for attr in &variant.attrs {
+                    reject_serde_attribute(attr)?;
+                }
+                for field in &variant.fields {
+                    for attr in &field.attrs {
+                        reject_serde_attribute(attr)?;
+                    }
+                }
+            }
+        }
+        Data::Union(union) => {
+            for field in &union.fields.named {
+                for attr in &field.attrs {
+                    reject_serde_attribute(attr)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// We don't want to allow `serde` attributes on the top-level struct or any of its fields,
+/// because we rely on `serde`'s default behaviour to determine, at code-generartion time,
+/// if the route params can be deserialized from the URL of the incoming request.
+fn reject_serde_attribute(attr: &Attribute) -> Result<(), TokenStream> {
+    let err_msg = "`RouteParams` does not support `serde` attributes on the top-level struct or any of its fields.\n\n\
+      `RouteParams` takes care of deriving `serde::Serialize` and `serde::Deserialize` for your struct, using the default \
+       configuration. This allow `pavex` to determine, at code-generation time, if the route params can \
+       be successfully extracted from the URL of incoming requests for the relevant routes (e.g. do you \
+       have a named field that doesn't map to any of the registered route parameters?).\n\n\
+       If the default `serde` configuration won't work for your case, you should not derive `RouteParams` and \
+       opt instead for implementing `serde::Serialize` and `serde::Deserialize` directly for your struct (either \
+       manually or using a derive with custom attributes).\nKeep in mind that by going down this route \
+       you give up compile-time checking of the route parameters!";
+    if let Some(ident) = attr.path().get_ident() {
+        if ident == "serde" {
+            return Err(Error::new_spanned(&attr, err_msg)
+                .into_compile_error()
+                .into());
+        }
+    }
+    Ok(())
+}

--- a/libs/pavex_macros/tests/fail.rs
+++ b/libs/pavex_macros/tests/fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/fail/*.rs");
+}

--- a/libs/pavex_macros/tests/fail/serde_conflict.rs
+++ b/libs/pavex_macros/tests/fail/serde_conflict.rs
@@ -1,0 +1,10 @@
+#[derive(serde::Deserialize)]
+#[pavex_macros::RouteParams]
+#[serde(rename_all = "camelCase")]
+struct MyStruct {
+    #[serde(rename = "field1")]
+    field1: i32,
+    field2: String,
+}
+
+fn main() {}

--- a/libs/pavex_macros/tests/fail/serde_conflict.stderr
+++ b/libs/pavex_macros/tests/fail/serde_conflict.stderr
@@ -1,0 +1,10 @@
+error: `RouteParams` does not support `serde` attributes on the top-level struct or any of its fields.
+
+       `RouteParams` takes care of deriving `serde::Serialize` and `serde::Deserialize` for your struct, using the default configuration. This allow `pavex` to determine, at code-generation time, if the route params can be successfully extracted from the URL of incoming requests for the relevant routes (e.g. do you have a named field that doesn't map to any of the registered route parameters?).
+
+       If the default `serde` configuration won't work for your case, you should not derive `RouteParams` and opt instead for implementing `serde::Serialize` and `serde::Deserialize` directly for your struct (either manually or using a derive with custom attributes).
+       Keep in mind that by going down this route you give up compile-time checking of the route parameters!
+ --> tests/fail/serde_conflict.rs:3:1
+  |
+3 | #[serde(rename_all = "camelCase")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/libs/pavex_macros/tests/fail/serde_conflict_after_route_params_without_attributes.rs
+++ b/libs/pavex_macros/tests/fail/serde_conflict_after_route_params_without_attributes.rs
@@ -1,0 +1,8 @@
+#[pavex_macros::RouteParams]
+#[derive(serde::Deserialize)]
+struct MyStruct {
+    field1: i32,
+    field2: String,
+}
+
+fn main() {}

--- a/libs/pavex_macros/tests/fail/serde_conflict_after_route_params_without_attributes.stderr
+++ b/libs/pavex_macros/tests/fail/serde_conflict_after_route_params_without_attributes.stderr
@@ -1,0 +1,20 @@
+error[E0119]: conflicting implementations of trait `Deserialize<'_>` for type `MyStruct`
+ --> tests/fail/serde_conflict_after_route_params_without_attributes.rs:1:1
+  |
+1 | #[pavex_macros::RouteParams]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyStruct`
+2 | #[derive(serde::Deserialize)]
+  |          ------------------ first implementation here
+  |
+  = note: this error originates in the derive macro `serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0119]: conflicting implementations of trait `Deserialize<'_>` for type `MyStruct`
+ --> tests/fail/serde_conflict_after_route_params_without_attributes.rs:2:10
+  |
+2 | #[derive(serde::Deserialize)]
+  |          ^^^^^^^^^^^^^^^^^^
+  |          |
+  |          first implementation here
+  |          conflicting implementation for `MyStruct`
+  |
+  = note: this error originates in the derive macro `serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/libs/pavex_macros/tests/fail/serde_conflict_before_route_params_without_attributes.rs
+++ b/libs/pavex_macros/tests/fail/serde_conflict_before_route_params_without_attributes.rs
@@ -1,0 +1,8 @@
+#[derive(serde::Deserialize)]
+#[pavex_macros::RouteParams]
+struct MyStruct {
+    field1: i32,
+    field2: String,
+}
+
+fn main() {}

--- a/libs/pavex_macros/tests/fail/serde_conflict_before_route_params_without_attributes.stderr
+++ b/libs/pavex_macros/tests/fail/serde_conflict_before_route_params_without_attributes.stderr
@@ -1,0 +1,9 @@
+error[E0119]: conflicting implementations of trait `Deserialize<'_>` for type `MyStruct`
+ --> tests/fail/serde_conflict_before_route_params_without_attributes.rs:2:1
+  |
+1 | #[derive(serde::Deserialize)]
+  |          ------------------ first implementation here
+2 | #[pavex_macros::RouteParams]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyStruct`
+  |
+  = note: this error originates in the derive macro `serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/libs/pavex_macros/tests/happy.rs
+++ b/libs/pavex_macros/tests/happy.rs
@@ -1,0 +1,5 @@
+#[test]
+fn pass() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/success/*.rs");
+}

--- a/libs/pavex_macros/tests/success/happy.rs
+++ b/libs/pavex_macros/tests/success/happy.rs
@@ -1,0 +1,76 @@
+#[pavex_macros::RouteParams]
+struct SimpleStruct {
+    field1: i32,
+    field2: String,
+}
+
+#[pavex_macros::RouteParams]
+struct NestedStruct {
+    field1: SimpleStruct,
+}
+
+#[pavex_macros::RouteParams]
+struct StructWithOneGeneric<T> {
+    field1: T,
+    field2: String,
+}
+
+#[pavex_macros::RouteParams]
+struct StructWithOneInlineBoundGeneric<T: std::fmt::Display> {
+    field1: T,
+    field2: String,
+}
+
+#[pavex_macros::RouteParams]
+struct StructWithTwoGenerics<T, S> {
+    field1: T,
+    field2: S,
+}
+
+#[pavex_macros::RouteParams]
+struct StructWithOneGenericAndALifetime<'a, S> {
+    field1: &'a str,
+    field2: S,
+}
+
+#[pavex_macros::RouteParams]
+struct StructWithTwoLifetimes<'a, 'b: 'a> {
+    field1: &'a str,
+    field2: &'b str,
+}
+
+/// Verify that the given type implements the traits we expect.
+fn has_required_traits<
+    'a,
+    T: pavex_runtime::serialization::StructuralDeserialize + serde::Deserialize<'a> + serde::Serialize,
+>(
+    _t: T,
+) {
+}
+
+fn main() {
+    has_required_traits(SimpleStruct {
+        field1: 1,
+        field2: "hello".to_string(),
+    });
+    has_required_traits(StructWithOneGeneric {
+        field1: 1,
+        field2: "hello".to_string(),
+    });
+    has_required_traits(StructWithOneInlineBoundGeneric {
+        field1: 1,
+        field2: "hello".to_string(),
+    });
+    has_required_traits(StructWithTwoGenerics {
+        field1: 1,
+        field2: "hello".to_string(),
+    });
+    has_required_traits(StructWithOneGenericAndALifetime {
+        field1: "HEY",
+        field2: "hello".to_string(),
+    });
+    has_required_traits(StructWithTwoLifetimes {
+        field1: "HEY",
+        field2: "hello",
+    });
+}

--- a/libs/pavex_runtime/Cargo.toml
+++ b/libs/pavex_runtime/Cargo.toml
@@ -15,6 +15,7 @@ mime = "0.3"
 percent-encoding = "2"
 thiserror = "1"
 serde = "1"
+pavex_macros = { path = "../pavex_macros" }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/libs/pavex_runtime/src/extract/route/errors.rs
+++ b/libs/pavex_runtime/src/extract/route/errors.rs
@@ -26,6 +26,8 @@ pub enum ExtractRouteParamsError {
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
+/// One of the percent-decoded route parameters is not a valid UTF8 string.
+///
 /// URL parameters must be percent-encoded whenever they contain characters that are not
 /// URL safe—e.g. whitespaces.
 ///
@@ -137,7 +139,7 @@ impl std::error::Error for PathDeserializationError {}
 /// more precise error messages (e.g. implementing your own custom conversion from
 /// `PathDeserializationError` into an HTTP response).
 ///
-/// [`RouteParams`]: crate::extract::route::RouteParams
+/// [`RouteParams`]: struct@crate::extract::route::RouteParams
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {

--- a/libs/pavex_runtime/src/extract/route/mod.rs
+++ b/libs/pavex_runtime/src/extract/route/mod.rs
@@ -4,28 +4,69 @@
 //! use pavex_builder::{f, router::GET, Blueprint, Lifecycle};
 //! use pavex_runtime::extract::route::RouteParams;
 //!
-//! # fn main() {
-//! let mut bp = Blueprint::new();
-//! // [...]
-//! // Register a route with a route parameter, `:home_id`.
-//! bp.route(GET, "/home/:home_id", f!(crate::get_home));
-//! # }
+//! fn blueprint() -> Blueprint{
+//!     let mut bp = Blueprint::new();
+//!     // [...]
+//!     // Register a route with a route parameter, `:home_id`.
+//!     bp.route(GET, "/home/:home_id", f!(crate::get_home));
+//!     bp
+//! }
 //!
-//! #[derive(serde::Deserialize)]
-//! struct HomeRouteParams {
+//! // The RouteParams attribute macro derives the necessary (de)serialization traits.
+//! #[RouteParams]
+//! struct Home {
 //!     // The name of the field must match the name of the route parameter
 //!     // used in `bp.route`.
 //!     home_id: u32
 //! }
 //!
-//! // The `RouteParams` extractor will deserialize the route parameters into
-//! // the type you specified—`HomeRouteParams` in this case.
-//! fn get_home(params: &RouteParams<HomeRouteParams>) -> String {
+//! // The `RouteParams` extractor deserializes the extracted route parameters into
+//! // the type you specified—`Home` in this case.
+//! fn get_home(params: &RouteParams<Home>) -> String {
 //!    format!("The identifier for this home is: {}", params.0.home_id)
 //! }
 //! ```
 //!
 //! Check out [`RouteParams`]' documentation for more details.
+//!
+//! [`RouteParams`]: struct@RouteParams
+
+/// Derive (de)serialization logic for a type that is going to be used to extract route parameters.
+///
+/// This macro derives [`StructuralDeserialize`], [`serde::Serialize`] and [`serde::Deserialize`]
+/// for the type that it is applied to.
+///
+/// Check out [`RouteParams`](struct@RouteParams) for more details on how to work with
+/// route parameters in `pavex`.  
+/// Check out [`StructuralDeserialize`] if you are curious about the rationale behind this
+/// macro.
+///
+/// # Example
+///
+/// ```rust
+/// use pavex_builder::{f, router::GET, Blueprint, Lifecycle};
+/// use pavex_runtime::extract::route::RouteParams;
+///
+/// fn blueprint() -> Blueprint { ///
+///     let mut bp = Blueprint::new();
+///     // [...]
+///     // Register a route with a route parameter, `:home_id`.
+///     bp.route(GET, "/home/:home_id", f!(crate::get_home));
+///     # bp
+/// }
+///
+/// #[RouteParams]
+/// struct Home {
+///     home_id: u32
+/// }
+///
+/// fn get_home(params: &RouteParams<Home>) -> String {
+///     format!("The identifier for this home is: {}", params.0.home_id)
+/// }
+/// ```
+///
+/// [`StructuralDeserialize`]: crate::serialization::StructuralDeserialize
+pub use pavex_macros::RouteParams;
 pub use raw_route_params::{RawRouteParams, RawRouteParamsIter};
 pub use route_params::RouteParams;
 

--- a/libs/pavex_runtime/src/extract/route/raw_route_params.rs
+++ b/libs/pavex_runtime/src/extract/route/raw_route_params.rs
@@ -8,12 +8,13 @@ use matchit::{Params, ParamsIter};
 /// use pavex_builder::{f, router::GET, Blueprint};
 /// use pavex_runtime::extract::route::RawRouteParams;
 ///
-/// # fn main() {
-/// let mut bp = Blueprint::new();
-/// // [...]
-/// // Register a route with a few route parameters.
-/// bp.route(GET, "/address/:address_id/home/:home_id", f!(crate::get_home));
-/// # }
+/// fn blueprint() -> Blueprint {
+///     let mut bp = Blueprint::new();
+///     // [...]
+///     // Register a route with a few route parameters.
+///     bp.route(GET, "/address/:address_id/home/:home_id", f!(crate::get_home));
+///     bp
+/// }
 ///
 /// fn get_home(params: &RawRouteParams) -> String {
 ///     let home_id = &params.get("home_id").unwrap();
@@ -52,8 +53,8 @@ use matchit::{Params, ParamsIter};
 /// most of the time you'll want to use [`RouteParams`] instead—it performs percent-decoding
 /// and deserialization for you.
 ///
-/// [`RouteParams`]: crate::extract::route::RouteParams
-pub struct RawRouteParams<'server, 'request>(matchit::Params<'server, 'request>);
+/// [`RouteParams`]: struct@crate::extract::route::RouteParams
+pub struct RawRouteParams<'server, 'request>(Params<'server, 'request>);
 
 impl<'server, 'request> RawRouteParams<'server, 'request> {
     /// Returns the number of extracted route parameters.

--- a/libs/pavex_runtime/src/extract/route/route_params.rs
+++ b/libs/pavex_runtime/src/extract/route/route_params.rs
@@ -60,7 +60,7 @@ use super::RawRouteParams;
 /// `T` in `RouteParams<T>` must implement [`serde::Deserialize`]—it is automatically derived if
 /// you use the [`RouteParams`](macro@crate::extract::route::RouteParams) attribute macro, the
 /// approach we recommend.  
-/// `T` must be struct with named fields, where each field name matches one of the route parameter
+/// `T` must be a struct with named fields, where each field name matches one of the route parameter
 /// names used in the route's path template.
 ///
 /// ```rust

--- a/libs/pavex_runtime/src/lib.rs
+++ b/libs/pavex_runtime/src/lib.rs
@@ -9,3 +9,5 @@ pub mod body;
 pub mod error;
 pub mod extract;
 pub mod response;
+
+pub mod serialization;

--- a/libs/pavex_runtime/src/serialization.rs
+++ b/libs/pavex_runtime/src/serialization.rs
@@ -1,0 +1,25 @@
+//! Serialization and deserialization utilities.
+
+/// A marker trait for types that perform deserialization using the strategy provided "out-of-the-box" by `serde`.
+///
+/// All types that derive `RouteParams` automatically implement this trait.  
+/// It is **discouraged** to manually implement this trait for one of your types—and you should
+/// have no need to do so.
+///
+/// # Why do we need this?
+///
+/// > This is largely an implementation detail of `pavex` and you don't need to worry about it
+/// > unless you are curious and want to know more about how `pavex` works under the hood.
+///
+/// This trait is used by `pavex` to reason about the way a type is going to be deserialized—i.e.
+/// mapping the shape of the Rust type to the expected shape of the data to be deserialized.
+///
+/// This enables `pavex` to confidently detect common errors at compile time—e.g. if a type
+/// is trying to deserialize a route parameter that doesn't exist in the route template for the
+/// relevant request handler.  
+/// Doing this analysis for arbitrary types would result in false positives—e.g. a type might resort to
+/// a custom implementation of `serde::Deserialize` that does not actually look for a route parameter
+/// named as the field that we see in the type definition.  
+/// `StructuralDeserialize` acts as a tag that tells `pavex` that a type should be in scope
+/// for additional static analysis and that it's OK to make certain assumptions.
+pub trait StructuralDeserialize {}


### PR DESCRIPTION
We introduce a `RouteParams` attribute macro which derives `serde::Deserialize`, `serde::Serialize` and `StructuralDeserialize`.
The latter is a new marker trait that we introduce to tag types that use the "out-of-the-box" deserialization strategy provided by `serde`. For those types we perform additional static analysis: we ensure that all their fields are named after a route parameter when they are used in combination with the `RouteParams` extractor.
