### PR TITLE
Add Json, BufferedBody and BodySizeLimits

### DIFF
--- a/examples/realworld/Cargo.lock
+++ b/examples/realworld/Cargo.lock
@@ -1105,6 +1105,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_html_form",
+ "serde_json",
  "thiserror",
 ]
 

--- a/examples/realworld/api_server_sdk/blueprint.ron
+++ b/examples/realworld/api_server_sdk/blueprint.ron
@@ -4,7 +4,112 @@
         column: 18,
         file: "conduit_core/src/lib.rs",
     ),
-    constructors: [],
+    constructors: [
+        (
+            constructor: (
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "pavex_runtime :: extract :: query :: QueryParams :: extract",
+                ),
+                location: (
+                    line: 14,
+                    column: 8,
+                    file: "conduit_core/src/lib.rs",
+                ),
+            ),
+            lifecycle: RequestScoped,
+            cloning_strategy: None,
+            error_handler: Some((
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "pavex_runtime :: extract :: query :: errors :: ExtractQueryParamsError ::\ninto_response",
+                ),
+                location: (
+                    line: 18,
+                    column: 6,
+                    file: "conduit_core/src/lib.rs",
+                ),
+            )),
+        ),
+        (
+            constructor: (
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "pavex_runtime :: extract :: route :: RouteParams :: extract",
+                ),
+                location: (
+                    line: 21,
+                    column: 8,
+                    file: "conduit_core/src/lib.rs",
+                ),
+            ),
+            lifecycle: RequestScoped,
+            cloning_strategy: None,
+            error_handler: Some((
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "pavex_runtime :: extract :: route :: errors :: ExtractRouteParamsError ::\ninto_response",
+                ),
+                location: (
+                    line: 25,
+                    column: 6,
+                    file: "conduit_core/src/lib.rs",
+                ),
+            )),
+        ),
+        (
+            constructor: (
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "pavex_runtime :: extract :: body :: JsonBody :: extract",
+                ),
+                location: (
+                    line: 28,
+                    column: 8,
+                    file: "conduit_core/src/lib.rs",
+                ),
+            ),
+            lifecycle: RequestScoped,
+            cloning_strategy: None,
+            error_handler: Some((
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "pavex_runtime :: extract :: body :: errors :: ExtractJsonBodyError ::\ninto_response",
+                ),
+                location: (
+                    line: 32,
+                    column: 6,
+                    file: "conduit_core/src/lib.rs",
+                ),
+            )),
+        ),
+        (
+            constructor: (
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "pavex_runtime :: extract :: body :: BufferedBody :: extract",
+                ),
+                location: (
+                    line: 35,
+                    column: 8,
+                    file: "conduit_core/src/lib.rs",
+                ),
+            ),
+            lifecycle: RequestScoped,
+            cloning_strategy: None,
+            error_handler: Some((
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "pavex_runtime :: extract :: body :: errors :: ExtractBufferedBodyError ::\ninto_response",
+                ),
+                location: (
+                    line: 39,
+                    column: 6,
+                    file: "conduit_core/src/lib.rs",
+                ),
+            )),
+        ),
+    ],
     routes: [
         (
             path: "/api/ping",
@@ -19,7 +124,7 @@
                     import_path: "crate :: ping",
                 ),
                 location: (
-                    line: 13,
+                    line: 43,
                     column: 8,
                     file: "conduit_core/src/lib.rs",
                 ),
@@ -31,7 +136,7 @@
         (
             blueprint: (
                 creation_location: (
-                    line: 7,
+                    line: 16,
                     column: 18,
                     file: "conduit_core/src/articles/mod.rs",
                 ),
@@ -40,32 +145,22 @@
                         constructor: (
                             callable: (
                                 registered_at: "conduit_core",
-                                import_path: "pavex_runtime :: extract :: query :: QueryParams :: extract",
+                                import_path: "crate :: articles :: body_size_limit",
                             ),
                             location: (
-                                line: 9,
+                                line: 17,
                                 column: 8,
                                 file: "conduit_core/src/articles/mod.rs",
                             ),
                         ),
-                        lifecycle: RequestScoped,
+                        lifecycle: Singleton,
                         cloning_strategy: None,
-                        error_handler: Some((
-                            callable: (
-                                registered_at: "conduit_core",
-                                import_path: "pavex_runtime :: extract :: query :: errors :: ExtractQueryParamsError ::\ninto_response",
-                            ),
-                            location: (
-                                line: 13,
-                                column: 6,
-                                file: "conduit_core/src/articles/mod.rs",
-                            ),
-                        )),
+                        error_handler: None,
                     ),
                 ],
                 routes: [
                     (
-                        path: "/",
+                        path: "",
                         method_guard: (
                             allowed_methods: [
                                 "GET",
@@ -77,7 +172,107 @@
                                 import_path: "crate :: articles :: list_articles",
                             ),
                             location: (
-                                line: 17,
+                                line: 19,
+                                column: 8,
+                                file: "conduit_core/src/articles/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "",
+                        method_guard: (
+                            allowed_methods: [
+                                "POST",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate :: articles :: publish_article",
+                            ),
+                            location: (
+                                line: 20,
+                                column: 8,
+                                file: "conduit_core/src/articles/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/feed",
+                        method_guard: (
+                            allowed_methods: [
+                                "GET",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate :: articles :: get_feed",
+                            ),
+                            location: (
+                                line: 21,
+                                column: 8,
+                                file: "conduit_core/src/articles/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/:slug",
+                        method_guard: (
+                            allowed_methods: [
+                                "GET",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate :: articles :: get_article",
+                            ),
+                            location: (
+                                line: 22,
+                                column: 8,
+                                file: "conduit_core/src/articles/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/:slug",
+                        method_guard: (
+                            allowed_methods: [
+                                "DELETE",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate :: articles :: delete_article",
+                            ),
+                            location: (
+                                line: 23,
+                                column: 8,
+                                file: "conduit_core/src/articles/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/:slug",
+                        method_guard: (
+                            allowed_methods: [
+                                "PUT",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate :: articles :: update_article",
+                            ),
+                            location: (
+                                line: 24,
                                 column: 8,
                                 file: "conduit_core/src/articles/mod.rs",
                             ),
@@ -89,7 +284,7 @@
             ),
             path_prefix: Some("/articles"),
             nesting_location: (
-                line: 14,
+                line: 44,
                 column: 8,
                 file: "conduit_core/src/lib.rs",
             ),

--- a/examples/realworld/conduit_core/src/articles/mod.rs
+++ b/examples/realworld/conduit_core/src/articles/mod.rs
@@ -1,25 +1,40 @@
 use pavex_builder::constructor::Lifecycle;
+use pavex_builder::router::{DELETE, POST, PUT};
 use pavex_builder::{f, router::GET, Blueprint};
+use pavex_runtime::extract::body::{JsonBody, BodySizeLimit};
 use pavex_runtime::extract::query::QueryParams;
+use pavex_runtime::extract::route::RouteParams;
 use pavex_runtime::hyper::StatusCode;
+
+pub fn body_size_limit() -> BodySizeLimit {
+    BodySizeLimit::Enabled {
+        max_n_bytes: 10
+    }
+}
 
 pub(crate) fn articles_bp() -> Blueprint {
     let mut bp = Blueprint::new();
+    bp.constructor(f!(crate::articles::body_size_limit), Lifecycle::Singleton);
 
-    bp.constructor(
-        f!(pavex_runtime::extract::query::QueryParams::extract),
-        Lifecycle::RequestScoped,
-    )
-    .error_handler(f!(
-        pavex_runtime::extract::query::errors::ExtractQueryParamsError::into_response
-    ));
-
-    bp.route(GET, "/", f!(crate::articles::list_articles));
+    bp.route(GET, "", f!(crate::articles::list_articles));
+    bp.route(POST, "", f!(crate::articles::publish_article));
+    bp.route(GET, "/feed", f!(crate::articles::get_feed));
+    bp.route(GET, "/:slug", f!(crate::articles::get_article));
+    bp.route(DELETE, "/:slug", f!(crate::articles::delete_article));
+    bp.route(PUT, "/:slug", f!(crate::articles::update_article));
     bp
 }
 
 #[derive(Debug, serde::Deserialize)]
-pub struct GetArticlesApiRequest {
+pub struct GetFeed {
+    #[serde(default = "default_limit")]
+    pub limit: u64,
+    #[serde(default = "default_offset")]
+    pub offset: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GetArticles {
     pub tag: Option<String>,
     pub author: Option<String>,
     pub favorited: Option<String>,
@@ -27,6 +42,37 @@ pub struct GetArticlesApiRequest {
     pub limit: u64,
     #[serde(default = "default_offset")]
     pub offset: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct PublishArticle {
+    pub title: String,
+    pub description: String,
+    pub body: String,
+    #[serde(rename = "tagList", default)]
+    pub tag_list: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct UpdateArticleBody {
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct UpdateArticleRoute {
+    pub slug: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GetArticle {
+    pub slug: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct DeleteArticle {
+    pub slug: String,
 }
 
 fn default_limit() -> u64 {
@@ -37,6 +83,29 @@ fn default_offset() -> u64 {
     0
 }
 
-pub fn list_articles(_params: QueryParams<GetArticlesApiRequest>) -> StatusCode {
+pub fn list_articles(_params: QueryParams<GetArticles>) -> StatusCode {
+    StatusCode::OK
+}
+
+pub fn get_feed(_params: QueryParams<GetFeed>) -> StatusCode {
+    StatusCode::OK
+}
+
+pub fn get_article(_params: RouteParams<GetArticle>) -> StatusCode {
+    StatusCode::OK
+}
+
+pub fn publish_article(_body: JsonBody<PublishArticle>) -> StatusCode {
+    StatusCode::OK
+}
+
+pub fn delete_article(_params: RouteParams<DeleteArticle>) -> StatusCode {
+    StatusCode::OK
+}
+
+pub fn update_article(
+    _params: RouteParams<UpdateArticleRoute>,
+    _body: JsonBody<UpdateArticleBody>,
+) -> StatusCode {
     StatusCode::OK
 }

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -738,6 +738,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a28d25139df397cbca21408bb742cf6837e04cdbebf1b07b760caf971d6a972"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +833,12 @@ dependencies = [
  "termcolor",
  "threadpool",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1152,6 +1171,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "insta",
  "matchit",
  "mime",
  "pavex_builder",
@@ -1159,7 +1179,9 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_html_form",
+ "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1788,7 +1810,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2235,4 +2269,13 @@ checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
 dependencies = [
  "nix",
  "winapi",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/libs/pavex/src/compiler/analyses/constructibles.rs
+++ b/libs/pavex/src/compiler/analyses/constructibles.rs
@@ -62,27 +62,6 @@ impl ConstructibleDb {
             diagnostics,
         );
 
-        // For each type that supports dependency injection, we look up the constructors of their inputs.
-        // We assert that all their inputs are in a scope that is the same or a
-        // parent of the their own scope.
-        // This should always be the case, but we add an assertion to eagerly discover if our
-        // assumptions are wrong.
-        for (component_id, _) in component_db.iter() {
-            let component = component_db.hydrated_component(component_id, computation_db);
-            let component_scope = component_db.scope_id(component_id);
-            for input_type in component.input_types().iter() {
-                // Some inputs are not constructible and will be injected by the framework
-                // or as part of the application state.
-                if let Some((input_constructor_id, _)) =
-                    self_.get(component_scope, input_type, component_db.scope_graph())
-                {
-                    let input_constructor_scope = component_db.scope_id(input_constructor_id);
-                    assert!(component_scope
-                        .is_child_of(input_constructor_scope, component_db.scope_graph()));
-                }
-            }
-        }
-
         self_
     }
 

--- a/libs/pavex_runtime/Cargo.toml
+++ b/libs/pavex_runtime/Cargo.toml
@@ -22,6 +22,11 @@ percent-encoding = "2"
 # Query parameters
 serde_html_form = "0.1"
 
+# Json body extractor
+serde_json = "1"
+
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 pavex_builder = { path = "../pavex_builder" }
+tokio = { version = "1", features = ["macros"] }
+insta = "1.29.0"

--- a/libs/pavex_runtime/src/body/mod.rs
+++ b/libs/pavex_runtime/src/body/mod.rs
@@ -42,7 +42,6 @@ where
     B: Body<Data = Bytes> + Send + Sync + 'static,
     B::Error: Into<Box<dyn std::error::Error + Sync + Send>>,
 {
-    // We
     try_downcast(body).unwrap_or_else(|body| body.map_err(Error::new).boxed())
 }
 

--- a/libs/pavex_runtime/src/extract/body/buffered_body.rs
+++ b/libs/pavex_runtime/src/extract/body/buffered_body.rs
@@ -1,0 +1,293 @@
+use crate::{extract::body::errors::SizeLimitExceeded, request::RequestHead};
+
+use super::{
+    errors::{ExtractBufferedBodyError, UnexpectedBufferError},
+    BodySizeLimit,
+};
+use bytes::Bytes;
+use http::header::CONTENT_LENGTH;
+use http_body::Limited;
+use hyper::body::to_bytes;
+
+#[derive(Debug)]
+#[non_exhaustive]
+/// Buffer the entire body of an incoming request in memory.
+///
+/// `BufferedBody` is the ideal building block for _other_ extractors that need to
+/// have the entire body available in memory to do their job (e.g. [`JsonBody`](super::JsonBody)).  
+///
+/// It can also be useful if you need to access the raw bytes of the body ahead of deserialization
+/// (e.g. to compute its hash as a step of a signature verification process).
+///
+/// # Sections
+///
+/// - [Example](#example)
+/// - [Installation](#installtion)
+/// - [Body size limit](#body-size-limit)
+///
+/// # Example
+///
+/// ```rust
+/// use pavex_runtime::extract::body::BufferedBody;
+///
+/// // The `BufferedBody` extractor consumes the raw request body stream
+/// // and buffers its entire contents in memory.
+/// pub fn handler(body: &BufferedBody) -> String {
+///     format!(
+///         "The incoming request contains {} bytes",
+///         body.bytes.len(),
+///     )
+/// }
+/// ```
+///
+/// # Installation
+///
+/// You need the register the default constructor and error handler for
+/// `BufferedBody` in your `Blueprint`:
+///
+/// ```rust
+/// use pavex_builder::{f, Blueprint, constructor::Lifecycle};
+///
+/// fn blueprint() -> Blueprint {
+///    let mut bp = Blueprint::new();
+///    // Register the default constructor and error handler for `BufferedBody`.
+///    bp.constructor(
+///         f!(pavex_runtime::extract::body::BufferedBody::extract),
+///         Lifecycle::RequestScoped,
+///     ).error_handler(
+///         f!(pavex_runtime::extract::body::errors::ExtractBufferedBodyError::into_response)
+///     );
+///     // [...]
+///     bp
+/// }
+/// ```
+///
+/// You can then use the `BufferedBody` extractor as input to your route handlers and constructors.
+///
+/// # Body size limit
+///
+/// To prevent denial-of-service attacks, Pavex enforces an upper limit on the body size when
+/// trying to buffer it in memory. The default limit is 2 MBs.  
+///
+/// [`BufferedBody::extract`] will return the [`SizeLimitExceeded`](ExtractBufferedBodyError::SizeLimitExceeded) error variant if the limit is exceeded.
+///
+/// You can customize the limit by registering a constructor for [`BodySizeLimit`] in 
+/// your `Blueprint`:
+/// 
+/// ```rust
+/// use pavex_builder::{f, Blueprint, constructor::Lifecycle};
+/// use pavex_runtime::extract::body::BodySizeLimit;
+/// 
+/// pub fn body_size_limit() -> BodySizeLimit {
+///     BodySizeLimit::Enabled {
+///         max_n_bytes: 10_485_760 // 10 MBs
+///     }
+/// }
+/// 
+/// fn blueprint() -> Blueprint {
+///     let mut bp = Blueprint::new();
+///     // Register a custom constructor for `BodySizeLimit`.
+///     bp.constructor(f!(crate::body_size_limit), Lifecycle::Singleton);
+///     // [...]
+///     bp
+/// }
+/// ```
+/// 
+/// You can also disable the limit entirely:  
+/// 
+/// ```rust
+/// use pavex_builder::{f, Blueprint, constructor::Lifecycle};
+/// use pavex_runtime::extract::body::BodySizeLimit;
+/// 
+/// pub fn body_size_limit() -> BodySizeLimit {
+///    BodySizeLimit::Disabled
+/// }
+/// 
+/// fn blueprint() -> Blueprint {
+///     let mut bp = Blueprint::new();
+///     // Register a custom constructor for `BodySizeLimit`.
+///     bp.constructor(f!(crate::body_size_limit), Lifecycle::Singleton);
+///     // [...]
+///     bp
+/// }
+/// ```
+/// 
+/// There might be situations where you want granular control instead of having 
+/// a single global limit for all incoming requests.  
+/// You can leverage nesting for this purpose:
+/// 
+/// ```rust
+/// use pavex_builder::{f, Blueprint, constructor::Lifecycle};
+/// use pavex_runtime::extract::body::BodySizeLimit;
+/// # pub fn home() -> String { todo!() }
+/// # pub fn upload() -> String { todo!() }
+/// 
+/// fn blueprint() -> Blueprint {
+///     let mut bp = Blueprint::new();
+///     bp.route(GET, "/", f!(crate::home));
+///     bp.nest(upload_bp());
+///     // [...]
+///     bp
+/// }
+/// 
+/// fn upload_bp() -> Blueprint {
+///     let mut bp = Blueprint::new();
+///     // This limit will only apply to the routes registered
+///     // in this nested blueprint.
+///     bp.constructor(f!(crate::body_size_limit), Lifecycle::Singleton);
+///     bp.route(POST, "/upload", f!(crate::upload));
+///     bp
+/// }
+/// 
+/// pub fn upload_size_limit() -> BodySizeLimit {
+///     BodySizeLimit::Enabled {
+///         max_n_bytes: 1_073_741_824 // 1GB
+///     }
+/// }
+/// ```
+/// 
+/// Check out `Blueprint::nest` and `Blueprint::nest_at` for more details on nesting.
+pub struct BufferedBody {
+    /// The buffer of bytes that represents the body of the incoming request.
+    pub bytes: Bytes,
+}
+
+impl BufferedBody {
+    /// Default constructor for [`BufferedBody`].
+    ///
+    /// If extraction fails, an [`ExtractBufferedBodyError`] is returned.
+    pub async fn extract(
+        request_head: &RequestHead,
+        body: hyper::Body,
+        body_size_limit: BodySizeLimit,
+    ) -> Result<Self, ExtractBufferedBodyError> {
+        match body_size_limit {
+            BodySizeLimit::Enabled { max_n_bytes } => {
+                Self::_extract_with_limit(request_head, body, max_n_bytes).await
+            }
+            BodySizeLimit::Disabled => match to_bytes(body).await {
+                Ok(bytes) => Ok(Self { bytes }),
+                Err(e) => Err(UnexpectedBufferError { source: e.into() }.into()),
+            },
+        }
+    }
+
+    async fn _extract_with_limit(
+        request_head: &RequestHead,
+        body: hyper::Body,
+        max_n_bytes: usize,
+    ) -> Result<Self, ExtractBufferedBodyError> {
+        let content_length = request_head
+            .headers
+            .get(CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok()?.parse::<usize>().ok());
+
+        // Little shortcut to create a `SizeLimitExceeded` error.
+        let limit_error = || SizeLimitExceeded {
+            max_n_bytes,
+            content_length,
+        };
+
+        // We first check the `Content-Length` header, if it exists, to see if the
+        // "expected" size of the body is larger than the maximum size limit.
+        // If it is, we return an error immediately.
+        // This is a performance optimization: it allows us to short-circuit the
+        // body reading process entirely rather than reading the body incrementally
+        // until the limit is reached.
+        if let Some(len) = content_length {
+            if len > max_n_bytes {
+                return Err(limit_error().into());
+            }
+        }
+
+        // If the `Content-Length` header is missing, or if the expected size of the body
+        // is smaller than the maximum size limit, we start buffering the body while keeping
+        // track of the size limit.
+        let limited_body = Limited::new(body, max_n_bytes);
+        match to_bytes(limited_body).await {
+            Ok(bytes) => Ok(Self { bytes }),
+            Err(e) => {
+                if let Some(_) = e.downcast_ref::<http_body::LengthLimitError>() {
+                    Err(limit_error().into())
+                } else {
+                    Err(UnexpectedBufferError { source: e }.into())
+                }
+            }
+        }
+    }
+}
+
+impl From<BufferedBody> for Bytes {
+    fn from(buffered_body: BufferedBody) -> Self {
+        buffered_body.bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::HeaderMap;
+
+    use super::BufferedBody;
+    use crate::request::RequestHead;
+
+    // No headers.
+    fn dummy_request_head() -> RequestHead {
+        RequestHead {
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            version: http::Version::HTTP_11,
+            headers: HeaderMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn error_if_body_above_size_limit_without_content_length() {
+        let body: hyper::Body = vec![0; 1000].into();
+        // Smaller than the size of the body.
+        let max_n_bytes = 100;
+        let err = BufferedBody::_extract_with_limit(&dummy_request_head(), body, max_n_bytes)
+            .await
+            .unwrap_err();
+        insta::assert_display_snapshot!(err, @"The request body is larger than the maximum size limit enforced by this server.");
+        insta::assert_debug_snapshot!(err, @r###"
+        SizeLimitExceeded(
+            SizeLimitExceeded {
+                max_n_bytes: 100,
+                content_length: None,
+            },
+        )
+        "###);
+    }
+
+    #[tokio::test]
+    /// This is a case of a request lying about the size of its body,
+    /// triggering the limit check even though the actual body size
+    /// would have been fine.
+    async fn error_if_content_length_header_is_larger_than_limit() {
+        let mut request_head = dummy_request_head();
+
+        // Smaller than the value declared in the `Content-Length` header,
+        // even though it's bigger than the actual size of the body.
+        let max_n_bytes = 100;
+        let body: hyper::Body = vec![0; 500].into();
+        request_head
+            .headers
+            .insert("Content-Length", "1000".parse().unwrap());
+
+        // Act
+        let err = BufferedBody::_extract_with_limit(&request_head, body, max_n_bytes)
+            .await
+            .unwrap_err();
+        insta::assert_display_snapshot!(err, @"The request body is larger than the maximum size limit enforced by this server.");
+        insta::assert_debug_snapshot!(err, @r###"
+        SizeLimitExceeded(
+            SizeLimitExceeded {
+                max_n_bytes: 100,
+                content_length: Some(
+                    1000,
+                ),
+            },
+        )
+        "###);
+    }
+}

--- a/libs/pavex_runtime/src/extract/body/errors.rs
+++ b/libs/pavex_runtime/src/extract/body/errors.rs
@@ -1,0 +1,112 @@
+//! Errors that can occur while extracting information from the request body.
+use crate::http::StatusCode;
+use crate::response::Response;
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+/// The error returned by [`JsonBody::extract`] when the extraction fails.
+///
+/// [`JsonBody::extract`]: crate::extract::body::json::JsonBody::extract
+pub enum ExtractJsonBodyError {
+    #[error(transparent)]
+    /// See [`MissingJsonContentType`] for details.
+    MissingContentType(#[from] MissingJsonContentType),
+    #[error(transparent)]
+    /// See [`JsonContentTypeMismatch`] for details.
+    ContentTypeMismatch(#[from] JsonContentTypeMismatch),
+    #[error(transparent)]
+    // TODO: should we use an opaque `JsonDeserializationError` instead?
+    DeserializationError(#[from] serde_json::Error),
+}
+
+impl ExtractJsonBodyError {
+    /// Convert an [`ExtractJsonBodyError`] into an HTTP response.
+    pub fn into_response(&self) -> Response<String> {
+        match self {
+            ExtractJsonBodyError::MissingContentType(_)
+            | ExtractJsonBodyError::ContentTypeMismatch(_) => Response::builder()
+                .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
+                .body(format!("{}", self))
+                .unwrap(),
+            ExtractJsonBodyError::DeserializationError(e) => Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(format!("Invalid JSON.\n{}", e))
+                .unwrap(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+/// The error returned by [`BufferedBody::extract`] when the extraction fails.
+///
+/// [`BufferedBody::extract`]: crate::extract::body::buffered_body::BufferedBody::extract
+pub enum ExtractBufferedBodyError {
+    #[error(transparent)]
+    /// See [`SizeLimitExceeded`] for details.
+    SizeLimitExceeded(#[from] SizeLimitExceeded),
+    #[error(transparent)]
+    /// See [`UnexpectedBufferError`] for details.
+    UnexpectedBufferError(#[from] UnexpectedBufferError),
+}
+
+impl ExtractBufferedBodyError {
+    /// Convert an [`ExtractBufferedBodyError`] into an HTTP response.
+    pub fn into_response(&self) -> Response<String> {
+        match self {
+            ExtractBufferedBodyError::SizeLimitExceeded(_) => Response::builder()
+                .status(StatusCode::PAYLOAD_TOO_LARGE)
+                .body(format!("{}", self))
+                .unwrap(),
+            ExtractBufferedBodyError::UnexpectedBufferError(_) => Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(format!("{}", self))
+                .unwrap(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("The request body is larger than the maximum size limit enforced by this server.")]
+#[non_exhaustive]
+/// The request body is larger than the maximum size limit enforced by this server.
+pub struct SizeLimitExceeded {
+    /// The maximum size limit enforced by this server.
+    pub max_n_bytes: usize,
+    /// The value of the `Content-Length` header for the request that breached the body
+    /// size limit.  
+    ///
+    /// It's set to `None` if the `Content-Length` header was missing or invalid.  
+    /// If it's set to `Some(n)` and `n` is smaller than `max_n_bytes`, then the request
+    /// lied about the size of its body in the `Content-Length` header.
+    pub content_length: Option<usize>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Something went wrong while reading the request body.")]
+#[non_exhaustive]
+/// Something went wrong while reading the request body, but we don't know what specifically.
+pub struct UnexpectedBufferError {
+    #[source]
+    pub(super) source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "The `Content-Type` header is missing. This endpoint expects requests with a `Content-Type` header set to `application/json`, or another `application/*+json` MIME type"
+)]
+#[non_exhaustive]
+/// The `Content-Type` header is missing, while we expected it to be set to `application/json`, or
+/// another `application/*+json` MIME type.
+pub struct MissingJsonContentType;
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "The `Content-Type` header was set to `{actual}`. This endpoint expects requests with a `Content-Type` header set to `application/json`, or another `application/*+json` MIME type"
+)]
+#[non_exhaustive]
+/// The `Content-Type` header not set to `application/json`, or another `application/*+json` MIME type.
+pub struct JsonContentTypeMismatch {
+    /// The actual value of the `Content-Type` header for this request.
+    pub actual: String,
+}

--- a/libs/pavex_runtime/src/extract/body/json.rs
+++ b/libs/pavex_runtime/src/extract/body/json.rs
@@ -1,0 +1,252 @@
+use http::HeaderMap;
+use serde::Deserialize;
+
+use crate::request::RequestHead;
+
+use super::{
+    buffered_body::BufferedBody,
+    errors::{ExtractJsonBodyError, JsonContentTypeMismatch, MissingJsonContentType},
+};
+
+#[doc(alias = "Json")]
+/// Parse the body of an incoming request as JSON.
+///
+/// # Sections
+///
+/// - [Example](#example)
+/// - [Installation](#installtion)
+/// - [Avoiding allocations](#avoiding-allocations)
+/// - [Body size limit](#body-size-limit)
+///
+/// # Example
+///
+/// ```rust
+/// use pavex_runtime::extract::body::JsonBody;
+///
+/// // You must derive `serde::Deserialize` for the type you want to extract,
+/// // in this case `HomeListing`.
+/// #[derive(serde::Deserialize)]
+/// pub struct HomeListing {
+///     address: String,
+///     price: u64,
+/// }
+///
+/// // The `Json` extractor deserializes the request body into
+/// // the type you specified—`HomeListing` in this case.
+/// pub fn get_home(body: &JsonBody<HomeListing>) -> String {
+///     format!(
+///         "The home you want to sell for {} is located at {}",
+///         body.0.price,
+///         body.0.address
+///     )
+/// }
+/// ```
+///
+/// # Installation
+///
+/// First of all, you need the register the default constructor and error handler for
+/// `JsonBody` in your `Blueprint`:
+///
+/// ```rust
+/// use pavex_builder::{f, Blueprint, constructor::Lifecycle};
+///
+/// fn blueprint() -> Blueprint {
+///    let mut bp = Blueprint::new();
+///    // Register the default constructor and error handler for `JsonBody`.
+///    bp.constructor(
+///         f!(pavex_runtime::extract::body::JsonBody::extract),
+///         Lifecycle::RequestScoped,
+///     ).error_handler(
+///         f!(pavex_runtime::extract::body::errors::ExtractJsonBodyError::into_response)
+///     );
+///     // [...]
+///     bp
+/// }
+/// ```
+///
+/// You can then use the `JsonBody` extractor as input to your route handlers and constructors.
+///
+/// # Avoiding allocations
+///
+/// If you want to minimize memory usage, you can try to avoid unnecessary memory allocations when
+/// deserializing string-like fields from the body of the incoming request.    
+/// Pavex supports this use case—you can borrow from the request body instead of having to
+/// allocate a brand new string.
+///
+/// It is not always possible to avoid allocations, though.  
+/// In particular, Pavex *must* allocate a new `String` if the JSON string you are trying to
+/// deserialize contains escape sequences, such as `\n` or `\"`.
+/// Using a `&str` in this case would result in a runtime error when attempting the deserialization.
+///
+/// Given the above, we recommend using `Cow<'_, str>` as field type: it borrows from the request
+/// body if possible, and allocates a new `String` only if strictly necessary.
+///
+/// ```rust
+/// use pavex_runtime::extract::body::JsonBody;
+/// use std::borrow::Cow;
+///
+/// #[derive(serde::Deserialize)]
+/// pub struct Payee<'a> {
+///     name: Cow<'a, str>,
+/// }
+///
+/// pub fn get_payee(body: &JsonBody<Payee<'_>>) -> String {
+///    format!("The payee's name is {}", body.0.name)
+/// }
+/// ```
+///
+/// # Body size limit
+///
+/// The `JsonBody` extractor buffers the entire body in memory before
+/// attempting to deserialize it.  
+///
+/// To prevent denial-of-service attacks, Pavex enforces an upper limit on the body size.    
+/// The limit is enforced by the [`BufferedBody`] extractor,
+/// which is injected as one of the inputs of [`JsonBody::extract`]. Check out [`BufferedBody`]'s
+/// documentation for more details on the size limit (and how to configure it).
+///
+/// [`BufferedBody`]: super::buffered_body::BufferedBody
+pub struct JsonBody<T>(pub T);
+
+impl<T> JsonBody<T> {
+    /// The default constructor for [`JsonBody`].
+    ///
+    /// The extraction can fail for a number of reasons:
+    ///
+    /// - the `Content-Type` is missing
+    /// - the `Content-Type` header is not set to `application/json` or another `application/*+json` MIME type
+    /// - the request body is not a valid JSON document
+    ///
+    /// In all of the above cases, an [`ExtractJsonBodyError`] is returned.
+    // # Implementation notes
+    //
+    // We are using two separate lifetimes here to make it clear to the compiler
+    // that `JsonBody` doesn't borrow from `RequestHead`.
+    pub fn extract<'head, 'body>(
+        request_head: &'head RequestHead,
+        buffered_body: &'body BufferedBody,
+    ) -> Result<Self, ExtractJsonBodyError>
+    where
+        T: Deserialize<'body>,
+    {
+        check_json_content_type(&request_head.headers)?;
+        // TODO: improve error message if deserialization fails here.
+        let body = serde_json::from_slice(&buffered_body.bytes)?;
+        Ok(JsonBody(body))
+    }
+}
+
+/// Check that the `Content-Type` header is set to `application/json`, or another
+/// `application/*+json` MIME type.
+///
+/// Return an error otherwise.
+fn check_json_content_type(headers: &HeaderMap) -> Result<(), ExtractJsonBodyError> {
+    let Some(content_type) = headers.get(http::header::CONTENT_TYPE) else {
+        return Err(MissingJsonContentType.into());
+    };
+    let Ok(content_type) = content_type.to_str() else {
+        return Err(MissingJsonContentType.into());
+    };
+
+    let Ok(mime) = content_type.parse::<mime::Mime>() else {
+        return Err(JsonContentTypeMismatch {
+            actual: content_type.to_string(),
+        }.into());
+    };
+
+    let is_json_content_type = mime.type_() == "application"
+        && (mime.subtype() == "json" || mime.suffix().map_or(false, |name| name == "json"));
+    if !is_json_content_type {
+        return Err(JsonContentTypeMismatch {
+            actual: content_type.to_string(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn missing_content_type() {
+        let headers = http::HeaderMap::new();
+        let err = super::check_json_content_type(&headers).unwrap_err();
+        insta::assert_display_snapshot!(err, @"The `Content-Type` header is missing. This endpoint expects requests with a `Content-Type` header set to `application/json`, or another `application/*+json` MIME type");
+        insta::assert_debug_snapshot!(err, @r###"
+        MissingContentType(
+            MissingJsonContentType,
+        )
+        "###);
+    }
+
+    #[test]
+    fn content_type_is_not_valid_mime() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::CONTENT_TYPE, "hello world".parse().unwrap());
+
+        let err = super::check_json_content_type(&headers).unwrap_err();
+        insta::assert_display_snapshot!(err, @"The `Content-Type` header was set to `hello world`. This endpoint expects requests with a `Content-Type` header set to `application/json`, or another `application/*+json` MIME type");
+        insta::assert_debug_snapshot!(err, @r###"
+        ContentTypeMismatch(
+            JsonContentTypeMismatch {
+                actual: "hello world",
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn content_type_is_not_json() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/xml".parse().unwrap(),
+        );
+
+        let err = super::check_json_content_type(&headers).unwrap_err();
+        insta::assert_display_snapshot!(err, @"The `Content-Type` header was set to `application/xml`. This endpoint expects requests with a `Content-Type` header set to `application/json`, or another `application/*+json` MIME type");
+        insta::assert_debug_snapshot!(err, @r###"
+        ContentTypeMismatch(
+            JsonContentTypeMismatch {
+                actual: "application/xml",
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn content_type_is_json() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        );
+
+        let outcome = super::check_json_content_type(&headers);
+        assert!(outcome.is_ok());
+    }
+
+    #[test]
+    fn content_type_has_json_suffix() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/hal+json".parse().unwrap(),
+        );
+
+        let outcome = super::check_json_content_type(&headers);
+        assert!(outcome.is_ok());
+    }
+
+    #[test]
+    fn json_content_type_with_charset() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/json; charset=utf-8".parse().unwrap(),
+        );
+
+        let outcome = super::check_json_content_type(&headers);
+        assert!(outcome.is_ok());
+    }
+}

--- a/libs/pavex_runtime/src/extract/body/limit.rs
+++ b/libs/pavex_runtime/src/extract/body/limit.rs
@@ -1,0 +1,21 @@
+#[derive(Debug, Clone, Copy)]
+/// An upper limit on the size of incoming request bodies.  
+/// 
+/// Check out the documentation of [`BufferedBody`](crate::extract::body::BufferedBody) for more details.
+pub enum BodySizeLimit {
+    /// There is an active limit on the size of incoming request bodies.
+    Enabled {
+        /// The maximum size of incoming request bodies, in bytes.
+        max_n_bytes: usize,
+    },
+    /// There is no limit on the size of incoming request bodies.
+    Disabled,
+}
+
+impl Default for BodySizeLimit {
+    fn default() -> Self {
+        Self::Enabled {
+            max_n_bytes: 2_097_152 // 2 MBs
+        }
+    }
+}

--- a/libs/pavex_runtime/src/extract/body/mod.rs
+++ b/libs/pavex_runtime/src/extract/body/mod.rs
@@ -1,0 +1,9 @@
+//! Extract data from the body of incoming requests.
+mod json;
+mod buffered_body;
+mod limit;
+pub mod errors;
+
+pub use buffered_body::BufferedBody;
+pub use json::JsonBody;
+pub use limit::BodySizeLimit;

--- a/libs/pavex_runtime/src/extract/mod.rs
+++ b/libs/pavex_runtime/src/extract/mod.rs
@@ -1,3 +1,4 @@
 //! Extract structured data from incoming HTTP requests.
 pub mod route;
 pub mod query;
+pub mod body;

--- a/libs/pavex_runtime/src/extract/route/raw_route_params.rs
+++ b/libs/pavex_runtime/src/extract/route/raw_route_params.rs
@@ -16,7 +16,7 @@ use matchit::{Params, ParamsIter};
 ///     bp
 /// }
 ///
-/// fn get_home(params: &RawRouteParams) -> String {
+/// pub fn get_home(params: &RawRouteParams) -> String {
 ///     let home_id = &params.get("home_id").unwrap();
 ///     let street_id = &params.get("street_id").unwrap();
 ///     format!("The home with id {} is in street {}", home_id, street_id)

--- a/libs/pavex_runtime/src/extract/route/route_params.rs
+++ b/libs/pavex_runtime/src/extract/route/route_params.rs
@@ -27,10 +27,10 @@ use super::RawRouteParams;
 ///     let mut bp = Blueprint::new();
 ///     // Register the default constructor and error handler for `RouteParams`.
 ///     bp.constructor(
-///         f!(pavex_runtime::extract::path::RouteParams::extract),
+///         f!(pavex_runtime::extract::route::RouteParams::extract),
 ///         Lifecycle::RequestScoped,
 ///     ).error_handler(
-///         f!(pavex_runtime::extract::path::errors::ExtractRouteParamsError::into_response)
+///         f!(pavex_runtime::extract::route::errors::ExtractRouteParamsError::into_response)
 ///     );
 ///     // Register a route with a route parameter, `:home_id`.
 ///     bp.route(GET, "/home/:home_id", f!(crate::get_home));
@@ -39,7 +39,7 @@ use super::RawRouteParams;
 ///
 /// // The RouteParams attribute macro derives the necessary (de)serialization traits.
 /// #[RouteParams]
-/// struct Home {
+/// pub struct Home {
 ///     // The name of the field must match the name of the route parameter
 ///     // used in `bp.route`.
 ///     home_id: u32
@@ -47,7 +47,7 @@ use super::RawRouteParams;
 ///
 /// // The `RouteParams` extractor deserializes the extracted route parameters into
 /// // the type you specified—`HomeRouteParams` in this case.
-/// fn get_home(params: &RouteParams<Home>) -> String {
+/// pub fn get_home(params: &RouteParams<Home>) -> String {
 ///    format!("The identifier for this home is: {}", params.0.home_id)
 /// }
 /// ```
@@ -76,7 +76,7 @@ use super::RawRouteParams;
 /// }
 ///
 /// #[RouteParams]
-/// struct Room {
+/// pub struct Room {
 ///     // The name of the extracted fields must match the names of the route parameters
 ///     // used in the template we passed to `bp.route`.
 ///     home_id: u32,
@@ -87,7 +87,7 @@ use super::RawRouteParams;
 ///
 /// // The `RouteParams` extractor will deserialize the route parameters into the
 /// // type you specified—`Room` in this case.
-/// fn get_room(params: &RouteParams<Room>) -> String {
+/// pub fn get_room(params: &RouteParams<Room>) -> String {
 ///     let params = &params.0;
 ///     format!("The home with id {} is in street {}", params.home_id, params.street_id)
 /// }
@@ -108,13 +108,13 @@ use super::RawRouteParams;
 /// // This is self-documenting ✅
 /// // No need to check the route's path template to understand what each field represents.
 /// #[RouteParams]
-/// struct Room {
+/// pub struct Room {
 ///     home_id: u32,
 ///     room_id: u32,
 ///     street_id: u32,
 /// }
 ///
-/// fn get_room(params: &RouteParams<Room>) -> String {
+/// pub fn get_room(params: &RouteParams<Room>) -> String {
 ///     // [...]
 /// # unimplemented!()
 /// }
@@ -122,7 +122,7 @@ use super::RawRouteParams;
 /// // This isn't self-documenting ❌
 /// // What does the second u32 represent? The room id? The street id?
 /// // Impossible to tell without checking the route's path template.
-/// fn get_room_tuple(params: &RouteParams<(u32, u32, u32)>) -> String {
+/// pub fn get_room_tuple(params: &RouteParams<(u32, u32, u32)>) -> String {
 ///     // [...]
 /// # unimplemented!()
 /// }
@@ -139,7 +139,7 @@ use super::RawRouteParams;
 ///
 /// # Additional compile-time checks
 ///
-///Pavex is able to perform additional checks at compile-time if you use the
+/// Pavex is able to perform additional checks at compile-time if you use the
 /// [`RouteParams`](macro@crate::extract::route::RouteParams) macro instead
 /// of deriving [`serde::Deserialize`] on your own.
 ///
@@ -149,7 +149,7 @@ use super::RawRouteParams;
 ///
 /// // Do this 👇
 /// #[RouteParams]
-/// struct Home {
+/// pub struct Home {
 ///     home_id: u32
 /// }
 /// # }
@@ -157,7 +157,7 @@ use super::RawRouteParams;
 /// # mod home2 {
 /// // ..instead of this ❌
 /// #[derive(serde::Deserialize)]
-/// struct Home {
+/// pub struct Home {
 ///     home_id: u32
 /// }
 /// # }
@@ -193,11 +193,11 @@ use super::RawRouteParams;
 /// use std::borrow::Cow;
 ///
 /// #[RouteParams]
-/// struct Payee<'a> {
+/// pub struct Payee<'a> {
 ///     name: Cow<'a, str>,
 /// }
 ///
-/// fn get_payee(params: &RouteParams<Payee<'_>>) -> String {
+/// pub fn get_payee(params: &RouteParams<Payee<'_>>) -> String {
 ///    format!("The payee's name is {}", params.0.name)
 /// }
 /// ```


### PR DESCRIPTION
In order to cover the remaining `/articles` routes in the Realworld spec, Pavex needs to be able to handle request bodies.

This PR adds:

- `BufferedBody`, an extractor that buffer the whole body of the incoming request in memory;
- `Json`, an extractor to deserialize a buffered body as JSON;
- `BodySizeLimits`, a configuration knob for `BufferedBody` that determines if there is a limit on the size of the body of incoming requests.

We ran into a few unrelated issues though:

- In order to override the limit on a per-request basis, the compiler must allow for constructors whose inputs are in a _child_ scope. At the moment, we require them to be in either the same scope or a parent scope;
- In order to server `POST /articlees` from a nested blueprint with an `/articles` prefix, we must allow users to register routes with an empty path, which is currently forbidden.

Both issues will be addressed in a follow-up PR.

Miscellaneous:
- Fix a typo in the trait checker that would result in `Copy` not being detected correctly for reference types.
- Make handlers and constructors public in examples.