### PR TITLE
Catch-all route parameters

### DIFF
--- a/libs/pavex_cli/tests/ui_tests/route_parameters_happy_path/expectations/diagnostics.dot
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_happy_path/expectations/diagnostics.dot
@@ -40,6 +40,27 @@ digraph "GET /home/:home_id/room/:room_id" {
     7 -> 8 [ ]
     2 -> 9 [ ]
 }
+digraph "GET /town/*town" {
+    0 [ label = "app::get_town(pavex_runtime::extract::route::RouteParams<app::TownRouteParams<'_>>) -> alloc::string::String"]
+    1 [ label = "core::prelude::rust_2015::v1::Result<pavex_runtime::extract::route::RouteParams<app::TownRouteParams<'_>>, pavex_runtime::extract::route::errors::ExtractRouteParamsError> -> pavex_runtime::extract::route::RouteParams<app::TownRouteParams<'_>>"]
+    2 [ label = "pavex_runtime::extract::route::RouteParams::extract(pavex_runtime::extract::route::RawRouteParams<'_, '_>) -> core::prelude::rust_2015::v1::Result<pavex_runtime::extract::route::RouteParams<app::TownRouteParams<'_>>, pavex_runtime::extract::route::errors::ExtractRouteParamsError>"]
+    3 [ label = "pavex_runtime::extract::route::RawRouteParams<'_, '_>"]
+    4 [ label = "<alloc::string::String as pavex_runtime::response::IntoResponse>::into_response(alloc::string::String) -> http::Response<http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>>"]
+    5 [ label = "core::prelude::rust_2015::v1::Result<pavex_runtime::extract::route::RouteParams<app::TownRouteParams<'_>>, pavex_runtime::extract::route::errors::ExtractRouteParamsError> -> pavex_runtime::extract::route::errors::ExtractRouteParamsError"]
+    6 [ label = "pavex_runtime::extract::route::errors::ExtractRouteParamsError -> &pavex_runtime::extract::route::errors::ExtractRouteParamsError"]
+    7 [ label = "pavex_runtime::extract::route::errors::ExtractRouteParamsError::into_response(&pavex_runtime::extract::route::errors::ExtractRouteParamsError) -> http::Response<alloc::string::String>"]
+    8 [ label = "<http::Response::<alloc::string::String> as pavex_runtime::response::IntoResponse>::into_response(http::Response<alloc::string::String>) -> http::Response<http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>>"]
+    9 [ label = "`match`"]
+    1 -> 0 [ ]
+    9 -> 5 [ ]
+    3 -> 2 [ ]
+    0 -> 4 [ ]
+    9 -> 1 [ ]
+    5 -> 6 [ ]
+    6 -> 7 [ ]
+    7 -> 8 [ ]
+    2 -> 9 [ ]
+}
 digraph app_state {
     0 [ label = "crate::ApplicationState() -> crate::ApplicationState"]
 }

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_happy_path/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_happy_path/lib.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use pavex_builder::{f, router::GET, Blueprint, Lifecycle};
 use pavex_runtime::extract::route::RouteParams;
 
@@ -21,6 +23,15 @@ pub fn get_room(params: RouteParams<RoomRouteParams>) -> String {
     format!("{}", params.0.home_id)
 }
 
+#[RouteParams]
+pub struct TownRouteParams<'a> {
+    pub town: Cow<'a, str>,
+}
+
+pub fn get_town(params: RouteParams<TownRouteParams<'_>>) -> String {
+    format!("{}", params.0.town)
+}
+
 pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
     bp.constructor(
@@ -32,5 +43,6 @@ pub fn blueprint() -> Blueprint {
     ));
     bp.route(GET, "/home/:home_id", f!(crate::get_home));
     bp.route(GET, "/home/:home_id/room/:room_id", f!(crate::get_room));
+    bp.route(GET, "/town/*town", f!(crate::get_town));
     bp
 }

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_happy_path/test.rs
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_happy_path/test.rs
@@ -32,6 +32,42 @@ async fn route_parameter_extraction_works() {
 }
 
 #[tokio::test]
+async fn catch_all_extraction_works_on_a_single_segment() {
+    let port = spawn_test_server().await;
+    let response = reqwest::get(&format!("http://localhost:{}/town/123", port))
+        .await
+        .expect("Failed to make request")
+        .error_for_status()
+        .expect("Failed to get successful response");
+    let text = response.text().await.expect("Failed to get response body");
+    assert_eq!("123", text);
+}
+
+#[tokio::test]
+async fn catch_all_extraction_works_on_a_multiple_segments() {
+    let port = spawn_test_server().await;
+    let response = reqwest::get(&format!(
+        "http://localhost:{}/town/123/street/hello%20mate",
+        port
+    ))
+    .await
+    .expect("Failed to make request")
+    .error_for_status()
+    .expect("Failed to get successful response");
+    let text = response.text().await.expect("Failed to get response body");
+    assert_eq!("123/street/hello mate", text);
+}
+
+#[tokio::test]
+async fn catch_all_match_cannot_be_empty() {
+    let port = spawn_test_server().await;
+    let response = reqwest::get(&format!("http://localhost:{}/town/", port))
+        .await
+        .expect("Failed to make request");
+    assert_eq!(response.status(), 404);
+}
+
+#[tokio::test]
 async fn route_parameter_has_the_wrong_type() {
     let port = spawn_test_server().await;
     let response = reqwest::get(&format!("http://localhost:{}/home/abc", port))

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_non_existing_fields/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_non_existing_fields/expectations/stderr.txt
@@ -2,7 +2,7 @@
   [31m×[0m `app::missing_one` is trying to extract route parameters using
   [31m│[0m `RouteParams<app::MissingOne>`.
   [31m│[0m Every struct field in `app::MissingOne` must be named after one of the
-  [31m│[0m route parameters that appear in `a/:x`:
+  [31m│[0m route parameters that appear in `/a/:x`:
   [31m│[0m - `x`
   [31m│[0m 
   [31m│[0m There is no route parameter named `y`, but there is a struct field named
@@ -10,10 +10,10 @@
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:43:1]
   [31m│[0m  [2m43[0m │     ));
-  [31m│[0m  [2m44[0m │     bp.route(GET, "a/:x", f!(crate::missing_one));
-  [31m│[0m     · [35;1m                          ───────────┬──────────[0m
-  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MissingOne>`[0m[0m
-  [31m│[0m  [2m45[0m │     bp.route(GET, "b/:x", f!(crate::missing_two));
+  [31m│[0m  [2m44[0m │     bp.route(GET, "/a/:x", f!(crate::missing_one));
+  [31m│[0m     · [35;1m                           ───────────┬──────────[0m
+  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MissingOne>`[0m[0m
+  [31m│[0m  [2m45[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
   [31m│[0m         parameter.
@@ -22,18 +22,18 @@
   [31m×[0m `app::missing_two` is trying to extract route parameters using
   [31m│[0m `RouteParams<app::MissingTwo>`.
   [31m│[0m Every struct field in `app::MissingTwo` must be named after one of the
-  [31m│[0m route parameters that appear in `b/:x`:
+  [31m│[0m route parameters that appear in `/b/:x`:
   [31m│[0m - `x`
   [31m│[0m 
-  [31m│[0m There are no route parameters named ``y`, `z``, but they appear as field
+  [31m│[0m There are no route parameters named `y` or `z`, but they appear as field
   [31m│[0m names in `app::MissingTwo`. This is going to cause a runtime error!
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:44:1]
-  [31m│[0m  [2m44[0m │     bp.route(GET, "a/:x", f!(crate::missing_one));
-  [31m│[0m  [2m45[0m │     bp.route(GET, "b/:x", f!(crate::missing_two));
-  [31m│[0m     · [35;1m                          ───────────┬──────────[0m
-  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MissingTwo>`[0m[0m
-  [31m│[0m  [2m46[0m │     bp.route(GET, "c", f!(crate::no_route_params));
+  [31m│[0m  [2m44[0m │     bp.route(GET, "/a/:x", f!(crate::missing_one));
+  [31m│[0m  [2m45[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
+  [31m│[0m     · [35;1m                           ───────────┬──────────[0m
+  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MissingTwo>`[0m[0m
+  [31m│[0m  [2m46[0m │     bp.route(GET, "/c", f!(crate::no_route_params));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
   [31m│[0m         parameter.
@@ -41,19 +41,15 @@
 [31m[1mERROR[0m[39m: 
   [31m×[0m `app::no_route_params` is trying to extract route parameters using
   [31m│[0m `RouteParams<app::NoRouteParams>`.
-  [31m│[0m Every struct field in `app::NoRouteParams` must be named after one of the
-  [31m│[0m route parameters that appear in `c`:
-  [31m│[0m 
-  [31m│[0m 
-  [31m│[0m There are no route parameters named ``x`, `y``, but they appear as field
-  [31m│[0m names in `app::NoRouteParams`. This is going to cause a runtime error!
+  [31m│[0m But there are no route parameters in `/c`, the corresponding route
+  [31m│[0m template!
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:45:1]
-  [31m│[0m  [2m45[0m │     bp.route(GET, "b/:x", f!(crate::missing_two));
-  [31m│[0m  [2m46[0m │     bp.route(GET, "c", f!(crate::no_route_params));
-  [31m│[0m     · [35;1m                       ─────────────┬────────────[0m
-  [31m│[0m     ·                                     [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::NoRouteParams>`[0m[0m
+  [31m│[0m  [2m45[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
+  [31m│[0m  [2m46[0m │     bp.route(GET, "/c", f!(crate::no_route_params));
+  [31m│[0m     · [35;1m                        ─────────────┬────────────[0m
+  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::NoRouteParams>`[0m[0m
   [31m│[0m  [2m47[0m │     bp
   [31m│[0m     ╰────
-  [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
-  [31m│[0m         parameter.
+  [31m│[0m [36m  help: [0mStop trying to extract route parameters, or add them to the route
+  [31m│[0m         template!

--- a/libs/pavex_cli/tests/ui_tests/route_parameters_unsupported_types/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters_unsupported_types/expectations/stderr.txt
@@ -8,10 +8,10 @@
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:59:1]
   [31m│[0m  [2m59[0m │     ));
-  [31m│[0m  [2m60[0m │     bp.route(GET, "a/:x", f!(crate::primitive));
-  [31m│[0m     · [35;1m                          ──────────┬─────────[0m
-  [31m│[0m     ·                                     [35;1m╰── [35;1mThe request handler asking for `RouteParams<u32>`[0m[0m
-  [31m│[0m  [2m61[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
+  [31m│[0m  [2m60[0m │     bp.route(GET, "/a/:x", f!(crate::primitive));
+  [31m│[0m     · [35;1m                           ──────────┬─────────[0m
+  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<u32>`[0m[0m
+  [31m│[0m  [2m61[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -26,11 +26,11 @@
   [31m│[0m request.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:60:1]
-  [31m│[0m  [2m60[0m │     bp.route(GET, "a/:x", f!(crate::primitive));
-  [31m│[0m  [2m61[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
-  [31m│[0m     · [35;1m                             ────────┬───────[0m
-  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<(u32, u32)>`[0m[0m
-  [31m│[0m  [2m62[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
+  [31m│[0m  [2m60[0m │     bp.route(GET, "/a/:x", f!(crate::primitive));
+  [31m│[0m  [2m61[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
+  [31m│[0m     · [35;1m                              ────────┬───────[0m
+  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler asking for `RouteParams<(u32, u32)>`[0m[0m
+  [31m│[0m  [2m62[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -45,11 +45,11 @@
   [31m│[0m request.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:61:1]
-  [31m│[0m  [2m61[0m │     bp.route(GET, "b/:x/:y", f!(crate::tuple));
-  [31m│[0m  [2m62[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
-  [31m│[0m     · [35;1m                             ──────────┬─────────[0m
-  [31m│[0m     ·                                        [35;1m╰── [35;1mThe request handler asking for `RouteParams<&[u32]>`[0m[0m
-  [31m│[0m  [2m63[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
+  [31m│[0m  [2m61[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
+  [31m│[0m  [2m62[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
+  [31m│[0m     · [35;1m                              ──────────┬─────────[0m
+  [31m│[0m     ·                                         [35;1m╰── [35;1mThe request handler asking for `RouteParams<&[u32]>`[0m[0m
+  [31m│[0m  [2m63[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -64,11 +64,11 @@
   [31m│[0m runtime, when trying to process an incoming request.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:62:1]
-  [31m│[0m  [2m62[0m │     bp.route(GET, "c/:x/:z", f!(crate::slice_ref));
-  [31m│[0m  [2m63[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
-  [31m│[0m     · [35;1m                             ───────────────────┬───────────────────[0m
-  [31m│[0m     ·                                                 [35;1m╰── [35;1mThe request handler asking for `RouteParams<&app::MyStruct>`[0m[0m
-  [31m│[0m  [2m64[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
+  [31m│[0m  [2m62[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
+  [31m│[0m  [2m63[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
+  [31m│[0m     · [35;1m                              ───────────────────┬───────────────────[0m
+  [31m│[0m     ·                                                  [35;1m╰── [35;1mThe request handler asking for `RouteParams<&app::MyStruct>`[0m[0m
+  [31m│[0m  [2m64[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -83,11 +83,11 @@
   [31m│[0m request.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:63:1]
-  [31m│[0m  [2m63[0m │     bp.route(GET, "d/:x/:y", f!(crate::reference::<crate::MyStruct>));
-  [31m│[0m  [2m64[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
-  [31m│[0m     · [35;1m                             ────────┬───────[0m
-  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MyEnum>`[0m[0m
-  [31m│[0m  [2m65[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
+  [31m│[0m  [2m63[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
+  [31m│[0m  [2m64[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
+  [31m│[0m     · [35;1m                              ────────┬───────[0m
+  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MyEnum>`[0m[0m
+  [31m│[0m  [2m65[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -102,11 +102,11 @@
   [31m│[0m an incoming request.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:64:1]
-  [31m│[0m  [2m64[0m │     bp.route(GET, "e/:x/:y", f!(crate::enum_));
-  [31m│[0m  [2m65[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
-  [31m│[0m     · [35;1m                             ───────────┬───────────[0m
-  [31m│[0m     ·                                         [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::TupleStruct>`[0m[0m
-  [31m│[0m  [2m66[0m │     bp.route(GET, "g/:x/:y", f!(crate::unit_struct));
+  [31m│[0m  [2m64[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
+  [31m│[0m  [2m65[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
+  [31m│[0m     · [35;1m                              ───────────┬───────────[0m
+  [31m│[0m     ·                                          [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::TupleStruct>`[0m[0m
+  [31m│[0m  [2m66[0m │     bp.route(GET, "/g/:x/:y", f!(crate::unit_struct));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
   [31m│[0m         Check out `RouteParams`' documentation for all the details!
@@ -121,10 +121,10 @@
   [31m│[0m runtime, when trying to process an incoming request.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:65:1]
-  [31m│[0m  [2m65[0m │     bp.route(GET, "f/:x/:y", f!(crate::tuple_struct));
-  [31m│[0m  [2m66[0m │     bp.route(GET, "g/:x/:y", f!(crate::unit_struct));
-  [31m│[0m     · [35;1m                             ───────────┬──────────[0m
-  [31m│[0m     ·                                         [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::UnitStruct>`[0m[0m
+  [31m│[0m  [2m65[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
+  [31m│[0m  [2m66[0m │     bp.route(GET, "/g/:x/:y", f!(crate::unit_struct));
+  [31m│[0m     · [35;1m                              ───────────┬──────────[0m
+  [31m│[0m     ·                                          [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::UnitStruct>`[0m[0m
   [31m│[0m  [2m67[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.


### PR DESCRIPTION
Add support for catch-all parameters.

We also update test expectations and fix a compiler error that slipped through in #33.