### PR TITLE
Lift bounds on Next's definition, rather than on its implementations

### DIFF
--- a/libs/pavex/src/blueprint/blueprint.rs
+++ b/libs/pavex/src/blueprint/blueprint.rs
@@ -357,7 +357,7 @@ impl Blueprint {
     ///     config: TimeoutConfig
     /// ) -> Result<Response, Elapsed>
     /// where
-    ///     C: Future<Output = Response>
+    ///     C: IntoFuture<Output = Response>
     /// {
     ///     timeout(config.request_timeout, next.into_future()).await
     /// }

--- a/libs/pavex/src/middleware.rs
+++ b/libs/pavex/src/middleware.rs
@@ -15,16 +15,19 @@ use crate::response::Response;
 /// Check out [`Blueprint::wrap`] for more information.
 ///
 /// [`Blueprint::wrap`]: crate::blueprint::Blueprint::wrap
-pub struct Next<C> {
+pub struct Next<C>
+where
+    C: IntoFuture<Output = Response>,
+{
     request_pipeline: C,
 }
 
-impl<C> Next<C> {
+impl<C> Next<C>
+where
+    C: IntoFuture<Output = Response>,
+{
     /// Creates a new [`Next`] instance.
-    pub fn new(request_pipeline: C) -> Self
-    where
-        C: IntoFuture<Output = Response>,
-    {
+    pub fn new(request_pipeline: C) -> Self {
         Self { request_pipeline }
     }
 }

--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/components_can_fail/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/components_can_fail/lib.rs
@@ -1,3 +1,4 @@
+use std::future::IntoFuture;
 use std::path::PathBuf;
 
 use pavex::blueprint::{constructor::Lifecycle, router::GET, Blueprint};
@@ -72,7 +73,10 @@ pub fn handle_middleware_error(_e: &MiddlewareError) -> Response {
     todo!()
 }
 
-pub fn fallible_wrapping_middleware<T>(_next: Next<T>) -> Result<Response, MiddlewareError> {
+pub fn fallible_wrapping_middleware<T>(_next: Next<T>) -> Result<Response, MiddlewareError>
+where
+    T: IntoFuture<Output = Response>,
+{
     todo!()
 }
 

--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/output_type_must_implement_into_response/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/output_type_must_implement_into_response/expectations/stderr.txt
@@ -3,12 +3,12 @@
   [31m│[0m response.
   [31m│[0m It doesn't implement `pavex::response::IntoResponse`.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:32:1]
-  [31m│[0m  [2m32[0m │         .error_handler(f!(crate::error_handler));
-  [31m│[0m  [2m33[0m │     bp.route(GET, "/home", f!(crate::handler))
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:37:1]
+  [31m│[0m  [2m37[0m │         .error_handler(f!(crate::error_handler));
+  [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
   [31m│[0m     · [35;1m                           ─────────┬────────[0m
   [31m│[0m     ·                                     [35;1m╰── [35;1mThe request handler was registered here[0m[0m
-  [31m│[0m  [2m34[0m │         .error_handler(f!(crate::error_handler));
+  [31m│[0m  [2m39[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
   [31m│[0m         `app::MyCustomOutputType`.
@@ -18,12 +18,12 @@
   [31m│[0m HTTP response.
   [31m│[0m It doesn't implement `pavex::response::IntoResponse`.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:28:1]
-  [31m│[0m  [2m28[0m │     let mut bp = Blueprint::new();
-  [31m│[0m  [2m29[0m │     bp.wrap(f!(crate::wrapping_middleware))
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:33:1]
+  [31m│[0m  [2m33[0m │     let mut bp = Blueprint::new();
+  [31m│[0m  [2m34[0m │     bp.wrap(f!(crate::wrapping_middleware))
   [31m│[0m     · [35;1m            ───────────────┬──────────────[0m
   [31m│[0m     ·                            [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
-  [31m│[0m  [2m30[0m │         .error_handler(f!(crate::error_handler));
+  [31m│[0m  [2m35[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
   [31m│[0m         `app::MyCustomOutputType`.
@@ -33,12 +33,12 @@
   [31m│[0m response.
   [31m│[0m It doesn't implement `pavex::response::IntoResponse`.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:29:1]
-  [31m│[0m  [2m29[0m │     bp.wrap(f!(crate::wrapping_middleware))
-  [31m│[0m  [2m30[0m │         .error_handler(f!(crate::error_handler));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:34:1]
+  [31m│[0m  [2m34[0m │     bp.wrap(f!(crate::wrapping_middleware))
+  [31m│[0m  [2m35[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
   [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
-  [31m│[0m  [2m31[0m │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
+  [31m│[0m  [2m36[0m │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
   [31m│[0m         `app::MyCustomOutputType`.
@@ -48,12 +48,12 @@
   [31m│[0m response.
   [31m│[0m It doesn't implement `pavex::response::IntoResponse`.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:33:1]
-  [31m│[0m  [2m33[0m │     bp.route(GET, "/home", f!(crate::handler))
-  [31m│[0m  [2m34[0m │         .error_handler(f!(crate::error_handler));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:38:1]
+  [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
+  [31m│[0m  [2m39[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
   [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
-  [31m│[0m  [2m35[0m │     bp
+  [31m│[0m  [2m40[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
   [31m│[0m         `app::MyCustomOutputType`.
@@ -63,12 +63,12 @@
   [31m│[0m response.
   [31m│[0m It doesn't implement `pavex::response::IntoResponse`.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:31:1]
-  [31m│[0m  [2m31[0m │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
-  [31m│[0m  [2m32[0m │         .error_handler(f!(crate::error_handler));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:36:1]
+  [31m│[0m  [2m36[0m │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
+  [31m│[0m  [2m37[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
   [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
-  [31m│[0m  [2m33[0m │     bp.route(GET, "/home", f!(crate::handler))
+  [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
   [31m│[0m         `app::MyCustomOutputType`.

--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/output_type_must_implement_into_response/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/output_type_must_implement_into_response/lib.rs
@@ -1,6 +1,8 @@
 use pavex::blueprint::{constructor::Lifecycle, router::GET, Blueprint};
-use pavex::middleware::Next;
 use pavex::f;
+use pavex::middleware::Next;
+use pavex::response::Response;
+use std::future::IntoFuture;
 
 pub fn request_scoped() -> Result<String, ErrorType> {
     todo!()
@@ -20,7 +22,10 @@ pub fn error_handler(e: &ErrorType) -> MyCustomOutputType {
     todo!()
 }
 
-pub fn wrapping_middleware<T>(_next: Next<T>) -> Result<MyCustomOutputType, ErrorType> {
+pub fn wrapping_middleware<T>(_next: Next<T>) -> Result<MyCustomOutputType, ErrorType>
+where
+    T: IntoFuture<Output = Response>,
+{
     todo!()
 }
 

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/cannot_have_multiple_next_inputs/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/cannot_have_multiple_next_inputs/expectations/stderr.txt
@@ -3,11 +3,11 @@
   [31m│[0m `pavex::middleware::Next<_>` as input parameter.
   [31m│[0m This middleware does.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:15:1]
-  [31m│[0m  [2m15[0m │     let mut bp = Blueprint::new();
-  [31m│[0m  [2m16[0m │     bp.wrap(f!(crate::mw));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:20:1]
+  [31m│[0m  [2m20[0m │     let mut bp = Blueprint::new();
+  [31m│[0m  [2m21[0m │     bp.wrap(f!(crate::mw));
   [31m│[0m     · [35;1m            ──────┬──────[0m
   [31m│[0m     ·                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
-  [31m│[0m  [2m17[0m │     bp.route(GET, "/home", f!(crate::handler));
+  [31m│[0m  [2m22[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove the extra `Next` input parameters until only one is left.

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/cannot_have_multiple_next_inputs/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/cannot_have_multiple_next_inputs/lib.rs
@@ -1,9 +1,14 @@
+use std::future::IntoFuture;
+
 use pavex::blueprint::{constructor::Lifecycle, router::GET, Blueprint};
 use pavex::f;
 use pavex::middleware::Next;
 use pavex::response::Response;
 
-pub fn mw<T>(_next: Next<T>, _second_next: Next<T>) -> Response {
+pub fn mw<T>(_next: Next<T>, _second_next: Next<T>) -> Response
+where
+    T: IntoFuture<Output = Response>,
+{
     todo!()
 }
 

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/next_must_take_a_naked_generic_parameter/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/next_must_take_a_naked_generic_parameter/expectations/stderr.txt
@@ -4,12 +4,12 @@
   [31m│[0m This wrapping middleware, instead, uses `app::Custom<T>` as generic
   [31m│[0m parameter for `Next`.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:17:1]
-  [31m│[0m  [2m17[0m │     let mut bp = Blueprint::new();
-  [31m│[0m  [2m18[0m │     bp.wrap(f!(crate::mw));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:31:1]
+  [31m│[0m  [2m31[0m │     let mut bp = Blueprint::new();
+  [31m│[0m  [2m32[0m │     bp.wrap(f!(crate::mw));
   [31m│[0m     · [35;1m            ──────┬──────[0m
   [31m│[0m     ·                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
-  [31m│[0m  [2m19[0m │     bp.route(GET, "/home", f!(crate::handler));
+  [31m│[0m  [2m33[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mTake `Next<T>` rather than `Next<app::Custom<T>>` as input parameter
   [31m│[0m         in your middleware.

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/next_must_take_a_naked_generic_parameter/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/next_must_take_a_naked_generic_parameter/lib.rs
@@ -1,3 +1,5 @@
+use std::future::{IntoFuture, Ready};
+
 use pavex::blueprint::{constructor::Lifecycle, router::GET, Blueprint};
 use pavex::f;
 use pavex::middleware::Next;
@@ -5,7 +7,19 @@ use pavex::response::Response;
 
 pub struct Custom<T>(T);
 
-pub fn mw<T>(_next: Next<Custom<T>>) -> Response {
+impl<T> IntoFuture for Custom<T> {
+    type Output = Response;
+    type IntoFuture = Ready<Response>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        todo!()
+    }
+}
+
+pub fn mw<T>(_next: Next<Custom<T>>) -> Response
+where
+    T: IntoFuture<Output = Response>,
+{
     todo!()
 }
 

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/wrapping_middlewares_input_parameters_cannot_be_generic/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/wrapping_middlewares_input_parameters_cannot_be_generic/expectations/stderr.txt
@@ -5,18 +5,18 @@
   [31m│[0m apart from the one in `Next<_>`, but `T` does not seem to have been
   [31m│[0m assigned a concrete type.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:33:1]
-  [31m│[0m  [2m33[0m │     let mut bp = Blueprint::new();
-  [31m│[0m  [2m34[0m │     bp.wrap(f!(crate::generic_wrapping_middleware));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:45:1]
+  [31m│[0m  [2m45[0m │     let mut bp = Blueprint::new();
+  [31m│[0m  [2m46[0m │     bp.wrap(f!(crate::generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ───────────────────┬──────────────────[0m
   [31m│[0m     ·                                [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
-  [31m│[0m  [2m35[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
+  [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
-  [31m│[0m  [2m1[0m │ pub fn generic_wrapping_middleware<A, T>(_next: Next<A>, generic_input: GenericType<T>) -> u8 {
+  [31m│[0m  [2m1[0m │ pub fn generic_wrapping_middleware<A, T>(_next: Next<A>, generic_input: GenericType<T>) -> u8
   [31m│[0m    · [35;1m                                      ┬[0m
   [31m│[0m    ·                                       [35;1m╰── [35;1mThe generic parameter without a concrete type[0m[0m
-  [31m│[0m  [2m2[0m │     todo!()
+  [31m│[0m  [2m2[0m │ where
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type for `T` when registering the wrapping
   [31m│[0m         middleware against the blueprint:
@@ -31,12 +31,12 @@
   [31m│[0m apart from the one in `Next<_>`, but `T` and `S` do not seem to have been
   [31m│[0m assigned a concrete type.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:34:1]
-  [31m│[0m  [2m34[0m │     bp.wrap(f!(crate::generic_wrapping_middleware));
-  [31m│[0m  [2m35[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:46:1]
+  [31m│[0m  [2m46[0m │     bp.wrap(f!(crate::generic_wrapping_middleware));
+  [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ──────────────────────┬──────────────────────[0m
   [31m│[0m     ·                                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
-  [31m│[0m  [2m36[0m │     bp.wrap(f!(crate::triply_generic_wrapping_middleware));
+  [31m│[0m  [2m48[0m │     bp.wrap(f!(crate::triply_generic_wrapping_middleware));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn doubly_generic_wrapping_middleware<A, T, S>(
@@ -58,12 +58,12 @@
   [31m│[0m apart from the one in `Next<_>`, but `T`, `S` and `U` do not seem to have
   [31m│[0m been assigned a concrete type.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:35:1]
-  [31m│[0m  [2m35[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
-  [31m│[0m  [2m36[0m │     bp.wrap(f!(crate::triply_generic_wrapping_middleware));
+  [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:47:1]
+  [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
+  [31m│[0m  [2m48[0m │     bp.wrap(f!(crate::triply_generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ──────────────────────┬──────────────────────[0m
   [31m│[0m     ·                                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
-  [31m│[0m  [2m37[0m │     bp.route(GET, "/home", f!(crate::handler));
+  [31m│[0m  [2m49[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn triply_generic_wrapping_middleware<A, T, S, U>(

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/wrapping_middlewares_input_parameters_cannot_be_generic/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/wrapping_middlewares_input_parameters_cannot_be_generic/lib.rs
@@ -1,10 +1,16 @@
+use std::future::IntoFuture;
+
 use pavex::blueprint::{constructor::Lifecycle, router::GET, Blueprint};
 use pavex::f;
 use pavex::middleware::Next;
+use pavex::response::Response;
 
 pub struct GenericType<V>(V);
 
-pub fn generic_wrapping_middleware<A, T>(_next: Next<A>, generic_input: GenericType<T>) -> u8 {
+pub fn generic_wrapping_middleware<A, T>(_next: Next<A>, generic_input: GenericType<T>) -> u8
+where
+    A: IntoFuture<Output = Response>,
+{
     todo!()
 }
 
@@ -12,7 +18,10 @@ pub fn doubly_generic_wrapping_middleware<A, T, S>(
     _next: Next<A>,
     i1: GenericType<T>,
     i2: GenericType<S>,
-) -> u16 {
+) -> u16
+where
+    A: IntoFuture<Output = Response>,
+{
     todo!()
 }
 
@@ -21,7 +30,10 @@ pub fn triply_generic_wrapping_middleware<A, T, S, U>(
     i1: GenericType<T>,
     i2: GenericType<S>,
     i3: GenericType<U>,
-) -> u32 {
+) -> u32
+where
+    A: IntoFuture<Output = Response>,
+{
     todo!()
 }
 


### PR DESCRIPTION
Considering the way Pavex works, this ensures that errors are raised early (by the Rust compiler against the user's code) rather than delayed (a compilation failure in the generated code).
