### PR TITLE
[Realworld example] Add a ping route.

### DIFF
--- a/examples/realworld/Cargo.lock
+++ b/examples/realworld/Cargo.lock
@@ -76,7 +76,10 @@ dependencies = [
 name = "app_server_sdk"
 version = "0.1.0"
 dependencies = [
+ "app_blueprint",
+ "bytes",
  "http",
+ "http-body",
  "hyper",
  "pavex_runtime",
 ]

--- a/examples/realworld/app_blueprint/src/lib.rs
+++ b/examples/realworld/app_blueprint/src/lib.rs
@@ -1,5 +1,12 @@
-use pavex_builder::Blueprint;
+use pavex_builder::{Blueprint, router::GET, f};
+use pavex_runtime::hyper::StatusCode;
+
+pub fn ping() -> StatusCode {
+    StatusCode::OK
+}
 
 pub fn app_blueprint() -> Blueprint {
-    Blueprint::new()
+    let mut bp = Blueprint::new();
+    bp.route(GET, "/api/ping", f!(crate::ping));
+    bp
 }

--- a/examples/realworld/app_server_sdk/Cargo.toml
+++ b/examples/realworld/app_server_sdk/Cargo.toml
@@ -8,6 +8,9 @@ generator_type = "cargo_workspace_binary"
 generator_name = "bp"
 
 [dependencies]
+app_blueprint = { version = "0.1.0", path = "../app_blueprint", package = "app_blueprint" }
+bytes = { version = "1.4.0", package = "bytes" }
 http = { version = "0.2.9", package = "http" }
+http_body = { version = "0.4.5", package = "http-body" }
 hyper = { version = "0.14.26", package = "hyper" }
 pavex_runtime = { version = "0.1.0", path = "../../../libs/pavex_runtime", package = "pavex_runtime" }

--- a/examples/realworld/app_server_sdk/blueprint.ron
+++ b/examples/realworld/app_server_sdk/blueprint.ron
@@ -1,10 +1,31 @@
 (
     creation_location: (
-        line: 4,
-        column: 5,
+        line: 9,
+        column: 18,
         file: "app_blueprint/src/lib.rs",
     ),
     constructors: [],
-    routes: [],
+    routes: [
+        (
+            path: "/ping",
+            method_guard: (
+                allowed_methods: [
+                    "GET",
+                ],
+            ),
+            request_handler: (
+                callable: (
+                    registered_at: "app_blueprint",
+                    import_path: "crate :: ping",
+                ),
+                location: (
+                    line: 10,
+                    column: 8,
+                    file: "app_blueprint/src/lib.rs",
+                ),
+            ),
+            error_handler: None,
+        ),
+    ],
     nested_blueprints: [],
 )

--- a/examples/realworld/app_server_sdk/src/lib.rs
+++ b/examples/realworld/app_server_sdk/src/lib.rs
@@ -48,6 +48,7 @@ fn build_router() -> Result<
     pavex_runtime::routing::InsertError,
 > {
     let mut router = pavex_runtime::routing::Router::new();
+    router.insert("/ping", 0u32)?;
     Ok(router)
 }
 async fn route_request(
@@ -69,6 +70,18 @@ async fn route_request(
         .params
         .into();
     match route_id {
+        0u32 => {
+            match request.method() {
+                &pavex_runtime::http::Method::GET => route_handler_0().await,
+                _ => {
+                    pavex_runtime::response::Response::builder()
+                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                        .header(pavex_runtime::http::header::ALLOW, "GET")
+                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+                        .unwrap()
+                }
+            }
+        }
         _ => {
             pavex_runtime::response::Response::builder()
                 .status(pavex_runtime::http::StatusCode::NOT_FOUND)
@@ -76,4 +89,10 @@ async fn route_request(
                 .unwrap()
         }
     }
+}
+pub async fn route_handler_0() -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v0 = app_blueprint::ping();
+    <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(v0)
 }


### PR DESCRIPTION
A simple "the app is reachable" endpoint that can be used as a shallow healthcheck.