### PR TITLE
Fix completion suggestions and go-to-definition in f! for IntellijRust

### DIFF
--- a/libs/pavex/src/blueprint/reflection/callable/mod.rs
+++ b/libs/pavex/src/blueprint/reflection/callable/mod.rs
@@ -2,9 +2,9 @@ pub use identifiers::{RawCallable, RawCallableIdentifiers};
 
 mod identifiers;
 
-// The `pavex_ide_hint`-let binding is a hack to "nudge" 
+// The `pavex_ide_hint`-let binding is a hack to "nudge"
 // rust-analyzer into parsing the macro input
-// as an expression path, therefore enabling auto-completion and 
+// as an expression path, therefore enabling auto-completion and
 // go-to-definition for the path that's passed as input.
 //
 // Rust-analyzer doesn't do this by default because it can't infer
@@ -12,14 +12,14 @@ mod identifiers;
 // `stringify` accepts anything as input, so that's not enough.
 //
 // The perma-disabled `let` binding lets us workaround the issue
-// that an _actual_ `let` binding would cause: it would fail to 
+// that an _actual_ `let` binding would cause: it would fail to
 // compile if the callable is generic, because the compiler would
 // demand to know the type of each generic parameter without a default.
 #[macro_export]
 macro_rules! f {
     ($p:expr) => {{
         #[cfg(pavex_ide_hint)]
-        let _ = $p;
+        const P:() = $p;
         $crate::blueprint::reflection::RawCallable {
             import_path: stringify!($p),
             registered_at: ::std::env!("CARGO_PKG_NAME", "Failed to load the CARGO_PKG_NAME environment variable. Are you using a custom build system?")


### PR DESCRIPTION
The new nightly build of IntellijRust fixes the IDE issues we were experiencing in the `f!` macro.
In order to get go-to-definition working as expected, they have suggested to use `const` as IDE hint rather than `let`. This seems to work in both IntellijRust and rust-analyzer, so I applied the change in this PR.