### PR TITLE
Missing routes for Realworld

### DIFF
--- a/examples/realworld/Cargo.lock
+++ b/examples/realworld/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
  "pavex_builder",
  "pavex_cli_client",
  "pavex_runtime",
+ "secrecy",
  "serde",
  "serde_json",
  "sqlx",
@@ -1482,6 +1483,16 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/examples/realworld/api_server_sdk/blueprint.ron
+++ b/examples/realworld/api_server_sdk/blueprint.ron
@@ -1,6 +1,6 @@
 (
     creation_location: (
-        line: 9,
+        line: 12,
         column: 18,
         file: "conduit_core/src/api/mod.rs",
     ),
@@ -12,7 +12,7 @@
                     import_path: "pavex_runtime::extract::query::QueryParams::extract",
                 ),
                 location: (
-                    line: 19,
+                    line: 25,
                     column: 8,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -25,7 +25,7 @@
                     import_path: "pavex_runtime::extract::query::errors::ExtractQueryParamsError::into_response",
                 ),
                 location: (
-                    line: 23,
+                    line: 29,
                     column: 6,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -38,7 +38,7 @@
                     import_path: "pavex_runtime::extract::route::RouteParams::extract",
                 ),
                 location: (
-                    line: 28,
+                    line: 34,
                     column: 8,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -51,7 +51,7 @@
                     import_path: "pavex_runtime::extract::route::errors::ExtractRouteParamsError::into_response",
                 ),
                 location: (
-                    line: 32,
+                    line: 38,
                     column: 6,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -64,7 +64,7 @@
                     import_path: "pavex_runtime::extract::body::JsonBody::extract",
                 ),
                 location: (
-                    line: 37,
+                    line: 43,
                     column: 8,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -77,7 +77,7 @@
                     import_path: "pavex_runtime::extract::body::errors::ExtractJsonBodyError::into_response",
                 ),
                 location: (
-                    line: 41,
+                    line: 47,
                     column: 6,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -90,7 +90,7 @@
                     import_path: "pavex_runtime::extract::body::BufferedBody::extract",
                 ),
                 location: (
-                    line: 44,
+                    line: 50,
                     column: 8,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -103,7 +103,7 @@
                     import_path: "pavex_runtime::extract::body::errors::ExtractBufferedBodyError::into_response",
                 ),
                 location: (
-                    line: 48,
+                    line: 54,
                     column: 6,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -116,7 +116,7 @@
                     import_path: "<pavex_runtime::extract::body::BodySizeLimit as\n    std::default::Default>::default",
                 ),
                 location: (
-                    line: 51,
+                    line: 57,
                     column: 8,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -140,7 +140,27 @@
                     import_path: "crate::api::status::ping",
                 ),
                 location: (
-                    line: 11,
+                    line: 17,
+                    column: 8,
+                    file: "conduit_core/src/api/mod.rs",
+                ),
+            ),
+            error_handler: None,
+        ),
+        (
+            path: "/tags",
+            method_guard: (
+                allowed_methods: [
+                    "GET",
+                ],
+            ),
+            request_handler: (
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "crate::api::tags::get_tags",
+                ),
+                location: (
+                    line: 18,
                     column: 8,
                     file: "conduit_core/src/api/mod.rs",
                 ),
@@ -383,7 +403,185 @@
             ),
             path_prefix: Some("/articles"),
             nesting_location: (
-                line: 12,
+                line: 14,
+                column: 8,
+                file: "conduit_core/src/api/mod.rs",
+            ),
+        ),
+        (
+            blueprint: (
+                creation_location: (
+                    line: 5,
+                    column: 18,
+                    file: "conduit_core/src/api/profiles/mod.rs",
+                ),
+                constructors: [],
+                routes: [
+                    (
+                        path: "/:username",
+                        method_guard: (
+                            allowed_methods: [
+                                "GET",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate::api::profiles::get_user",
+                            ),
+                            location: (
+                                line: 6,
+                                column: 8,
+                                file: "conduit_core/src/api/profiles/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/:username/follow",
+                        method_guard: (
+                            allowed_methods: [
+                                "POST",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate::api::profiles::follow_user",
+                            ),
+                            location: (
+                                line: 7,
+                                column: 8,
+                                file: "conduit_core/src/api/profiles/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/:username/follow",
+                        method_guard: (
+                            allowed_methods: [
+                                "DELETE",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate::api::profiles::unfollow_user",
+                            ),
+                            location: (
+                                line: 8,
+                                column: 8,
+                                file: "conduit_core/src/api/profiles/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                ],
+                nested_blueprints: [],
+            ),
+            path_prefix: Some("/profiles"),
+            nesting_location: (
+                line: 15,
+                column: 8,
+                file: "conduit_core/src/api/mod.rs",
+            ),
+        ),
+        (
+            blueprint: (
+                creation_location: (
+                    line: 5,
+                    column: 18,
+                    file: "conduit_core/src/api/users/mod.rs",
+                ),
+                constructors: [],
+                routes: [
+                    (
+                        path: "/users",
+                        method_guard: (
+                            allowed_methods: [
+                                "POST",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate::api::users::signup",
+                            ),
+                            location: (
+                                line: 6,
+                                column: 8,
+                                file: "conduit_core/src/api/users/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/users/login",
+                        method_guard: (
+                            allowed_methods: [
+                                "POST",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate::api::users::login",
+                            ),
+                            location: (
+                                line: 7,
+                                column: 8,
+                                file: "conduit_core/src/api/users/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/user",
+                        method_guard: (
+                            allowed_methods: [
+                                "GET",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate::api::users::get_user",
+                            ),
+                            location: (
+                                line: 8,
+                                column: 8,
+                                file: "conduit_core/src/api/users/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                    (
+                        path: "/user",
+                        method_guard: (
+                            allowed_methods: [
+                                "PUT",
+                            ],
+                        ),
+                        request_handler: (
+                            callable: (
+                                registered_at: "conduit_core",
+                                import_path: "crate::api::users::update_user",
+                            ),
+                            location: (
+                                line: 9,
+                                column: 8,
+                                file: "conduit_core/src/api/users/mod.rs",
+                            ),
+                        ),
+                        error_handler: None,
+                    ),
+                ],
+                nested_blueprints: [],
+            ),
+            path_prefix: None,
+            nesting_location: (
+                line: 16,
                 column: 8,
                 file: "conduit_core/src/api/mod.rs",
             ),

--- a/examples/realworld/api_server_sdk/src/lib.rs
+++ b/examples/realworld/api_server_sdk/src/lib.rs
@@ -55,6 +55,12 @@ fn build_router() -> Result<
     router.insert("/articles/:slug/comments/:comment_id", 4u32)?;
     router.insert("/articles/:slug/favorite", 5u32)?;
     router.insert("/articles/feed", 6u32)?;
+    router.insert("/profiles/:username", 7u32)?;
+    router.insert("/profiles/:username/follow", 8u32)?;
+    router.insert("/tags", 9u32)?;
+    router.insert("/user", 10u32)?;
+    router.insert("/users", 11u32)?;
+    router.insert("/users/login", 12u32)?;
     Ok(router)
 }
 async fn route_request(
@@ -171,6 +177,88 @@ async fn route_request(
                     pavex_runtime::response::Response::builder()
                         .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
                         .header(pavex_runtime::http::header::ALLOW, "GET")
+                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+                        .unwrap()
+                }
+            }
+        }
+        7u32 => {
+            match &request_head.method {
+                &pavex_runtime::http::Method::GET => route_handler_12(url_params).await,
+                _ => {
+                    pavex_runtime::response::Response::builder()
+                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                        .header(pavex_runtime::http::header::ALLOW, "GET")
+                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+                        .unwrap()
+                }
+            }
+        }
+        8u32 => {
+            match &request_head.method {
+                &pavex_runtime::http::Method::DELETE => {
+                    route_handler_13(url_params).await
+                }
+                &pavex_runtime::http::Method::POST => route_handler_14(url_params).await,
+                _ => {
+                    pavex_runtime::response::Response::builder()
+                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                        .header(pavex_runtime::http::header::ALLOW, "DELETE, POST")
+                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+                        .unwrap()
+                }
+            }
+        }
+        9u32 => {
+            match &request_head.method {
+                &pavex_runtime::http::Method::GET => route_handler_15().await,
+                _ => {
+                    pavex_runtime::response::Response::builder()
+                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                        .header(pavex_runtime::http::header::ALLOW, "GET")
+                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+                        .unwrap()
+                }
+            }
+        }
+        10u32 => {
+            match &request_head.method {
+                &pavex_runtime::http::Method::GET => route_handler_16().await,
+                &pavex_runtime::http::Method::PUT => {
+                    route_handler_17(request_body, &request_head).await
+                }
+                _ => {
+                    pavex_runtime::response::Response::builder()
+                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                        .header(pavex_runtime::http::header::ALLOW, "GET, PUT")
+                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+                        .unwrap()
+                }
+            }
+        }
+        11u32 => {
+            match &request_head.method {
+                &pavex_runtime::http::Method::POST => {
+                    route_handler_18(request_body, &request_head).await
+                }
+                _ => {
+                    pavex_runtime::response::Response::builder()
+                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                        .header(pavex_runtime::http::header::ALLOW, "POST")
+                        .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
+                        .unwrap()
+                }
+            }
+        }
+        12u32 => {
+            match &request_head.method {
+                &pavex_runtime::http::Method::POST => {
+                    route_handler_19(request_body, &request_head).await
+                }
+                _ => {
+                    pavex_runtime::response::Response::builder()
+                        .status(pavex_runtime::http::StatusCode::METHOD_NOT_ALLOWED)
+                        .header(pavex_runtime::http::header::ALLOW, "POST")
                         .body(pavex_runtime::body::boxed(hyper::body::Body::empty()))
                         .unwrap()
                 }
@@ -523,6 +611,201 @@ pub async fn route_handler_11(
             <http::Response<
                 alloc::string::String,
             > as pavex_runtime::response::IntoResponse>::into_response(v3)
+        }
+    }
+}
+pub async fn route_handler_12(
+    v0: pavex_runtime::extract::route::RawRouteParams<'_, '_>,
+) -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v1 = pavex_runtime::extract::route::RouteParams::extract(v0);
+    match v1 {
+        Ok(v2) => {
+            let v3 = conduit_core::api::profiles::get_user(v2);
+            <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(
+                v3,
+            )
+        }
+        Err(v2) => {
+            let v3 = pavex_runtime::extract::route::errors::ExtractRouteParamsError::into_response(
+                &v2,
+            );
+            <http::Response<
+                alloc::string::String,
+            > as pavex_runtime::response::IntoResponse>::into_response(v3)
+        }
+    }
+}
+pub async fn route_handler_13(
+    v0: pavex_runtime::extract::route::RawRouteParams<'_, '_>,
+) -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v1 = pavex_runtime::extract::route::RouteParams::extract(v0);
+    match v1 {
+        Ok(v2) => {
+            let v3 = conduit_core::api::profiles::unfollow_user(v2);
+            <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(
+                v3,
+            )
+        }
+        Err(v2) => {
+            let v3 = pavex_runtime::extract::route::errors::ExtractRouteParamsError::into_response(
+                &v2,
+            );
+            <http::Response<
+                alloc::string::String,
+            > as pavex_runtime::response::IntoResponse>::into_response(v3)
+        }
+    }
+}
+pub async fn route_handler_14(
+    v0: pavex_runtime::extract::route::RawRouteParams<'_, '_>,
+) -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v1 = pavex_runtime::extract::route::RouteParams::extract(v0);
+    match v1 {
+        Ok(v2) => {
+            let v3 = conduit_core::api::profiles::follow_user(v2);
+            <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(
+                v3,
+            )
+        }
+        Err(v2) => {
+            let v3 = pavex_runtime::extract::route::errors::ExtractRouteParamsError::into_response(
+                &v2,
+            );
+            <http::Response<
+                alloc::string::String,
+            > as pavex_runtime::response::IntoResponse>::into_response(v3)
+        }
+    }
+}
+pub async fn route_handler_15() -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v0 = conduit_core::api::tags::get_tags();
+    <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(v0)
+}
+pub async fn route_handler_16() -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v0 = conduit_core::api::users::get_user();
+    <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(v0)
+}
+pub async fn route_handler_17(
+    v0: hyper::Body,
+    v1: &pavex_runtime::request::RequestHead,
+) -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v2 = <pavex_runtime::extract::body::BodySizeLimit as std::default::Default>::default();
+    let v3 = pavex_runtime::extract::body::BufferedBody::extract(v1, v0, v2).await;
+    match v3 {
+        Ok(v4) => {
+            let v5 = pavex_runtime::extract::body::JsonBody::extract(v1, &v4);
+            match v5 {
+                Ok(v6) => {
+                    let v7 = conduit_core::api::users::update_user(v6);
+                    <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(
+                        v7,
+                    )
+                }
+                Err(v6) => {
+                    let v7 = pavex_runtime::extract::body::errors::ExtractJsonBodyError::into_response(
+                        &v6,
+                    );
+                    <http::Response<
+                        alloc::string::String,
+                    > as pavex_runtime::response::IntoResponse>::into_response(v7)
+                }
+            }
+        }
+        Err(v4) => {
+            let v5 = pavex_runtime::extract::body::errors::ExtractBufferedBodyError::into_response(
+                &v4,
+            );
+            <http::Response<
+                alloc::string::String,
+            > as pavex_runtime::response::IntoResponse>::into_response(v5)
+        }
+    }
+}
+pub async fn route_handler_18(
+    v0: hyper::Body,
+    v1: &pavex_runtime::request::RequestHead,
+) -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v2 = <pavex_runtime::extract::body::BodySizeLimit as std::default::Default>::default();
+    let v3 = pavex_runtime::extract::body::BufferedBody::extract(v1, v0, v2).await;
+    match v3 {
+        Ok(v4) => {
+            let v5 = pavex_runtime::extract::body::JsonBody::extract(v1, &v4);
+            match v5 {
+                Ok(v6) => {
+                    let v7 = conduit_core::api::users::signup(v6);
+                    <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(
+                        v7,
+                    )
+                }
+                Err(v6) => {
+                    let v7 = pavex_runtime::extract::body::errors::ExtractJsonBodyError::into_response(
+                        &v6,
+                    );
+                    <http::Response<
+                        alloc::string::String,
+                    > as pavex_runtime::response::IntoResponse>::into_response(v7)
+                }
+            }
+        }
+        Err(v4) => {
+            let v5 = pavex_runtime::extract::body::errors::ExtractBufferedBodyError::into_response(
+                &v4,
+            );
+            <http::Response<
+                alloc::string::String,
+            > as pavex_runtime::response::IntoResponse>::into_response(v5)
+        }
+    }
+}
+pub async fn route_handler_19(
+    v0: hyper::Body,
+    v1: &pavex_runtime::request::RequestHead,
+) -> http::Response<
+    http_body::combinators::BoxBody<bytes::Bytes, pavex_runtime::Error>,
+> {
+    let v2 = <pavex_runtime::extract::body::BodySizeLimit as std::default::Default>::default();
+    let v3 = pavex_runtime::extract::body::BufferedBody::extract(v1, v0, v2).await;
+    match v3 {
+        Ok(v4) => {
+            let v5 = pavex_runtime::extract::body::JsonBody::extract(v1, &v4);
+            match v5 {
+                Ok(v6) => {
+                    let v7 = conduit_core::api::users::login(v6);
+                    <http::StatusCode as pavex_runtime::response::IntoResponse>::into_response(
+                        v7,
+                    )
+                }
+                Err(v6) => {
+                    let v7 = pavex_runtime::extract::body::errors::ExtractJsonBodyError::into_response(
+                        &v6,
+                    );
+                    <http::Response<
+                        alloc::string::String,
+                    > as pavex_runtime::response::IntoResponse>::into_response(v7)
+                }
+            }
+        }
+        Err(v4) => {
+            let v5 = pavex_runtime::extract::body::errors::ExtractBufferedBodyError::into_response(
+                &v4,
+            );
+            <http::Response<
+                alloc::string::String,
+            > as pavex_runtime::response::IntoResponse>::into_response(v5)
         }
     }
 }

--- a/examples/realworld/conduit_core/Cargo.toml
+++ b/examples/realworld/conduit_core/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
+secrecy = { version = "0.8", features = ["serde"] }
 
 [dev-dependencies]
 wiremock = "0.5"

--- a/examples/realworld/conduit_core/src/api/articles/delete_article.rs
+++ b/examples/realworld/conduit_core/src/api/articles/delete_article.rs
@@ -1,6 +1,7 @@
 use pavex_runtime::{extract::route::RouteParams, hyper::StatusCode};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug)]
+#[RouteParams]
 pub struct DeleteArticle {
     pub slug: String,
 }

--- a/examples/realworld/conduit_core/src/api/articles/delete_comment.rs
+++ b/examples/realworld/conduit_core/src/api/articles/delete_comment.rs
@@ -1,6 +1,7 @@
 use pavex_runtime::{extract::route::RouteParams, hyper::StatusCode};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug)]
+#[RouteParams]
 pub struct DeleteComment {
     pub slug: String,
     pub comment_id: u64

--- a/examples/realworld/conduit_core/src/api/articles/favorite_article.rs
+++ b/examples/realworld/conduit_core/src/api/articles/favorite_article.rs
@@ -1,6 +1,7 @@
 use pavex_runtime::{hyper::StatusCode, extract::route::RouteParams};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug)]
+#[RouteParams]
 pub struct FavoriteArticle {
     pub slug: String,
 }

--- a/examples/realworld/conduit_core/src/api/articles/get_article.rs
+++ b/examples/realworld/conduit_core/src/api/articles/get_article.rs
@@ -1,6 +1,7 @@
 use pavex_runtime::{extract::route::RouteParams, hyper::StatusCode};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug)]
+#[RouteParams]
 pub struct GetArticle {
     pub slug: String,
 }

--- a/examples/realworld/conduit_core/src/api/articles/list_comments.rs
+++ b/examples/realworld/conduit_core/src/api/articles/list_comments.rs
@@ -1,6 +1,7 @@
 use pavex_runtime::{extract::route::RouteParams, hyper::StatusCode};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug)]
+#[RouteParams]
 pub struct ListComments {
     pub slug: String,
 }

--- a/examples/realworld/conduit_core/src/api/articles/publish_comment.rs
+++ b/examples/realworld/conduit_core/src/api/articles/publish_comment.rs
@@ -1,6 +1,7 @@
 use pavex_runtime::{extract::{body::JsonBody, route::RouteParams}, hyper::StatusCode};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug)]
+#[RouteParams]
 pub struct PublishCommentRoute {
     pub slug: String,
 }

--- a/examples/realworld/conduit_core/src/api/articles/unfavorite_article.rs
+++ b/examples/realworld/conduit_core/src/api/articles/unfavorite_article.rs
@@ -1,6 +1,7 @@
 use pavex_runtime::{extract::route::RouteParams, hyper::StatusCode};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug)]
+#[RouteParams]
 pub struct UnfavoriteArticle {
     pub slug: String,
 }

--- a/examples/realworld/conduit_core/src/api/articles/update_article.rs
+++ b/examples/realworld/conduit_core/src/api/articles/update_article.rs
@@ -7,7 +7,8 @@ pub struct UpdateArticleBody {
     pub body: Option<String>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug)]
+#[RouteParams]
 pub struct UpdateArticleRoute {
     pub slug: String,
 }

--- a/examples/realworld/conduit_core/src/api/mod.rs
+++ b/examples/realworld/conduit_core/src/api/mod.rs
@@ -1,15 +1,21 @@
 use pavex_builder::{Blueprint, constructor::Lifecycle, f, router::GET};
 
 pub mod articles;
+pub mod profiles;
 pub mod status;
+pub mod tags;
+pub mod users;
 
 /// The main API blueprint, containing all the routes, constructors and error handlers
 /// required to implement the Realworld API specification.
 pub fn api_blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
     register_common_constructors(&mut bp);
-    bp.route(GET, "/api/ping", f!(crate::api::status::ping));
     bp.nest_at("/articles", articles::articles_bp());
+    bp.nest_at("/profiles", profiles::profiles_bp());
+    bp.nest(users::users_bp());
+    bp.route(GET, "/api/ping", f!(crate::api::status::ping));
+    bp.route(GET, "/tags", f!(crate::api::tags::get_tags));
     bp
 }
 

--- a/examples/realworld/conduit_core/src/api/profiles/follow_user.rs
+++ b/examples/realworld/conduit_core/src/api/profiles/follow_user.rs
@@ -1,0 +1,11 @@
+use pavex_runtime::{extract::route::RouteParams, http::StatusCode};
+
+#[derive(Debug)]
+#[RouteParams]
+pub struct FollowUser {
+    pub username: String,
+}
+
+pub fn follow_user(_params: RouteParams<FollowUser>) -> StatusCode {
+    StatusCode::OK
+}

--- a/examples/realworld/conduit_core/src/api/profiles/get_user.rs
+++ b/examples/realworld/conduit_core/src/api/profiles/get_user.rs
@@ -1,0 +1,11 @@
+use pavex_runtime::{extract::route::RouteParams, http::StatusCode};
+
+#[derive(Debug)]
+#[RouteParams]
+pub struct GetUser {
+    pub username: String,
+}
+
+pub fn get_user(_params: RouteParams<GetUser>) -> StatusCode {
+    StatusCode::OK
+}

--- a/examples/realworld/conduit_core/src/api/profiles/mod.rs
+++ b/examples/realworld/conduit_core/src/api/profiles/mod.rs
@@ -1,0 +1,22 @@
+use pavex_builder::router::{DELETE, POST};
+use pavex_builder::{f, router::GET, Blueprint};
+
+pub(crate) fn profiles_bp() -> Blueprint {
+    let mut bp = Blueprint::new();
+    bp.route(GET, "/:username", f!(crate::api::profiles::get_user));
+    bp.route(POST, "/:username/follow", f!(crate::api::profiles::follow_user));
+    bp.route(
+        DELETE,
+        "/:username/follow",
+        f!(crate::api::profiles::unfollow_user),
+    );
+    bp
+}
+
+mod get_user;
+mod follow_user;
+mod unfollow_user;
+
+pub use get_user::*;
+pub use follow_user::*;
+pub use unfollow_user::*;

--- a/examples/realworld/conduit_core/src/api/profiles/unfollow_user.rs
+++ b/examples/realworld/conduit_core/src/api/profiles/unfollow_user.rs
@@ -1,0 +1,11 @@
+use pavex_runtime::{extract::route::RouteParams, http::StatusCode};
+
+#[RouteParams]
+#[derive(Debug)]
+pub struct UnfollowUser {
+    pub username: String,
+}
+
+pub fn unfollow_user(_params: RouteParams<UnfollowUser>) -> StatusCode {
+    StatusCode::OK
+}

--- a/examples/realworld/conduit_core/src/api/tags.rs
+++ b/examples/realworld/conduit_core/src/api/tags.rs
@@ -1,0 +1,5 @@
+use pavex_runtime::http::StatusCode;
+
+pub fn get_tags() -> StatusCode {
+    StatusCode::OK
+}

--- a/examples/realworld/conduit_core/src/api/users/get_user.rs
+++ b/examples/realworld/conduit_core/src/api/users/get_user.rs
@@ -1,0 +1,5 @@
+use pavex_runtime::http::StatusCode;
+
+pub fn get_user() -> StatusCode {
+    StatusCode::OK
+}

--- a/examples/realworld/conduit_core/src/api/users/login.rs
+++ b/examples/realworld/conduit_core/src/api/users/login.rs
@@ -1,0 +1,17 @@
+use pavex_runtime::{http::StatusCode, extract::body::JsonBody};
+use secrecy::Secret;
+
+#[derive(serde::Deserialize)]
+pub struct LoginUser {
+    pub user: UserCredentials,
+}
+
+#[derive(serde::Deserialize)]
+pub struct UserCredentials {
+    pub email: String,
+    pub password: Secret<String>,
+}
+
+pub fn login(_body: JsonBody<LoginUser>) -> StatusCode {
+    StatusCode::OK
+}

--- a/examples/realworld/conduit_core/src/api/users/mod.rs
+++ b/examples/realworld/conduit_core/src/api/users/mod.rs
@@ -1,0 +1,21 @@
+use pavex_builder::router::{POST, PUT};
+use pavex_builder::{f, router::GET, Blueprint};
+
+pub(crate) fn users_bp() -> Blueprint {
+    let mut bp = Blueprint::new();
+    bp.route(POST, "/users", f!(crate::api::users::signup));
+    bp.route(POST, "/users/login", f!(crate::api::users::login));
+    bp.route(GET, "/user", f!(crate::api::users::get_user));
+    bp.route(PUT, "/user", f!(crate::api::users::update_user));
+    bp
+}
+
+mod get_user;
+mod login;
+mod signup;
+mod update_user;
+
+pub use get_user::*;
+pub use login::*;
+pub use signup::*;
+pub use update_user::*;

--- a/examples/realworld/conduit_core/src/api/users/signup.rs
+++ b/examples/realworld/conduit_core/src/api/users/signup.rs
@@ -1,0 +1,18 @@
+use pavex_runtime::{extract::body::JsonBody, http::StatusCode};
+use secrecy::Secret;
+
+#[derive(serde::Deserialize)]
+pub struct Signup {
+    pub user: UserDetails
+}
+
+#[derive(serde::Deserialize)]
+pub struct UserDetails {
+    pub username: String,
+    pub email: String,
+    pub password: Secret<String>
+}
+
+pub fn signup(_body: JsonBody<Signup>) -> StatusCode {
+    StatusCode::OK
+}

--- a/examples/realworld/conduit_core/src/api/users/update_user.rs
+++ b/examples/realworld/conduit_core/src/api/users/update_user.rs
@@ -1,0 +1,20 @@
+use pavex_runtime::{extract::body::JsonBody, http::StatusCode};
+use secrecy::Secret;
+
+#[derive(serde::Deserialize)]
+pub struct UpdateUser {
+    pub user: UpdatedDetails,
+}
+
+#[derive(serde::Deserialize)]
+pub struct UpdatedDetails {
+    pub email: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<Secret<String>>,
+    pub bio: Option<String>,
+    pub image: Option<String>,
+}
+
+pub fn update_user(_body: JsonBody<UpdateUser>) -> StatusCode {
+    StatusCode::OK
+}

--- a/libs/pavex_macros/src/lib.rs
+++ b/libs/pavex_macros/src/lib.rs
@@ -7,7 +7,8 @@ use syn::{parse_macro_input, Attribute, Data, DeriveInput, Error, GenericParam, 
 #[allow(non_snake_case)]
 #[proc_macro_attribute]
 pub fn RouteParams(_metadata: TokenStream, input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
+    let mut ast = parse_macro_input!(input as DeriveInput);
+    ast.attrs.push(syn::parse_quote!(#[derive(serde::Serialize, serde::Deserialize)]));
 
     if let Err(mut e) = reject_serde_attributes(&ast) {
         // We emit both the error AND the original struct.
@@ -36,11 +37,8 @@ pub fn RouteParams(_metadata: TokenStream, input: TokenStream) -> TokenStream {
             }
         })
         .collect::<Punctuated<_, Token![,]>>();
-    let mut attrs = ast.attrs.clone();
-    attrs.push(syn::parse_quote!(#[derive(serde::Serialize, serde::Deserialize)]));
     let struct_name = &ast.ident;
     let expanded = quote! {
-        #(#attrs)*
         #ast
 
         impl #generics_with_bounds pavex_runtime::serialization::StructuralDeserialize for #struct_name < #generics_without_bounds > {}


### PR DESCRIPTION
This completes the modelling push for the request-side of the Realworld spec.

Miscellaneous:
- Fixed an issue in the `RouteParams` macro that would result in compiler errors if other derive macros were added _after_ `#[RouteParams]`.
- Use `#[RouteParams]` instead of `serde::Deserialize` when working with route parameters.
