### PR TITLE
Fix path rules.

### DIFF
--- a/examples/realworld/Cargo.toml
+++ b/examples/realworld/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["api_server", "api_server_sdk", "conduit_core"]
+resolver = "2"

--- a/examples/skeleton/Cargo.toml
+++ b/examples/skeleton/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["app_blueprint", "app_server_sdk"]
+resolver = "2"

--- a/examples/skeleton/app_server_sdk/src/lib.rs
+++ b/examples/skeleton/app_server_sdk/src/lib.rs
@@ -10,7 +10,9 @@ struct ServerState {
 pub struct ApplicationState {
     s0: app_blueprint::HttpClient,
 }
-pub async fn build_application_state(v0: app_blueprint::Config) -> crate::ApplicationState {
+pub async fn build_application_state(
+    v0: app_blueprint::Config,
+) -> crate::ApplicationState {
     let v1 = app_blueprint::http_client(v0);
     crate::ApplicationState { s0: v1 }
 }
@@ -27,25 +29,28 @@ pub async fn run(
     let make_service = pavex_runtime::hyper::service::make_service_fn(move |_| {
         let server_state = server_state.clone();
         async move {
-            Ok::<_, pavex_runtime::hyper::Error>(pavex_runtime::hyper::service::service_fn(
-                move |request| {
+            Ok::<
+                _,
+                pavex_runtime::hyper::Error,
+            >(
+                pavex_runtime::hyper::service::service_fn(move |request| {
                     let server_state = server_state.clone();
                     async move {
-                        Ok::<_, pavex_runtime::hyper::Error>(
-                            route_request(request, server_state).await,
-                        )
+                        Ok::<
+                            _,
+                            pavex_runtime::hyper::Error,
+                        >(route_request(request, server_state).await)
                     }
-                },
-            ))
+                }),
+            )
         }
     });
-    server_builder
-        .serve(make_service)
-        .await
-        .map_err(pavex_runtime::Error::new)
+    server_builder.serve(make_service).await.map_err(pavex_runtime::Error::new)
 }
-fn build_router() -> Result<pavex_runtime::routing::Router<u32>, pavex_runtime::routing::InsertError>
-{
+fn build_router() -> Result<
+    pavex_runtime::routing::Router<u32>,
+    pavex_runtime::routing::InsertError,
+> {
     let mut router = pavex_runtime::routing::Router::new();
     router.insert("/home", 0u32)?;
     Ok(router)
@@ -68,29 +73,42 @@ async fn route_request(
     };
     let route_id = matched_route.value;
     #[allow(unused)]
-    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> =
-        matched_route.params.into();
+    let url_params: pavex_runtime::extract::route::RawRouteParams<'_, '_> = matched_route
+        .params
+        .into();
     match route_id {
-        0u32 => match &request_head.method {
-            &pavex_runtime::http::Method::GET => {
-                route_handler_0(server_state.application_state.s0.clone(), &request_head).await
+        0u32 => {
+            match &request_head.method {
+                &pavex_runtime::http::Method::GET => {
+                    route_handler_0(
+                            server_state.application_state.s0.clone(),
+                            &request_head,
+                        )
+                        .await
+                }
+                _ => {
+                    pavex_runtime::response::Response::builder()
+                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                        .header(pavex_runtime::http::header::ALLOW, "GET")
+                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+                        .unwrap()
+                }
             }
-            _ => pavex_runtime::response::Response::builder()
-                .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
-                .header(pavex_runtime::http::header::ALLOW, "GET")
+        }
+        _ => {
+            pavex_runtime::response::Response::builder()
+                .status(pavex_runtime::http::StatusCode::NOT_FOUND)
                 .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
-                .unwrap(),
-        },
-        _ => pavex_runtime::response::Response::builder()
-            .status(pavex_runtime::http::StatusCode::NOT_FOUND)
-            .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
-            .unwrap(),
+                .unwrap()
+        }
     }
 }
 pub async fn route_handler_0(
     v0: app_blueprint::HttpClient,
     v1: &pavex_runtime::request::RequestHead,
-) -> http::Response<http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>> {
+) -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
     let v2 = app_blueprint::extract_path(v1);
     let v4 = {
         let v3 = app_blueprint::logger();

--- a/libs/pavex_builder/src/blueprint.rs
+++ b/libs/pavex_builder/src/blueprint.rs
@@ -257,6 +257,32 @@ impl Blueprint {
     /// `prefix` will be prepended to all the routes coming from the nested blueprint.  
     /// `prefix` must be non-empty and it must start with a `/`.  
     /// If you don't want to add a common prefix, check out [`Blueprint::nest`].
+    /// 
+    /// ## Trailing slashes
+    /// 
+    /// `prefix` **can't** end with a trailing `/`.  
+    /// This would result in routes with two consecutive `/` in their paths—e.g. 
+    /// `/prefix//path`—which is rarely desirable.  
+    /// If you actually need consecutive slashes in your route, you can add them explicitly to 
+    /// the path of the route registered in the nested blueprint:
+    /// 
+    /// ```rust
+    /// use pavex_builder::{Blueprint, f, router::GET};
+    /// 
+    /// fn app() -> Blueprint {
+    ///     let mut bp = Blueprint::new();
+    ///     bp.nest_at("/api", api_bp());
+    ///     bp
+    /// }
+    /// 
+    /// fn api_bp() -> Blueprint {
+    ///     let mut bp = Blueprint::new();
+    ///     // This will match `GET` requests to `/api//path`.
+    ///     bp.route(GET, "//path", f!(crate::handler));
+    ///     bp
+    /// }
+    /// # pub fn handler() {}
+    /// ```
     ///
     /// # Constructors
     ///

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nest_at_prefix_is_validated/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nest_at_prefix_is_validated/expectations/stderr.txt
@@ -1,13 +1,32 @@
 [31m[1mERROR[0m[39m: 
+  [31m×[0m The path prefix passed to `nest_at` can't end with a trailing slash, `/`.
+  [31m│[0m `/api/` does.
+  [31m│[0m Trailing slashes in path prefixes increase the likelihood of having
+  [31m│[0m consecutive slashes in the final route path, which is rarely desireable.
+  [31m│[0m If you want consecutive slashes in the final route path, you can add
+  [31m│[0m them explicitly in the paths of the routes registered against the nested
+  [31m│[0m blueprint.
+  [31m│[0m
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:11:1]
+  [31m│[0m  [2m11[0m │     // If the prefix is not empty, it **cannot** end with a `/`
+  [31m│[0m  [2m12[0m │     bp.nest_at("/api/", sub_blueprint());
+  [31m│[0m     · [35;1m               ───┬───[0m
+  [31m│[0m     ·                   [35;1m╰── [35;1mThe prefix ending with a trailing '/'[0m[0m
+  [31m│[0m  [2m13[0m │     bp
+  [31m│[0m     ╰────
+  [31m│[0m [36m  help: [0mRemove the '/' at the end of the path prefix to fix this error: use
+  [31m│[0m         `/api` instead of `/api/`.
+
+[31m[1mERROR[0m[39m: 
   [31m×[0m The path prefix passed to `nest_at` must begin with a forward slash, `/`.
   [31m│[0m `api` doesn't.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:9:1]
-  [31m│[0m  [2m 9[0m │     // Prefix does not start with a `/`
+  [31m│[0m  [2m 9[0m │     // If the prefix is not empty, it **must** start with a `/`
   [31m│[0m  [2m10[0m │     bp.nest_at("api", sub_blueprint());
   [31m│[0m     · [35;1m               ──┬──[0m
   [31m│[0m     ·                  [35;1m╰── [35;1mThe prefix missing a leading '/'[0m[0m
-  [31m│[0m  [2m11[0m │     bp
+  [31m│[0m  [2m11[0m │     // If the prefix is not empty, it **cannot** end with a `/`
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAdd a '/' at the beginning of the path prefix to fix this error: use
   [31m│[0m         `/api` instead of `api`.
@@ -16,11 +35,11 @@
   [31m×[0m The path prefix passed to `nest_at` cannot be empty.
   [31m│[0m
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:7:1]
-  [31m│[0m  [2m7[0m │     // Empty prefix
+  [31m│[0m  [2m7[0m │     // The prefix cannot be empty
   [31m│[0m  [2m8[0m │     bp.nest_at("", sub_blueprint());
   [31m│[0m    · [35;1m               ─┬[0m
   [31m│[0m    ·                 [35;1m╰── [35;1mThe empty prefix[0m[0m
-  [31m│[0m  [2m9[0m │     // Prefix does not start with a `/`
+  [31m│[0m  [2m9[0m │     // If the prefix is not empty, it **must** start with a `/`
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mIf you don't want to add a common prefix to all routes in the nested
   [31m│[0m         blueprint, use the `nest` method instead of `nest_at`.

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nest_at_prefix_is_validated/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nest_at_prefix_is_validated/lib.rs
@@ -4,10 +4,12 @@ use pavex_builder::{constructor::Lifecycle, f, router::GET, Blueprint};
 
 pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
-    // Empty prefix
+    // The prefix cannot be empty
     bp.nest_at("", sub_blueprint());
-    // Prefix does not start with a `/`
+    // If the prefix is not empty, it **must** start with a `/`
     bp.nest_at("api", sub_blueprint());
+    // If the prefix is not empty, it **cannot** end with a `/`
+    bp.nest_at("/api/", sub_blueprint());
     bp
 }
 

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/route_path_is_validated/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/route_path_is_validated/expectations/stderr.txt
@@ -1,22 +1,9 @@
 [31m[1mERROR[0m[39m: 
-  [31m×[0m The path for a route cannot be empty.
-  [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:9:1]
-  [31m│[0m  [2m 9[0m │     // Empty path
-  [31m│[0m  [2m10[0m │     bp.route(GET, "", f!(crate::handler));
-  [31m│[0m     · [35;1m                  ─┬[0m
-  [31m│[0m     ·                    [35;1m╰── [35;1mThe empty route path[0m[0m
-  [31m│[0m  [2m11[0m │     // Path does not start with a `/`
-  [31m│[0m     ╰────
-  [31m│[0m [36m  help: [0mIf you want to match requests to the base URL, use `/` as route path
-  [31m│[0m         instead of an empty one.
-
-[31m[1mERROR[0m[39m: 
   [31m×[0m All route paths must begin with a forward slash, `/`.
   [31m│[0m `api` doesn't.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:11:1]
-  [31m│[0m  [2m11[0m │     // Path does not start with a `/`
+  [31m│[0m  [2m11[0m │     // If the path is not empty, it *must* start with a `/`
   [31m│[0m  [2m12[0m │     bp.route(GET, "api", f!(crate::handler));
   [31m│[0m     · [35;1m                  ──┬──[0m
   [31m│[0m     ·                     [35;1m╰── [35;1mThe path missing a leading '/'[0m[0m

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/route_path_is_validated/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/route_path_is_validated/lib.rs
@@ -6,9 +6,9 @@ pub fn handler() -> String {
 
 pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
-    // Empty path
+    // Empty path is accepted
     bp.route(GET, "", f!(crate::handler));
-    // Path does not start with a `/`
+    // If the path is not empty, it *must* start with a `/`
     bp.route(GET, "api", f!(crate::handler));
     bp
 }


### PR DESCRIPTION
This PR tweaks the constraints on path and path prefixes:

- It now allows empty paths, which is required in order to serve the base URL (without a trailing slash). It also unblocks serving `GET /articles` from the a nested blueprint with prefix `/articles` in the Realworld example;
- We add a new restriction on path prefixes, enforcing that they don't end with a trailing slash. This ensures that consecutive slashes in paths are (mostly) intentional.