### PR TITLE
Use a pool of target directories for UI tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,12 @@ You are more than free to play around with the code though! The instructions bel
 - Rust's stable toolchain (`rustup toolchain install stable`);
 - Rust's nightly toolchain (`rustup toolchain install nightly`);
 - `sscache` (see [here](https://github.com/mozilla/sccache#installation) for installation instructions)
-- `cargo-nextest` (see [here](https://nexte.st/book/installation.html) for installation instructions)
 - `cargo-px` (`cargo install --locked cargo-px`)
 
 # Running tests
 
 ```bash
-cargo nextest run
+cargo test 
 ```
 
 We primarily rely on end-to-end testing to check that Pavex's behaviour meets our expectations.  

--- a/examples/realworld/Cargo.lock
+++ b/examples/realworld/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
+ "serde_path_to_error",
  "thiserror",
 ]
 
@@ -1524,6 +1525,15 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
  "serde",
 ]
 

--- a/examples/skeleton/Cargo.lock
+++ b/examples/skeleton/Cargo.lock
@@ -331,6 +331,8 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_html_form",
+ "serde_json",
+ "serde_path_to_error",
  "thiserror",
 ]
 
@@ -417,6 +419,26 @@ dependencies = [
  "indexmap",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
  "serde",
 ]
 

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
@@ -183,6 +192,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -570,6 +589,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick 0.7.20",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "guppy"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +770,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +808,15 @@ dependencies = [
  "linked-hash-map",
  "similar",
  "yaml-rust",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1002,6 +1071,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object-pool"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9a3e7196d09ec86002b939f1576e8e446d58def8fd48fe578e2c72d5328d68"
+dependencies = [
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,12 +1099,37 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1193,9 +1296,12 @@ dependencies = [
  "anyhow",
  "console",
  "fs-err",
+ "globwalk",
  "itertools",
  "libtest-mimic",
  "miette",
+ "num_cpus",
+ "object-pool",
  "persist_if_changed",
  "serde",
  "serde_json",
@@ -1291,7 +1397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.12.1",
  "scheduled-thread-pool",
 ]
 
@@ -1373,7 +1479,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.1",
  "memchr",
  "regex-syntax 0.7.2",
 ]
@@ -1480,7 +1586,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["./pavex*", "persist_if_changed"]
+resolver = "2"

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nest_at_prefix_is_validated/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nest_at_prefix_is_validated/expectations/stderr.txt
@@ -1,17 +1,4 @@
 [31m[1mERROR[0m[39m: 
-  [31m×[0m The path prefix passed to `nest_at` cannot be empty.
-  [31m│[0m
-  [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:7:1]
-  [31m│[0m  [2m7[0m │     // Empty prefix
-  [31m│[0m  [2m8[0m │     bp.nest_at("", sub_blueprint());
-  [31m│[0m    · [35;1m               ─┬[0m
-  [31m│[0m    ·                 [35;1m╰── [35;1mThe empty prefix[0m[0m
-  [31m│[0m  [2m9[0m │     // Prefix does not start with a `/`
-  [31m│[0m    ╰────
-  [31m│[0m [36m  help: [0mIf you don't want to add a common prefix to all routes in the nested
-  [31m│[0m         blueprint, use the `nest` method instead of `nest_at`.
-
-[31m[1mERROR[0m[39m: 
   [31m×[0m The path prefix passed to `nest_at` must begin with a forward slash, `/`.
   [31m│[0m `api` doesn't.
   [31m│[0m
@@ -24,3 +11,16 @@
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAdd a '/' at the beginning of the path prefix to fix this error: use
   [31m│[0m         `/api` instead of `api`.
+
+[31m[1mERROR[0m[39m: 
+  [31m×[0m The path prefix passed to `nest_at` cannot be empty.
+  [31m│[0m
+  [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:7:1]
+  [31m│[0m  [2m7[0m │     // Empty prefix
+  [31m│[0m  [2m8[0m │     bp.nest_at("", sub_blueprint());
+  [31m│[0m    · [35;1m               ─┬[0m
+  [31m│[0m    ·                 [35;1m╰── [35;1mThe empty prefix[0m[0m
+  [31m│[0m  [2m9[0m │     // Prefix does not start with a `/`
+  [31m│[0m    ╰────
+  [31m│[0m [36m  help: [0mIf you don't want to add a common prefix to all routes in the nested
+  [31m│[0m         blueprint, use the `nest` method instead of `nest_at`.

--- a/libs/pavex_test_runner/Cargo.toml
+++ b/libs/pavex_test_runner/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1"
 itertools = "0.10"
 sha2 = "0.10.6"
 persist_if_changed = { path = "../persist_if_changed" }
+object-pool = "0.5"
+num_cpus = "1"
+globwalk = "0.8.0"

--- a/libs/pavex_test_runner/src/lib.rs
+++ b/libs/pavex_test_runner/src/lib.rs
@@ -377,11 +377,15 @@ impl TestData {
             toml::to_string(&cargo_toml)?.as_bytes(),
         )?;
 
-        // Use sccache to avoid rebuilding the same dependencies
+        // - Use sccache to avoid rebuilding the same dependencies
         // over and over again.
+        // - Use the new sparse registry to speed up registry operations.
         let cargo_config = toml! {
             [build]
             rustc-wrapper = "sccache"
+
+            [registries.crates-io]
+            protocol = "sparse"
         };
         let dot_cargo_folder = self.runtime_directory.join(".cargo");
         fs_err::create_dir_all(&dot_cargo_folder)?;

--- a/libs/pavex_test_runner/src/target_directory.rs
+++ b/libs/pavex_test_runner/src/target_directory.rs
@@ -1,0 +1,62 @@
+//! Assigning a distinct target directory to each test case doesn't scale.
+//! Those directories are big and can easily fill up your disk (and they
+//! have started to do so once the number of tests grew to 50+).
+//!
+//! This module provides functionality to re-use target directories across
+//! different test cases.
+//! We create N target directories, where N is the number of cores on the
+//! machine. Each test case is assigned a target directory from this pool
+//! once it kicks off.
+//! Since the test runner doesn't execute more than N  test cases in
+//! parallel, this approach guarantees that test cases don't have to wait
+//! to be assigned a target directory (i.e. we still get maximum parallelism).
+//!
+//! We can't reuse the same target directory for all tests since each test
+//! needs to acquire a unique lock on the target directory in order to
+//! execute `cargo` commands. Having a single target directory would
+//! serialize all tests, which would be a huge performance hit.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use object_pool::Reusable;
+
+#[derive(Clone)]
+pub struct TargetDirectoryPool {
+    directories: Arc<object_pool::Pool<PathBuf>>,
+}
+
+impl TargetDirectoryPool {
+    pub fn new(size: Option<usize>, test_env_dir: &Path) -> Self {
+        let size = size.unwrap_or_else(|| num_cpus::get());
+        // The function signature here is awkward because it doesn't allow us to
+        // borrow from the environment in the closure, which in turns means we can't guarantee deterministic names for the target directories.
+        // We work around the issue by attaching objects to the pool manually
+        let directories = object_pool::Pool::new(0, || {
+            panic!("Target directories should never be initialized via the init closure")
+        });
+        for i in 0..size {
+            directories.attach(create_target_directory(test_env_dir, i));
+        }
+        Self {
+            directories: Arc::new(directories),
+        }
+    }
+
+    /// Pull a target directory from the pool.
+    pub fn pull(&self) -> Reusable<'_, PathBuf> {
+        self.directories
+            .try_pull()
+            .expect("Failed to pull a target directory from the pool")
+    }
+}
+
+fn create_target_directory(test_env_dir: &Path, i: usize) -> PathBuf {
+    let target_dir_path = test_env_dir
+        .join("target_dirs")
+        .join(format!("target_{:0>2}", i));
+    fs_err::create_dir_all(&target_dir_path).expect("Failed to create target directory");
+    target_dir_path
+}


### PR DESCRIPTION
Each UI test is its own `cargo` project with its own target directory.
This has now become a problem since there are ~70 UI tests and my laptop is running out of space.

We introduce a pool of target directories and assign them dynamically to each test case when they are run. This ensures that we have an upper limit on the disk usage without compromising on test parallelism.