### PR TITLE
Memoise needed crates across runs

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -335,6 +335,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +819,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +857,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miette"
@@ -930,6 +992,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1041,7 @@ dependencies = [
  "itertools",
  "la-arena",
  "miette",
+ "num_cpus",
  "once_cell",
  "pathdiff",
  "pavex_builder",
@@ -963,6 +1049,9 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
+ "r2d2",
+ "r2d2_sqlite",
+ "rayon",
  "rusqlite",
  "rustdoc-types",
  "semver",
@@ -1118,6 +1207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1238,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f31323d6161385f385046738df520e0e8694fa74852d35891fc0be08348ddc"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1251,6 +1429,21 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -1762,6 +1955,16 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+dependencies = [
+ "getrandom",
+ "rand",
+]
 
 [[package]]
 name = "valuable"

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -35,8 +35,16 @@ convert_case = "0.6"
 textwrap = "0.16.0"
 once_cell = "1.17.1"
 toml_edit = { version = "0.19.8", features = ["serde"] }
-xdg-home = "1.0.0"
 semver = "1.0.17"
-rusqlite = { version = "0.29.0", features = ["bundled"] }
-bincode = "1"
+
+# Checksum
 sha2 = "0.10.6"
+
+# Sqlite cache
+xdg-home = "1.0.0"
+rusqlite = { version = "0.29.0", features = ["bundled"] }
+r2d2_sqlite = "0.22.0"
+r2d2 = "0.8"
+bincode = "1"
+rayon = "1.7"
+num_cpus = "1.15.0"

--- a/libs/pavex/src/compiler/analyses/user_components/processed_db.rs
+++ b/libs/pavex/src/compiler/analyses/user_components/processed_db.rs
@@ -179,7 +179,7 @@ fn precompute_crate_docs(
     for (_, path) in resolved_path_db.iter() {
         path.collect_package_ids(&mut package_ids);
     }
-    if let Err(e) = krate_collection.batch_compute_crates(package_ids.into_iter().cloned()) {
+    if let Err(e) = krate_collection.bootstrap_collection(package_ids.into_iter().cloned()) {
         diagnostics.push(miette!(e.context(
             "I failed to compute the JSON documentation for one or more crates in the workspace."
         )));

--- a/libs/pavex/src/compiler/app.rs
+++ b/libs/pavex/src/compiler/app.rs
@@ -57,7 +57,7 @@ impl App {
     ///
     /// Many different things can go wrong during this process: this method tries its best to
     /// report all errors to the user, but it may not be able to do so in all cases.
-    pub fn build(bp: Blueprint) -> Result<Self, Vec<miette::Error>> {
+    pub fn build(bp: Blueprint, project_fingerprint: String) -> Result<Self, Vec<miette::Error>> {
         /// Exit early if there is at least one error.
         macro_rules! exit_on_errors {
             ($var:ident) => {
@@ -68,7 +68,7 @@ impl App {
         }
 
         let krate_collection =
-            CrateCollection::new().map_err(|e| vec![miette!(e)])?;
+            CrateCollection::new(project_fingerprint).map_err(|e| vec![miette!(e)])?;
         let package_graph = krate_collection.package_graph().to_owned();
         let mut diagnostics = vec![];
         let mut computation_db = ComputationDb::new();

--- a/libs/pavex/src/rustdoc/mod.rs
+++ b/libs/pavex/src/rustdoc/mod.rs
@@ -16,11 +16,13 @@ mod queries;
 mod utils;
 
 pub const STD_PACKAGE_ID_REPR: &str = "std";
+pub static STD_PACKAGE_ID: Lazy<PackageId> = Lazy::new(|| PackageId::new(STD_PACKAGE_ID_REPR));
 
 pub const CORE_PACKAGE_ID_REPR: &str = "core";
 pub static CORE_PACKAGE_ID: Lazy<PackageId> = Lazy::new(|| PackageId::new(CORE_PACKAGE_ID_REPR));
 
 pub const ALLOC_PACKAGE_ID_REPR: &str = "alloc";
+pub static ALLOC_PACKAGE_ID: Lazy<PackageId> = Lazy::new(|| PackageId::new(ALLOC_PACKAGE_ID_REPR));
 
 pub const TOOLCHAIN_CRATES: [&str; 3] = [
     STD_PACKAGE_ID_REPR,

--- a/libs/pavex_cli/src/main.rs
+++ b/libs/pavex_cli/src/main.rs
@@ -139,7 +139,9 @@ fn generate(
     output: PathBuf,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let blueprint = Blueprint::load(&blueprint)?;
-    let app = match App::build(blueprint) {
+    // We use the path to the generated application crate as a fingerprint for the project.
+    let project_fingerprint = output.to_string_lossy().into_owned();
+    let app = match App::build(blueprint, project_fingerprint) {
         Ok(a) => a,
         Err(errors) => {
             for e in errors {


### PR DESCRIPTION
Our biggest bottleneck is computing JSON docs, so this is once again an optimisation to try to maximise how much work we are doing in parallel every time we invoke `rustdoc` or retrieve items from the cache.

It's difficult to determine which crate docs we need ahead of performing the actual analysis, which in turn leads to multiple invocations that are not fully utilising the cores available on the host machine.  
We can't do much to improve on this problem when executing for the first time, but we can do much better when optimising for the feedback loop of an interactive coding session. 

Every time `pavex_cli` is invoked for a project, we keep track of which crate docs are accessed and store it in SQLite at the end of the invocation.
We then retrieve this list when invoked again on the same project and compute all those crate docs eagerly, leveraging as much parallelism as we can.

This brings the running time down from ~1050ms to ~770ms for the second invocation on the same project, a 26% speedup 🚀 