### PR TITLE
Improve deserialization errors for the JsonBody extractor.

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
+ "serde_path_to_error",
  "thiserror",
  "tokio",
 ]
@@ -1538,6 +1539,15 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
  "serde",
 ]
 

--- a/libs/pavex_runtime/Cargo.toml
+++ b/libs/pavex_runtime/Cargo.toml
@@ -24,6 +24,7 @@ serde_html_form = "0.1"
 
 # Json body extractor
 serde_json = "1"
+serde_path_to_error = "0.1"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/libs/pavex_runtime/src/extract/body/buffered_body.rs
+++ b/libs/pavex_runtime/src/extract/body/buffered_body.rs
@@ -117,7 +117,7 @@ use hyper::body::to_bytes;
 /// You can leverage nesting for this purpose:
 /// 
 /// ```rust
-/// use pavex_builder::{f, Blueprint, constructor::Lifecycle};
+/// use pavex_builder::{f, Blueprint, constructor::Lifecycle, router::{GET, POST}};
 /// use pavex_runtime::extract::body::BodySizeLimit;
 /// # pub fn home() -> String { todo!() }
 /// # pub fn upload() -> String { todo!() }


### PR DESCRIPTION
Using `serde_path_to_error` will give us better error messages.

I've added a snapshot test to check the error out, as well as fixing a broken doc test that slipped through the cracks.
