### PR TITLE
Improve diagnostic for ambiguous singletons

### DIFF
--- a/libs/pavex/src/compiler/analyses/call_graph/application_state.rs
+++ b/libs/pavex/src/compiler/analyses/call_graph/application_state.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use ahash::{HashMap, HashMapExt, HashSet};
 use bimap::BiHashMap;
@@ -58,7 +58,13 @@ pub(crate) fn application_state_call_graph(
         is_async: false,
         path: application_state_type.resolved_path(),
         output: Some(application_state_type.clone().into()),
-        inputs: runtime_singleton_bindings.right_values().cloned().collect(),
+        inputs: {
+            // Ensure that the inputs are sorted by name.
+            let b = runtime_singleton_bindings
+                .iter()
+                .collect::<BTreeMap<_, _>>();
+            b.into_values().cloned().collect()
+        },
         invocation_style: InvocationStyle::StructLiteral {
             field_names: runtime_singleton_bindings
                 .iter()

--- a/libs/pavex/src/compiler/analyses/constructibles.rs
+++ b/libs/pavex/src/compiler/analyses/constructibles.rs
@@ -238,8 +238,8 @@ impl ConstructibleDb {
                 // registration site for that constructor.
                 let mut snippets = Vec::new();
                 let mut source_code = None;
-                'inner: for (_, component_id) in component_ids {
-                    let Some(user_component_id) = component_db.user_component_id(*component_id) else {
+                'inner: for (_, component_id) in &component_ids {
+                    let Some(user_component_id) = component_db.user_component_id(**component_id) else {
                         continue 'inner;
                     };
                     let location = component_db
@@ -283,6 +283,13 @@ impl ConstructibleDb {
                         ))
                         .build()
                 } else {
+                    let _common_ancestor_scope_id =
+                        component_db.scope_graph().find_common_ancestor(
+                            component_ids
+                                .iter()
+                                .map(|(scope_id, _)| *scope_id)
+                                .collect(),
+                        );
                     let error = anyhow::anyhow!(
                         "The constructor for a singleton must be registered once.\n\
                         You registered the same constructor for `{type_:?}` against {n_constructors} \

--- a/libs/pavex/src/compiler/analyses/constructibles.rs
+++ b/libs/pavex/src/compiler/analyses/constructibles.rs
@@ -67,7 +67,7 @@ impl ConstructibleDb {
                 {
                     let input_constructor_scope = component_db.scope_id(input_constructor_id);
                     assert!(component_scope
-                        .is_child_of(input_constructor_scope, component_db.scope_graph(),));
+                        .is_child_of(input_constructor_scope, component_db.scope_graph()));
                 }
             }
         }
@@ -285,20 +285,18 @@ impl ConstructibleDb {
                 } else {
                     let error = anyhow::anyhow!(
                         "The constructor for a singleton must be registered once.\n\
-                        You registered the same constructor for `{type_:?}` against different \
-                        nested blueprints, but there can be at most one instance for each singleton \
-                        type.\n\
-                        I don't know how to proceed: do you want to share the same instance across \
-                        all nested blueprints, or do you want to create a new instance for each \
-                        nested blueprint?\n\
-                        You registered the same constructor for `{type_:?}` in {n_constructors} different places:",
+                        You registered the same constructor for `{type_:?}` against {n_constructors} \
+                        different nested blueprints.\n\
+                        I don't know how to proceed: do you want to share the same singleton instance across \
+                        all those nested blueprints, or do you want to create a new instance for each \
+                        nested blueprint?",
                     );
                     CompilerDiagnostic::builder(source_code, error)
                         .additional_annotated_snippets(snippets.into_iter())
                         // TODO: add a code snippet in the suggestion showing which blueprint
                         //   should be used to register the constructor.
                         .help(format!(
-                            "If you want a single instance of `{type_:?}`, remove \
+                            "If you want to share a single instance of `{type_:?}`, remove \
                             constructors for `{type_:?}` until there is only one left. It should \
                             be attached to a blueprint that is a parent of all the nested \
                             ones that need to use it.\n\

--- a/libs/pavex/src/compiler/analyses/user_components/scope_graph.rs
+++ b/libs/pavex/src/compiler/analyses/user_components/scope_graph.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeSet, HashMap};
 
-use indexmap::IndexSet;
 use petgraph::algo::has_path_connecting;
 use petgraph::graphmap::DiGraphMap;
 use petgraph::visit::IntoNodeIdentifiers;
@@ -60,7 +59,7 @@ pub struct ScopeGraphBuilder {
     next_node_id: usize,
 }
 
-#[derive(Copy, Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Copy, Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 /// The unique ID of a scope.
 ///
 /// See [`ScopeGraph`] for more information.
@@ -83,7 +82,7 @@ impl ScopeId {
     }
 
     /// Return the IDs of the parent scopes, if any.
-    pub fn parent_ids(&self, scope_graph: &ScopeGraph) -> IndexSet<ScopeId> {
+    pub fn parent_ids(&self, scope_graph: &ScopeGraph) -> BTreeSet<ScopeId> {
         scope_graph
             .graph
             .neighbors_directed(self.0, petgraph::Direction::Incoming)

--- a/libs/pavex/src/compiler/analyses/user_components/scope_graph.rs
+++ b/libs/pavex/src/compiler/analyses/user_components/scope_graph.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use indexmap::IndexSet;
 use petgraph::algo::has_path_connecting;
@@ -152,7 +152,7 @@ impl ScopeGraphBuilder {
                     .count()
                     == 0
             })
-            .collect::<IndexSet<_>>();
+            .collect::<BTreeSet<_>>();
         graph.add_node(application_state);
         for id in leaf_scopes {
             graph.add_edge(id, application_state, ());

--- a/libs/pavex/src/diagnostic/mod.rs
+++ b/libs/pavex/src/diagnostic/mod.rs
@@ -1,11 +1,11 @@
 //! A toolkit to assemble and report errors and warnings to the user.
 use std::fmt::{Display, Formatter};
 
-pub(crate) use compiler_diagnostic::{AnnotatedSnippet, CompilerDiagnostic};
+pub(crate) use compiler_diagnostic::{AnnotatedSnippet, CompilerDiagnostic, HelpWithSnippet};
 pub(crate) use ordinals::ZeroBasedOrdinal;
 pub(crate) use proc_macro_utils::ProcMacroSpanExt;
 pub(crate) use registration_locations::{
-    get_f_macro_invocation_span, get_nest_at_prefix_span, get_route_path_span,
+    get_bp_new_span, get_f_macro_invocation_span, get_nest_at_prefix_span, get_route_path_span,
 };
 pub(crate) use source_file::{read_source_file, LocationExt, ParsedSourceFile};
 

--- a/libs/pavex_builder/src/internals.rs
+++ b/libs/pavex_builder/src/internals.rs
@@ -36,5 +36,5 @@ pub struct NestedBlueprint {
     /// If `None`, the routes coming from the nested [`Blueprint`] will be registered as-they-are.
     pub path_prefix: Option<String>,
     /// The location where the [`Blueprint`] was nested under its parent [`Blueprint`].
-    pub location: Location,
+    pub nesting_location: Location,
 }

--- a/libs/pavex_cli/tests/ui_tests/application_state_should_include_runtime_singletons_from_all_scopes/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/application_state_should_include_runtime_singletons_from_all_scopes/expectations/app.rs
@@ -7,8 +7,8 @@ struct ServerState {
     application_state: ApplicationState,
 }
 pub struct ApplicationState {
-    s1: u64,
     s0: u32,
+    s1: u64,
 }
 pub async fn build_application_state() -> crate::ApplicationState {
     let v0 = app::singleton_dep();

--- a/libs/pavex_cli/tests/ui_tests/application_state_should_include_runtime_singletons_from_all_scopes/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/application_state_should_include_runtime_singletons_from_all_scopes/expectations/app.rs
@@ -11,12 +11,12 @@ pub struct ApplicationState {
     s1: u64,
 }
 pub async fn build_application_state() -> crate::ApplicationState {
-    let v0 = app::singleton_dep();
-    let v1 = app::nested_singleton(v0);
-    let v2 = app::parent_singleton();
+    let v0 = app::parent_singleton();
+    let v1 = app::singleton_dep();
+    let v2 = app::nested_singleton(v1);
     crate::ApplicationState {
-        s0: v1,
-        s1: v2,
+        s0: v2,
+        s1: v0,
     }
 }
 pub async fn run(

--- a/libs/pavex_cli/tests/ui_tests/application_state_should_include_runtime_singletons_from_all_scopes/expectations/diagnostics.dot
+++ b/libs/pavex_cli/tests/ui_tests/application_state_should_include_runtime_singletons_from_all_scopes/expectations/diagnostics.dot
@@ -13,11 +13,11 @@ digraph "GET /parent" {
     0 -> 2 [ ]
 }
 digraph app_state {
-    0 [ label = "crate::ApplicationState(u64, u32) -> crate::ApplicationState"]
-    1 [ label = "app::nested_singleton(u16) -> u32"]
-    2 [ label = "app::singleton_dep() -> u16"]
-    3 [ label = "app::parent_singleton() -> u64"]
+    0 [ label = "crate::ApplicationState(u32, u64) -> crate::ApplicationState"]
+    1 [ label = "app::parent_singleton() -> u64"]
+    2 [ label = "app::nested_singleton(u16) -> u32"]
+    3 [ label = "app::singleton_dep() -> u16"]
     1 -> 0 [ ]
-    2 -> 1 [ ]
-    3 -> 0 [ ]
+    2 -> 0 [ ]
+    3 -> 2 [ ]
 }

--- a/libs/pavex_cli/tests/ui_tests/nesting_fails_if_the_same_singleton_constructor_is_registered_in_different_scopes/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/nesting_fails_if_the_same_singleton_constructor_is_registered_in_different_scopes/expectations/stderr.txt
@@ -22,9 +22,16 @@
   [31m│[0m     ·                              [35;1m╰── [35;1mA constructor was registered here[0m[0m
   [31m│[0m  [2m24[0m │     bp.route(GET, "/child", f!(crate::handler));
   [31m│[0m     ╰────
-  [31m│[0m [36m  help: [0mIf you want to share a single instance of `u64`, remove constructors
-  [31m│[0m         for `u64` until there is only one left. It should be attached to
-  [31m│[0m         a blueprint that is a parent of all the nested ones that need to
-  [31m│[0m         use it.
-  [31m│[0m         If you want different instances, consider creating separate newtypes
+  [31m│[0m   [36mhelp:[0m If you want to share a single instance of `u64`, remove constructors
+  [31m│[0m         for `u64` until there is only one left. It should be attached to a
+  [31m│[0m         blueprint that is a parent of all the nested ones that need to use it.
+  [31m│[0m        ☞
+  [31m│[0m          ╭─[[36;1;4msrc/lib.rs[0m:5:1]
+  [31m│[0m        [2m5[0m │ pub fn blueprint() -> Blueprint {
+  [31m│[0m        [2m6[0m │     let mut bp = Blueprint::new();
+  [31m│[0m          · [35;1m                 ────────┬───────[0m
+  [31m│[0m          ·                          [35;1m╰── [35;1mRegister your constructor against this blueprint[0m[0m
+  [31m│[0m        [2m7[0m │     bp.constructor(f!(crate::singleton), Lifecycle::Singleton);
+  [31m│[0m          ╰────
+  [31m│[0m [36m  help: [0mIf you want different instances, consider creating separate newtypes
   [31m│[0m         that wrap a `u64`.

--- a/libs/pavex_cli/tests/ui_tests/nesting_fails_if_the_same_singleton_constructor_is_registered_in_different_scopes/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/nesting_fails_if_the_same_singleton_constructor_is_registered_in_different_scopes/expectations/stderr.txt
@@ -1,11 +1,10 @@
 [31m[1mERROR[0m[39m: 
   [31m×[0m The constructor for a singleton must be registered once.
-  [31m│[0m You registered the same constructor for `u64` against different nested
-  [31m│[0m blueprints, but there can be at most one instance for each singleton type.
-  [31m│[0m I don't know how to proceed: do you want to share the same instance across
-  [31m│[0m all nested blueprints, or do you want to create a new instance for each
-  [31m│[0m nested blueprint?
-  [31m│[0m You registered the same constructor for `u64` in 2 different places:
+  [31m│[0m You registered the same constructor for `u64` against 2 different nested
+  [31m│[0m blueprints.
+  [31m│[0m I don't know how to proceed: do you want to share the same singleton
+  [31m│[0m instance across all those nested blueprints, or do you want to create a
+  [31m│[0m new instance for each nested blueprint?
   [31m│[0m
   [31m│[0m   [31m×[0m 
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:6:1]
@@ -23,9 +22,9 @@
   [31m│[0m     ·                              [35;1m╰── [35;1mA constructor was registered here[0m[0m
   [31m│[0m  [2m24[0m │     bp.route(GET, "/child", f!(crate::handler));
   [31m│[0m     ╰────
-  [31m│[0m [36m  help: [0mIf you want a single instance of `u64`, remove constructors for
-  [31m│[0m         `u64` until there is only one left. It should be attached to a
-  [31m│[0m         blueprint that is a parent of all the nested ones that need to use
-  [31m│[0m         it.
+  [31m│[0m [36m  help: [0mIf you want to share a single instance of `u64`, remove constructors
+  [31m│[0m         for `u64` until there is only one left. It should be attached to
+  [31m│[0m         a blueprint that is a parent of all the nested ones that need to
+  [31m│[0m         use it.
   [31m│[0m         If you want different instances, consider creating separate newtypes
   [31m│[0m         that wrap a `u64`.


### PR DESCRIPTION
Show a code snippet, in the help section, pointing at the blueprint you should register your constructor against if you want to share a singleton across all found instances.

Drive-by changes:
- Fix a few sources of non-determinism for the application state. The new test for scoping triggered these edge cases since the state constructor has more than one parameter.
