### PR TITLE
Wrapping middleware #1: Blueprint API and docs

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "paste",
  "pavex_macros",
  "percent-encoding",
+ "pin-project-lite",
  "ron",
  "serde",
  "serde_html_form",
@@ -1185,6 +1186,7 @@ dependencies = [
  "serde_path_to_error",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 pavex_macros = { path = "../pavex_macros" }
 paste = "1"
+pin-project-lite = "0.2"
 
 # Route parameters
 matchit = "0.7"
@@ -35,3 +36,4 @@ ron = "0.8"
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }
 insta = "1.29.0"
+tracing = "0.1"

--- a/libs/pavex/src/blueprint/blueprint.rs
+++ b/libs/pavex/src/blueprint/blueprint.rs
@@ -398,22 +398,8 @@ impl Blueprint {
     /// [`Response`]: crate::response::Response
     /// [`Future`]: std::future::Future
     #[doc(alias = "middleware")]
-    pub fn wrap(&mut self, callable: RawCallable) -> Constructor {
-        let registered_constructor = RegisteredConstructor {
-            constructor: RegisteredCallable {
-                callable: RawCallableIdentifiers::from_raw_callable(callable),
-                location: std::panic::Location::caller().into(),
-            },
-            lifecycle: Lifecycle::Transient,
-            cloning_strategy: None,
-            error_handler: None,
-        };
-        let constructor_id = self.constructors.len();
-        self.constructors.push(registered_constructor);
-        Constructor {
-            constructor_id,
-            blueprint: self,
-        }
+    pub fn wrap(&mut self, _callable: RawCallable) {
+        todo!()
     }
 
     #[track_caller]

--- a/libs/pavex/src/blueprint/internals.rs
+++ b/libs/pavex/src/blueprint/internals.rs
@@ -1,3 +1,7 @@
+//! Internal types used by [`Blueprint`]s to keep track of what you registered.
+//! 
+//! This module is not meant to be used directly by users of the framework. It is only meant to be
+//! used by Pavex's CLI.
 use super::constructor::{CloningStrategy, Lifecycle};
 use super::reflection::{Location, RawCallableIdentifiers};
 use super::router::MethodGuard;

--- a/libs/pavex/src/blueprint/mod.rs
+++ b/libs/pavex/src/blueprint/mod.rs
@@ -1,3 +1,4 @@
+//! Define the routes and the structure of your application using a [`Blueprint`].
 pub use blueprint::Blueprint;
 
 mod blueprint;

--- a/libs/pavex/src/blueprint/reflection/mod.rs
+++ b/libs/pavex/src/blueprint/reflection/mod.rs
@@ -1,9 +1,9 @@
-//! Internal machinery to keep track of the metadata required by Pavex to later analyze your request
+//! Callable metadata used by Pavex's CLI to analyze your request
 //! handlers, constructors and error handlers (e.g. their input parameters, their return type,
 //! where they are defined, etc.).
 //!
 //! This module is not meant to be used directly by users of the framework. It is only meant to be
-//! used by the Pavex code generator.
+//! used by Pavex's CLI.
 pub use callable::{RawCallable, RawCallableIdentifiers};
 pub use location::Location;
 

--- a/libs/pavex/src/lib.rs
+++ b/libs/pavex/src/lib.rs
@@ -8,6 +8,7 @@ mod error;
 pub mod blueprint;
 pub mod extract;
 pub mod http;
+pub mod middleware;
 pub mod request;
 pub mod response;
 

--- a/libs/pavex/src/middleware.rs
+++ b/libs/pavex/src/middleware.rs
@@ -32,6 +32,7 @@ impl<C> Next<C>
 where
     C: Future<Output = Response>,
 {
+    /// Creates a new [`Next`] instance.
     pub fn new(request_pipeline: C) -> Self {
         Self { request_pipeline }
     }

--- a/libs/pavex/src/middleware.rs
+++ b/libs/pavex/src/middleware.rs
@@ -1,0 +1,50 @@
+//! Middleware types and utilities.
+//! 
+//! See [`Blueprint::wrap`] and [`Next`] for more information.
+//! 
+//! [`Blueprint::wrap`]: crate::blueprint::Blueprint::wrap
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use pin_project_lite::pin_project;
+
+use crate::response::Response;
+
+pin_project! {
+    /// A [`Future`] that represents the next step in the request processing pipeline.
+    /// 
+    /// It is used by wrapping middlewares to delegate the processing of the request to the next
+    /// middleware in the pipeline (or to the request handler).
+    /// 
+    /// Check out [`Blueprint::wrap`] for more information.
+    /// 
+    /// [`Blueprint`]: crate::blueprint::Blueprint
+    pub struct Next<C> {
+        #[pin]
+        request_pipeline: C,
+    }
+}
+
+impl<C> Next<C>
+where
+    C: Future<Output = Response>,
+{
+    pub fn new(request_pipeline: C) -> Self {
+        Self { request_pipeline }
+    }
+}
+
+impl<C> Future for Next<C>
+where
+    C: Future<Output = Response>,
+{
+    type Output = Response;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.request_pipeline.poll(cx)
+    }
+}


### PR DESCRIPTION
Going for a slightly different approach on wrapping middleware: multiple small PRs rather than getting the whole thing done at once.

This is the first step: defining the API exposed via `Blueprint` and, in particular, fleshing out the docs and examples.
