### PR TITLE
Add repository link to Cargo.toml

### DIFF
--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pavex"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/LukeMathWalker/pavex"
 
 [dependencies]
 hyper = { version = "0.14", features = ["server", "http1", "http2", "tcp"] }


### PR DESCRIPTION
Hi!

Nothing important here - just saw the headline for your talk at RustLab, looked up `pavex` on crates.io and then noticed there was no link to the repo :+1: Feel free to disregard