### PR TITLE
Realworld: logging middleware

### DIFF
--- a/examples/realworld/README.md
+++ b/examples/realworld/README.md
@@ -36,6 +36,7 @@ For more information on how this works with other frontends/backends, head over 
   ```
 
 ### Setup steps
+
 - Launch a local Postgres instance and run SQL migrations:
 ```bash
 ./scripts/init_db.sh
@@ -69,3 +70,29 @@ APP_PROFILE=prod cargo px run --bin api
 ```
 
 All configurable parameters are listed in `api_server/src/configuration.rs`.
+
+### Auth configuration
+
+The application uses JWT for authentication, therefore it requires a secret key pair to sign and verify tokens. You can
+generate one for local development purposes by running:
+
+```bash 
+openssl genpkey -algorithm ed25519 -out private.pem
+openssl pkey -in private.pem -pubout -out public.pem
+```
+
+You then need to copy the generated keys to your configuration file, `api_server/configuration/dev.yml` for 
+local development:
+
+```yaml
+# [...]
+auth:
+  eddsa_private_key_pem: |
+    -----BEGIN PRIVATE KEY-----
+    # Paste the contents of private.pem here
+    -----END PRIVATE KEY-----
+  eddsa_public_key_pem: |
+    -----BEGIN PUBLIC KEY-----
+    # Paste the contents of public.pem here
+    -----END PUBLIC KEY-----
+```

--- a/examples/realworld/api_server_sdk/blueprint.ron
+++ b/examples/realworld/api_server_sdk/blueprint.ron
@@ -1,6 +1,6 @@
 (
     creation_location: (
-        line: 8,
+        line: 9,
         column: 18,
         file: "conduit_core/src/blueprint.rs",
     ),
@@ -12,7 +12,7 @@
                     import_path: "pavex::extract::query::QueryParams::extract",
                 ),
                 location: (
-                    line: 32,
+                    line: 33,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -25,7 +25,7 @@
                     import_path: "pavex::extract::query::errors::ExtractQueryParamsError::into_response",
                 ),
                 location: (
-                    line: 36,
+                    line: 37,
                     column: 6,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -38,7 +38,7 @@
                     import_path: "pavex::extract::route::RouteParams::extract",
                 ),
                 location: (
-                    line: 41,
+                    line: 42,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -51,7 +51,7 @@
                     import_path: "pavex::extract::route::errors::ExtractRouteParamsError::into_response",
                 ),
                 location: (
-                    line: 45,
+                    line: 46,
                     column: 6,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -64,7 +64,7 @@
                     import_path: "pavex::extract::body::JsonBody::extract",
                 ),
                 location: (
-                    line: 50,
+                    line: 51,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -77,7 +77,7 @@
                     import_path: "pavex::extract::body::errors::ExtractJsonBodyError::into_response",
                 ),
                 location: (
-                    line: 54,
+                    line: 55,
                     column: 6,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -90,7 +90,7 @@
                     import_path: "pavex::extract::body::BufferedBody::extract",
                 ),
                 location: (
-                    line: 57,
+                    line: 58,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -103,7 +103,7 @@
                     import_path: "pavex::extract::body::errors::ExtractBufferedBodyError::into_response",
                 ),
                 location: (
-                    line: 61,
+                    line: 62,
                     column: 6,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -116,7 +116,7 @@
                     import_path: "<pavex::extract::body::BodySizeLimit as std::default::Default>::default",
                 ),
                 location: (
-                    line: 64,
+                    line: 65,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -132,7 +132,7 @@
                     import_path: "crate::configuration::DatabaseConfig::get_pool",
                 ),
                 location: (
-                    line: 10,
+                    line: 11,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -148,13 +148,29 @@
                     import_path: "crate::configuration::AuthConfig::decoding_key",
                 ),
                 location: (
-                    line: 14,
+                    line: 15,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
             ),
             lifecycle: Singleton,
             cloning_strategy: None,
+            error_handler: None,
+        ),
+        (
+            constructor: (
+                callable: (
+                    registered_at: "conduit_core",
+                    import_path: "crate::telemetry::RootSpan::new",
+                ),
+                location: (
+                    line: 73,
+                    column: 8,
+                    file: "conduit_core/src/blueprint.rs",
+                ),
+            ),
+            lifecycle: RequestScoped,
+            cloning_strategy: Some(CloneIfNecessary),
             error_handler: None,
         ),
     ],
@@ -166,7 +182,7 @@
                     import_path: "crate::telemetry::logger",
                 ),
                 location: (
-                    line: 19,
+                    line: 79,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -188,7 +204,7 @@
                     import_path: "crate::routes::status::ping",
                 ),
                 location: (
-                    line: 24,
+                    line: 25,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -208,7 +224,7 @@
                     import_path: "crate::routes::tags::get_tags",
                 ),
                 location: (
-                    line: 25,
+                    line: 26,
                     column: 8,
                     file: "conduit_core/src/blueprint.rs",
                 ),
@@ -452,7 +468,7 @@
             ),
             path_prefix: Some("/articles"),
             nesting_location: (
-                line: 21,
+                line: 22,
                 column: 8,
                 file: "conduit_core/src/blueprint.rs",
             ),
@@ -532,7 +548,7 @@
             ),
             path_prefix: Some("/profiles"),
             nesting_location: (
-                line: 22,
+                line: 23,
                 column: 8,
                 file: "conduit_core/src/blueprint.rs",
             ),
@@ -669,7 +685,7 @@
             ),
             path_prefix: None,
             nesting_location: (
-                line: 23,
+                line: 24,
                 column: 8,
                 file: "conduit_core/src/blueprint.rs",
             ),

--- a/examples/realworld/api_server_sdk/src/lib.rs
+++ b/examples/realworld/api_server_sdk/src/lib.rs
@@ -48,15 +48,44 @@ pub async fn build_application_state(
     };
     core::result::Result::Ok(v6)
 }
+<<<<<<< HEAD
 pub fn run(
     server_builder: pavex::server::Server,
+=======
+pub async fn run(
+    server_builder: pavex::hyper::server::Builder<
+        pavex::hyper::server::conn::AddrIncoming,
+    >,
+>>>>>>> 649dd92 (Register telemetry middleware.)
     application_state: ApplicationState,
 ) -> Result<pavex::server::ServerHandle, pavex::Error> {
     let server_state = std::sync::Arc::new(ServerState {
         router: build_router().map_err(pavex::Error::new)?,
         application_state,
     });
+<<<<<<< HEAD
     Ok(server_builder.serve(route_request, server_state))
+=======
+    let make_service = pavex::hyper::service::make_service_fn(move |_| {
+        let server_state = server_state.clone();
+        async move {
+            Ok::<
+                _,
+                pavex::hyper::Error,
+            >(
+                pavex::hyper::service::service_fn(move |request| {
+                    let server_state = server_state.clone();
+                    async move {
+                        let response = route_request(request, server_state).await;
+                        let response = pavex::hyper::Response::from(response);
+                        Ok::<_, pavex::hyper::Error>(response)
+                    }
+                }),
+            )
+        }
+    });
+    server_builder.serve(make_service).await.map_err(pavex::Error::new)
+>>>>>>> 649dd92 (Register telemetry middleware.)
 }
 fn build_router() -> Result<pavex::routing::Router<u32>, pavex::routing::InsertError> {
     let mut router = pavex::routing::Router::new();
@@ -96,7 +125,11 @@ async fn route_request(
     match route_id {
         0u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::GET => route_0::middleware_0().await,
+=======
+                &pavex::http::Method::GET => route_0::middleware_0(&request_head).await,
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -123,8 +156,17 @@ async fn route_request(
         }
         2u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::DELETE => route_3::middleware_0(url_params).await,
                 &pavex::http::Method::GET => route_4::middleware_0(url_params).await,
+=======
+                &pavex::http::Method::DELETE => {
+                    route_3::middleware_0(url_params, &request_head).await
+                }
+                &pavex::http::Method::GET => {
+                    route_4::middleware_0(url_params, &request_head).await
+                }
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 &pavex::http::Method::PUT => {
                     route_5::middleware_0(url_params, request_body, &request_head).await
                 }
@@ -140,7 +182,13 @@ async fn route_request(
         }
         3u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::GET => route_6::middleware_0(url_params).await,
+=======
+                &pavex::http::Method::GET => {
+                    route_6::middleware_0(url_params, &request_head).await
+                }
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 &pavex::http::Method::POST => {
                     route_7::middleware_0(url_params, request_body, &request_head).await
                 }
@@ -156,7 +204,13 @@ async fn route_request(
         }
         4u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::DELETE => route_8::middleware_0(url_params).await,
+=======
+                &pavex::http::Method::DELETE => {
+                    route_8::middleware_0(url_params, &request_head).await
+                }
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("DELETE");
                     pavex::response::Response::method_not_allowed()
@@ -167,8 +221,17 @@ async fn route_request(
         }
         5u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::DELETE => route_9::middleware_0(url_params).await,
                 &pavex::http::Method::POST => route_10::middleware_0(url_params).await,
+=======
+                &pavex::http::Method::DELETE => {
+                    route_9::middleware_0(url_params, &request_head).await
+                }
+                &pavex::http::Method::POST => {
+                    route_10::middleware_0(url_params, &request_head).await
+                }
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
                         "DELETE, POST",
@@ -192,7 +255,13 @@ async fn route_request(
         }
         7u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::GET => route_12::middleware_0(url_params).await,
+=======
+                &pavex::http::Method::GET => {
+                    route_12::middleware_0(url_params, &request_head).await
+                }
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -203,8 +272,17 @@ async fn route_request(
         }
         8u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::DELETE => route_13::middleware_0(url_params).await,
                 &pavex::http::Method::POST => route_14::middleware_0(url_params).await,
+=======
+                &pavex::http::Method::DELETE => {
+                    route_13::middleware_0(url_params, &request_head).await
+                }
+                &pavex::http::Method::POST => {
+                    route_14::middleware_0(url_params, &request_head).await
+                }
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
                         "DELETE, POST",
@@ -217,7 +295,11 @@ async fn route_request(
         }
         9u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::GET => route_15::middleware_0().await,
+=======
+                &pavex::http::Method::GET => route_15::middleware_0(&request_head).await,
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -228,7 +310,11 @@ async fn route_request(
         }
         10u32 => {
             match &request_head.method {
+<<<<<<< HEAD
                 &pavex::http::Method::GET => route_16::middleware_0().await,
+=======
+                &pavex::http::Method::GET => route_16::middleware_0(&request_head).await,
+>>>>>>> 649dd92 (Register telemetry middleware.)
                 &pavex::http::Method::PUT => {
                     route_17::middleware_0(request_body, &request_head).await
                 }
@@ -244,9 +330,15 @@ async fn route_request(
             match &request_head.method {
                 &pavex::http::Method::POST => {
                     route_18::middleware_0(
+<<<<<<< HEAD
                             &server_state.application_state.s1,
                             request_body,
                             &server_state.application_state.s0,
+=======
+                            &server_state.application_state.s0,
+                            &server_state.application_state.s1,
+                            request_body,
+>>>>>>> 649dd92 (Register telemetry middleware.)
                             &request_head,
                         )
                         .await
@@ -263,9 +355,15 @@ async fn route_request(
             match &request_head.method {
                 &pavex::http::Method::POST => {
                     route_19::middleware_0(
+<<<<<<< HEAD
                             &server_state.application_state.s1,
                             request_body,
                             &server_state.application_state.s0,
+=======
+                            &server_state.application_state.s0,
+                            &server_state.application_state.s1,
+                            request_body,
+>>>>>>> 649dd92 (Register telemetry middleware.)
                             &request_head,
                         )
                         .await
@@ -282,12 +380,24 @@ async fn route_request(
     }
 }
 pub mod route_0 {
+<<<<<<< HEAD
     pub async fn middleware_0() -> pavex::response::Response {
         let v0 = crate::route_0::Next0 {
             next: handler,
         };
         let v1 = pavex::middleware::Next::new(v0);
         conduit_core::telemetry::logger(v1).await
+=======
+    pub async fn middleware_0(
+        v0: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v1 = conduit_core::telemetry::RootSpan::new(v0);
+        let v2 = crate::route_0::Next0 {
+            next: handler,
+        };
+        let v3 = pavex::middleware::Next::new(v2);
+        conduit_core::telemetry::logger(v3, v1).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::status::ping();
@@ -314,12 +424,22 @@ pub mod route_1 {
     pub async fn middleware_0(
         v0: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_1::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v1 = conduit_core::telemetry::RootSpan::new(v0);
+        let v2 = crate::route_1::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v3 = pavex::middleware::Next::new(v2);
+        conduit_core::telemetry::logger(v3, v1).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(v0: &pavex::request::RequestHead) -> pavex::response::Response {
         let v1 = pavex::extract::query::QueryParams::extract(v0);
@@ -359,16 +479,29 @@ pub mod route_1 {
 }
 pub mod route_2 {
     pub async fn middleware_0(
+<<<<<<< HEAD
         v0: hyper::body::Incoming,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v2 = crate::route_2::Next0 {
+=======
+        v0: hyper::Body,
+        v1: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_2::Next0 {
+>>>>>>> 649dd92 (Register telemetry middleware.)
             s_0: v0,
             s_1: v1,
             next: handler,
         };
+<<<<<<< HEAD
         let v3 = pavex::middleware::Next::new(v2);
         conduit_core::telemetry::logger(v3).await
+=======
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -410,9 +543,15 @@ pub mod route_2 {
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
+<<<<<<< HEAD
         s_0: hyper::body::Incoming,
         s_1: &'a pavex::request::RequestHead,
         next: fn(hyper::body::Incoming, &'a pavex::request::RequestHead) -> T,
+=======
+        s_0: hyper::Body,
+        s_1: &'a pavex::request::RequestHead,
+        next: fn(hyper::Body, &'a pavex::request::RequestHead) -> T,
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     impl<'a, T> std::future::IntoFuture for Next0<'a, T>
     where
@@ -428,13 +567,24 @@ pub mod route_2 {
 pub mod route_3 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_3::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_3::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -477,13 +627,24 @@ pub mod route_3 {
 pub mod route_4 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_4::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_4::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -526,17 +687,25 @@ pub mod route_4 {
 pub mod route_5 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+<<<<<<< HEAD
         v1: hyper::body::Incoming,
         v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v3 = crate::route_5::Next0 {
+=======
+        v1: hyper::Body,
+        v2: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v3 = conduit_core::telemetry::RootSpan::new(v2);
+        let v4 = crate::route_5::Next0 {
+>>>>>>> 649dd92 (Register telemetry middleware.)
             s_0: v1,
             s_1: v0,
             s_2: v2,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -589,6 +758,7 @@ pub mod route_5 {
         let v10 = conduit_core::routes::articles::update_article(v9, v7);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v10)
     }
+<<<<<<< HEAD
     pub struct Next0<'b, 'a, 'c, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
@@ -598,11 +768,26 @@ pub mod route_5 {
         s_2: &'c pavex::request::RequestHead,
         next: fn(
             hyper::body::Incoming,
+=======
+    pub struct Next0<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: hyper::Body,
+        s_1: pavex::extract::route::RawRouteParams<'a, 'b>,
+        s_2: &'c pavex::request::RequestHead,
+        next: fn(
+            hyper::Body,
+>>>>>>> 649dd92 (Register telemetry middleware.)
             pavex::extract::route::RawRouteParams<'a, 'b>,
             &'c pavex::request::RequestHead,
         ) -> T,
     }
+<<<<<<< HEAD
     impl<'b, 'a, 'c, T> std::future::IntoFuture for Next0<'b, 'a, 'c, T>
+=======
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+>>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -616,13 +801,24 @@ pub mod route_5 {
 pub mod route_6 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_6::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_6::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -665,17 +861,25 @@ pub mod route_6 {
 pub mod route_7 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+<<<<<<< HEAD
         v1: hyper::body::Incoming,
         v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v3 = crate::route_7::Next0 {
+=======
+        v1: hyper::Body,
+        v2: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v3 = conduit_core::telemetry::RootSpan::new(v2);
+        let v4 = crate::route_7::Next0 {
+>>>>>>> 649dd92 (Register telemetry middleware.)
             s_0: v1,
             s_1: v0,
             s_2: v2,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -728,6 +932,7 @@ pub mod route_7 {
         let v10 = conduit_core::routes::articles::publish_comment(v9, v7);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v10)
     }
+<<<<<<< HEAD
     pub struct Next0<'b, 'a, 'c, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
@@ -737,11 +942,26 @@ pub mod route_7 {
         s_2: &'c pavex::request::RequestHead,
         next: fn(
             hyper::body::Incoming,
+=======
+    pub struct Next0<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: hyper::Body,
+        s_1: pavex::extract::route::RawRouteParams<'a, 'b>,
+        s_2: &'c pavex::request::RequestHead,
+        next: fn(
+            hyper::Body,
+>>>>>>> 649dd92 (Register telemetry middleware.)
             pavex::extract::route::RawRouteParams<'a, 'b>,
             &'c pavex::request::RequestHead,
         ) -> T,
     }
+<<<<<<< HEAD
     impl<'b, 'a, 'c, T> std::future::IntoFuture for Next0<'b, 'a, 'c, T>
+=======
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+>>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -755,13 +975,24 @@ pub mod route_7 {
 pub mod route_8 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_8::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_8::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -783,14 +1014,22 @@ pub mod route_8 {
         let v3 = conduit_core::routes::articles::delete_comment(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
+<<<<<<< HEAD
     pub struct Next0<'b, 'a, T>
+=======
+    pub struct Next0<'a, 'b, T>
+>>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
+<<<<<<< HEAD
     impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
+=======
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+>>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -804,13 +1043,24 @@ pub mod route_8 {
 pub mod route_9 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_9::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_9::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -853,13 +1103,24 @@ pub mod route_9 {
 pub mod route_10 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_10::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_10::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -903,12 +1164,22 @@ pub mod route_11 {
     pub async fn middleware_0(
         v0: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_11::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v1 = conduit_core::telemetry::RootSpan::new(v0);
+        let v2 = crate::route_11::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v3 = pavex::middleware::Next::new(v2);
+        conduit_core::telemetry::logger(v3, v1).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(v0: &pavex::request::RequestHead) -> pavex::response::Response {
         let v1 = pavex::extract::query::QueryParams::extract(v0);
@@ -949,13 +1220,24 @@ pub mod route_11 {
 pub mod route_12 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_12::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_12::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -977,14 +1259,22 @@ pub mod route_12 {
         let v3 = conduit_core::routes::profiles::get_profile(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
+<<<<<<< HEAD
     pub struct Next0<'a, 'b, T>
+=======
+    pub struct Next0<'b, 'a, T>
+>>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
+<<<<<<< HEAD
     impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+=======
+    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
+>>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -998,13 +1288,24 @@ pub mod route_12 {
 pub mod route_13 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_13::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_13::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1047,13 +1348,24 @@ pub mod route_13 {
 pub mod route_14 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
+<<<<<<< HEAD
         let v1 = crate::route_14::Next0 {
             s_0: v0,
             next: handler,
         };
         let v2 = pavex::middleware::Next::new(v1);
         conduit_core::telemetry::logger(v2).await
+=======
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_14::Next0 {
+            s_0: v0,
+            next: handler,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1094,12 +1406,24 @@ pub mod route_14 {
     }
 }
 pub mod route_15 {
+<<<<<<< HEAD
     pub async fn middleware_0() -> pavex::response::Response {
         let v0 = crate::route_15::Next0 {
             next: handler,
         };
         let v1 = pavex::middleware::Next::new(v0);
         conduit_core::telemetry::logger(v1).await
+=======
+    pub async fn middleware_0(
+        v0: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v1 = conduit_core::telemetry::RootSpan::new(v0);
+        let v2 = crate::route_15::Next0 {
+            next: handler,
+        };
+        let v3 = pavex::middleware::Next::new(v2);
+        conduit_core::telemetry::logger(v3, v1).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::tags::get_tags();
@@ -1123,12 +1447,24 @@ pub mod route_15 {
     }
 }
 pub mod route_16 {
+<<<<<<< HEAD
     pub async fn middleware_0() -> pavex::response::Response {
         let v0 = crate::route_16::Next0 {
             next: handler,
         };
         let v1 = pavex::middleware::Next::new(v0);
         conduit_core::telemetry::logger(v1).await
+=======
+    pub async fn middleware_0(
+        v0: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v1 = conduit_core::telemetry::RootSpan::new(v0);
+        let v2 = crate::route_16::Next0 {
+            next: handler,
+        };
+        let v3 = pavex::middleware::Next::new(v2);
+        conduit_core::telemetry::logger(v3, v1).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::users::get_user();
@@ -1153,16 +1489,29 @@ pub mod route_16 {
 }
 pub mod route_17 {
     pub async fn middleware_0(
+<<<<<<< HEAD
         v0: hyper::body::Incoming,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v2 = crate::route_17::Next0 {
+=======
+        v0: hyper::Body,
+        v1: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v2 = conduit_core::telemetry::RootSpan::new(v1);
+        let v3 = crate::route_17::Next0 {
+>>>>>>> 649dd92 (Register telemetry middleware.)
             s_0: v0,
             s_1: v1,
             next: handler,
         };
+<<<<<<< HEAD
         let v3 = pavex::middleware::Next::new(v2);
         conduit_core::telemetry::logger(v3).await
+=======
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -1204,9 +1553,15 @@ pub mod route_17 {
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
+<<<<<<< HEAD
         s_0: hyper::body::Incoming,
         s_1: &'a pavex::request::RequestHead,
         next: fn(hyper::body::Incoming, &'a pavex::request::RequestHead) -> T,
+=======
+        s_0: hyper::Body,
+        s_1: &'a pavex::request::RequestHead,
+        next: fn(hyper::Body, &'a pavex::request::RequestHead) -> T,
+>>>>>>> 649dd92 (Register telemetry middleware.)
     }
     impl<'a, T> std::future::IntoFuture for Next0<'a, T>
     where
@@ -1221,6 +1576,7 @@ pub mod route_17 {
 }
 pub mod route_18 {
     pub async fn middleware_0(
+<<<<<<< HEAD
         v0: &jsonwebtoken::EncodingKey,
         v1: hyper::body::Incoming,
         v2: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
@@ -1231,10 +1587,23 @@ pub mod route_18 {
             s_1: v3,
             s_2: v1,
             s_3: v0,
+=======
+        v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        v1: &jsonwebtoken::EncodingKey,
+        v2: hyper::Body,
+        v3: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v4 = conduit_core::telemetry::RootSpan::new(v3);
+        let v5 = crate::route_18::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
+>>>>>>> 649dd92 (Register telemetry middleware.)
             next: handler,
         };
-        let v5 = pavex::middleware::Next::new(v4);
-        conduit_core::telemetry::logger(v5).await
+        let v6 = pavex::middleware::Next::new(v5);
+        conduit_core::telemetry::logger(v6, v4).await
     }
     pub async fn handler(
         v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
@@ -1295,12 +1664,20 @@ pub mod route_18 {
     {
         s_0: &'a sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         s_1: &'b pavex::request::RequestHead,
+<<<<<<< HEAD
         s_2: hyper::body::Incoming,
+=======
+        s_2: hyper::Body,
+>>>>>>> 649dd92 (Register telemetry middleware.)
         s_3: &'c jsonwebtoken::EncodingKey,
         next: fn(
             &'a sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
             &'b pavex::request::RequestHead,
+<<<<<<< HEAD
             hyper::body::Incoming,
+=======
+            hyper::Body,
+>>>>>>> 649dd92 (Register telemetry middleware.)
             &'c jsonwebtoken::EncodingKey,
         ) -> T,
     }
@@ -1317,6 +1694,7 @@ pub mod route_18 {
 }
 pub mod route_19 {
     pub async fn middleware_0(
+<<<<<<< HEAD
         v0: &jsonwebtoken::EncodingKey,
         v1: hyper::body::Incoming,
         v2: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
@@ -1327,10 +1705,23 @@ pub mod route_19 {
             s_1: v3,
             s_2: v1,
             s_3: v0,
+=======
+        v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        v1: &jsonwebtoken::EncodingKey,
+        v2: hyper::Body,
+        v3: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v4 = conduit_core::telemetry::RootSpan::new(v3);
+        let v5 = crate::route_19::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
+>>>>>>> 649dd92 (Register telemetry middleware.)
             next: handler,
         };
-        let v5 = pavex::middleware::Next::new(v4);
-        conduit_core::telemetry::logger(v5).await
+        let v6 = pavex::middleware::Next::new(v5);
+        conduit_core::telemetry::logger(v6, v4).await
     }
     pub async fn handler(
         v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
@@ -1391,12 +1782,20 @@ pub mod route_19 {
     {
         s_0: &'a sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         s_1: &'b pavex::request::RequestHead,
+<<<<<<< HEAD
         s_2: hyper::body::Incoming,
+=======
+        s_2: hyper::Body,
+>>>>>>> 649dd92 (Register telemetry middleware.)
         s_3: &'c jsonwebtoken::EncodingKey,
         next: fn(
             &'a sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
             &'b pavex::request::RequestHead,
+<<<<<<< HEAD
             hyper::body::Incoming,
+=======
+            hyper::Body,
+>>>>>>> 649dd92 (Register telemetry middleware.)
             &'c jsonwebtoken::EncodingKey,
         ) -> T,
     }

--- a/examples/realworld/api_server_sdk/src/lib.rs
+++ b/examples/realworld/api_server_sdk/src/lib.rs
@@ -95,8 +95,13 @@ async fn route_request(
         .into();
     match route_id {
         0u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/api/ping",
+            );
             match &request_head.method {
-                &pavex::http::Method::GET => route_0::middleware_0(&request_head).await,
+                &pavex::http::Method::GET => {
+                    route_0::middleware_0(matched_route_template, &request_head).await
+                }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -106,10 +111,20 @@ async fn route_request(
             }
         }
         1u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/articles",
+            );
             match &request_head.method {
-                &pavex::http::Method::GET => route_1::middleware_0(&request_head).await,
+                &pavex::http::Method::GET => {
+                    route_1::middleware_0(matched_route_template, &request_head).await
+                }
                 &pavex::http::Method::POST => {
-                    route_2::middleware_0(request_body, &request_head).await
+                    route_2::middleware_0(
+                            matched_route_template,
+                            request_body,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
@@ -122,15 +137,34 @@ async fn route_request(
             }
         }
         2u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/articles/:slug",
+            );
             match &request_head.method {
                 &pavex::http::Method::DELETE => {
-                    route_3::middleware_0(url_params, &request_head).await
+                    route_3::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 &pavex::http::Method::GET => {
-                    route_4::middleware_0(url_params, &request_head).await
+                    route_4::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 &pavex::http::Method::PUT => {
-                    route_5::middleware_0(url_params, request_body, &request_head).await
+                    route_5::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            request_body,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
@@ -143,12 +177,26 @@ async fn route_request(
             }
         }
         3u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/articles/:slug/comments",
+            );
             match &request_head.method {
                 &pavex::http::Method::GET => {
-                    route_6::middleware_0(url_params, &request_head).await
+                    route_6::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 &pavex::http::Method::POST => {
-                    route_7::middleware_0(url_params, request_body, &request_head).await
+                    route_7::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            request_body,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
@@ -161,9 +209,17 @@ async fn route_request(
             }
         }
         4u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/articles/:slug/comments/:comment_id",
+            );
             match &request_head.method {
                 &pavex::http::Method::DELETE => {
-                    route_8::middleware_0(url_params, &request_head).await
+                    route_8::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("DELETE");
@@ -174,12 +230,25 @@ async fn route_request(
             }
         }
         5u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/articles/:slug/favorite",
+            );
             match &request_head.method {
                 &pavex::http::Method::DELETE => {
-                    route_9::middleware_0(url_params, &request_head).await
+                    route_9::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 &pavex::http::Method::POST => {
-                    route_10::middleware_0(url_params, &request_head).await
+                    route_10::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
@@ -192,8 +261,13 @@ async fn route_request(
             }
         }
         6u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/articles/feed",
+            );
             match &request_head.method {
-                &pavex::http::Method::GET => route_11::middleware_0(&request_head).await,
+                &pavex::http::Method::GET => {
+                    route_11::middleware_0(matched_route_template, &request_head).await
+                }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -203,9 +277,17 @@ async fn route_request(
             }
         }
         7u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/profiles/:username",
+            );
             match &request_head.method {
                 &pavex::http::Method::GET => {
-                    route_12::middleware_0(url_params, &request_head).await
+                    route_12::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
@@ -216,12 +298,25 @@ async fn route_request(
             }
         }
         8u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/profiles/:username/follow",
+            );
             match &request_head.method {
                 &pavex::http::Method::DELETE => {
-                    route_13::middleware_0(url_params, &request_head).await
+                    route_13::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 &pavex::http::Method::POST => {
-                    route_14::middleware_0(url_params, &request_head).await
+                    route_14::middleware_0(
+                            matched_route_template,
+                            url_params,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
@@ -234,8 +329,13 @@ async fn route_request(
             }
         }
         9u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/tags",
+            );
             match &request_head.method {
-                &pavex::http::Method::GET => route_15::middleware_0(&request_head).await,
+                &pavex::http::Method::GET => {
+                    route_15::middleware_0(matched_route_template, &request_head).await
+                }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -245,10 +345,20 @@ async fn route_request(
             }
         }
         10u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/user",
+            );
             match &request_head.method {
-                &pavex::http::Method::GET => route_16::middleware_0(&request_head).await,
+                &pavex::http::Method::GET => {
+                    route_16::middleware_0(matched_route_template, &request_head).await
+                }
                 &pavex::http::Method::PUT => {
-                    route_17::middleware_0(request_body, &request_head).await
+                    route_17::middleware_0(
+                            matched_route_template,
+                            request_body,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET, PUT");
@@ -259,9 +369,13 @@ async fn route_request(
             }
         }
         11u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/users",
+            );
             match &request_head.method {
                 &pavex::http::Method::POST => {
                     route_18::middleware_0(
+                            matched_route_template,
                             &server_state.application_state.s0,
                             &server_state.application_state.s1,
                             request_body,
@@ -278,9 +392,13 @@ async fn route_request(
             }
         }
         12u32 => {
+            let matched_route_template = pavex::extract::route::MatchedRouteTemplate::new(
+                "/users/login",
+            );
             match &request_head.method {
                 &pavex::http::Method::POST => {
                     route_19::middleware_0(
+                            matched_route_template,
                             &server_state.application_state.s0,
                             &server_state.application_state.s1,
                             request_body,
@@ -301,14 +419,15 @@ async fn route_request(
 }
 pub mod route_0 {
     pub async fn middleware_0(
-        v0: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v1 = conduit_core::telemetry::RootSpan::new(v0);
-        let v2 = crate::route_0::Next0 {
+        let v2 = conduit_core::telemetry::RootSpan::new(v1, v0);
+        let v3 = crate::route_0::Next0 {
             next: handler,
         };
-        let v3 = pavex::middleware::Next::new(v2);
-        conduit_core::telemetry::logger(v3, v1).await
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::status::ping();
@@ -333,15 +452,16 @@ pub mod route_0 {
 }
 pub mod route_1 {
     pub async fn middleware_0(
-        v0: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v1 = conduit_core::telemetry::RootSpan::new(v0);
-        let v2 = crate::route_1::Next0 {
-            s_0: v0,
+        let v2 = conduit_core::telemetry::RootSpan::new(v1, v0);
+        let v3 = crate::route_1::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v3 = pavex::middleware::Next::new(v2);
-        conduit_core::telemetry::logger(v3, v1).await
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
     }
     pub async fn handler(v0: &pavex::request::RequestHead) -> pavex::response::Response {
         let v1 = pavex::extract::query::QueryParams::extract(v0);
@@ -381,17 +501,18 @@ pub mod route_1 {
 }
 pub mod route_2 {
     pub async fn middleware_0(
-        v0: hyper::body::Incoming,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: hyper::body::Incoming,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_2::Next0 {
-            s_0: v0,
-            s_1: v1,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_2::Next0 {
+            s_0: v1,
+            s_1: v2,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -450,16 +571,17 @@ pub mod route_2 {
 }
 pub mod route_3 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_3::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_3::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -501,16 +623,17 @@ pub mod route_3 {
 }
 pub mod route_4 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_4::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_4::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -532,14 +655,14 @@ pub mod route_4 {
         let v3 = conduit_core::routes::articles::get_article(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'a, 'b, T>
+    pub struct Next0<'b, 'a, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -552,19 +675,20 @@ pub mod route_4 {
 }
 pub mod route_5 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: hyper::body::Incoming,
-        v2: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: hyper::body::Incoming,
+        v3: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v3 = conduit_core::telemetry::RootSpan::new(v2);
-        let v4 = crate::route_5::Next0 {
-            s_0: v1,
-            s_1: v0,
-            s_2: v2,
+        let v4 = conduit_core::telemetry::RootSpan::new(v3, v0);
+        let v5 = crate::route_5::Next0 {
+            s_0: v2,
+            s_1: v1,
+            s_2: v3,
             next: handler,
         };
-        let v5 = pavex::middleware::Next::new(v4);
-        conduit_core::telemetry::logger(v5, v3).await
+        let v6 = pavex::middleware::Next::new(v5);
+        conduit_core::telemetry::logger(v6, v4).await
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -643,16 +767,17 @@ pub mod route_5 {
 }
 pub mod route_6 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_6::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_6::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -694,19 +819,20 @@ pub mod route_6 {
 }
 pub mod route_7 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: hyper::body::Incoming,
-        v2: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: hyper::body::Incoming,
+        v3: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v3 = conduit_core::telemetry::RootSpan::new(v2);
-        let v4 = crate::route_7::Next0 {
-            s_0: v1,
-            s_1: v0,
-            s_2: v2,
+        let v4 = conduit_core::telemetry::RootSpan::new(v3, v0);
+        let v5 = crate::route_7::Next0 {
+            s_0: v2,
+            s_1: v1,
+            s_2: v3,
             next: handler,
         };
-        let v5 = pavex::middleware::Next::new(v4);
-        conduit_core::telemetry::logger(v5, v3).await
+        let v6 = pavex::middleware::Next::new(v5);
+        conduit_core::telemetry::logger(v6, v4).await
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -785,16 +911,17 @@ pub mod route_7 {
 }
 pub mod route_8 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_8::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_8::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -836,16 +963,17 @@ pub mod route_8 {
 }
 pub mod route_9 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_9::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_9::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -867,14 +995,14 @@ pub mod route_9 {
         let v3 = conduit_core::routes::articles::unfavorite_article(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'a, 'b, T>
+    pub struct Next0<'b, 'a, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -887,16 +1015,17 @@ pub mod route_9 {
 }
 pub mod route_10 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_10::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_10::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -938,15 +1067,16 @@ pub mod route_10 {
 }
 pub mod route_11 {
     pub async fn middleware_0(
-        v0: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v1 = conduit_core::telemetry::RootSpan::new(v0);
-        let v2 = crate::route_11::Next0 {
-            s_0: v0,
+        let v2 = conduit_core::telemetry::RootSpan::new(v1, v0);
+        let v3 = crate::route_11::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v3 = pavex::middleware::Next::new(v2);
-        conduit_core::telemetry::logger(v3, v1).await
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
     }
     pub async fn handler(v0: &pavex::request::RequestHead) -> pavex::response::Response {
         let v1 = pavex::extract::query::QueryParams::extract(v0);
@@ -986,16 +1116,17 @@ pub mod route_11 {
 }
 pub mod route_12 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_12::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_12::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1017,14 +1148,14 @@ pub mod route_12 {
         let v3 = conduit_core::routes::profiles::get_profile(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'b, 'a, T>
+    pub struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1037,16 +1168,17 @@ pub mod route_12 {
 }
 pub mod route_13 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_13::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_13::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1088,16 +1220,17 @@ pub mod route_13 {
 }
 pub mod route_14 {
     pub async fn middleware_0(
-        v0: pavex::extract::route::RawRouteParams<'_, '_>,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: pavex::extract::route::RawRouteParams<'_, '_>,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_14::Next0 {
-            s_0: v0,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_14::Next0 {
+            s_0: v1,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1119,14 +1252,14 @@ pub mod route_14 {
         let v3 = conduit_core::routes::profiles::follow_profile(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'b, 'a, T>
+    pub struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1139,14 +1272,15 @@ pub mod route_14 {
 }
 pub mod route_15 {
     pub async fn middleware_0(
-        v0: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v1 = conduit_core::telemetry::RootSpan::new(v0);
-        let v2 = crate::route_15::Next0 {
+        let v2 = conduit_core::telemetry::RootSpan::new(v1, v0);
+        let v3 = crate::route_15::Next0 {
             next: handler,
         };
-        let v3 = pavex::middleware::Next::new(v2);
-        conduit_core::telemetry::logger(v3, v1).await
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::tags::get_tags();
@@ -1171,14 +1305,15 @@ pub mod route_15 {
 }
 pub mod route_16 {
     pub async fn middleware_0(
-        v0: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v1 = conduit_core::telemetry::RootSpan::new(v0);
-        let v2 = crate::route_16::Next0 {
+        let v2 = conduit_core::telemetry::RootSpan::new(v1, v0);
+        let v3 = crate::route_16::Next0 {
             next: handler,
         };
-        let v3 = pavex::middleware::Next::new(v2);
-        conduit_core::telemetry::logger(v3, v1).await
+        let v4 = pavex::middleware::Next::new(v3);
+        conduit_core::telemetry::logger(v4, v2).await
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::users::get_user();
@@ -1203,17 +1338,18 @@ pub mod route_16 {
 }
 pub mod route_17 {
     pub async fn middleware_0(
-        v0: hyper::body::Incoming,
-        v1: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: hyper::body::Incoming,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = conduit_core::telemetry::RootSpan::new(v1);
-        let v3 = crate::route_17::Next0 {
-            s_0: v0,
-            s_1: v1,
+        let v3 = conduit_core::telemetry::RootSpan::new(v2, v0);
+        let v4 = crate::route_17::Next0 {
+            s_0: v1,
+            s_1: v2,
             next: handler,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        conduit_core::telemetry::logger(v4, v2).await
+        let v5 = pavex::middleware::Next::new(v4);
+        conduit_core::telemetry::logger(v5, v3).await
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -1272,21 +1408,22 @@ pub mod route_17 {
 }
 pub mod route_18 {
     pub async fn middleware_0(
-        v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
-        v1: &jsonwebtoken::EncodingKey,
-        v2: hyper::body::Incoming,
-        v3: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        v2: &jsonwebtoken::EncodingKey,
+        v3: hyper::body::Incoming,
+        v4: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v4 = conduit_core::telemetry::RootSpan::new(v3);
-        let v5 = crate::route_18::Next0 {
-            s_0: v0,
-            s_1: v3,
-            s_2: v2,
-            s_3: v1,
+        let v5 = conduit_core::telemetry::RootSpan::new(v4, v0);
+        let v6 = crate::route_18::Next0 {
+            s_0: v1,
+            s_1: v4,
+            s_2: v3,
+            s_3: v2,
             next: handler,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        conduit_core::telemetry::logger(v6, v4).await
+        let v7 = pavex::middleware::Next::new(v6);
+        conduit_core::telemetry::logger(v7, v5).await
     }
     pub async fn handler(
         v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
@@ -1369,21 +1506,22 @@ pub mod route_18 {
 }
 pub mod route_19 {
     pub async fn middleware_0(
-        v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
-        v1: &jsonwebtoken::EncodingKey,
-        v2: hyper::body::Incoming,
-        v3: &pavex::request::RequestHead,
+        v0: pavex::extract::route::MatchedRouteTemplate,
+        v1: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        v2: &jsonwebtoken::EncodingKey,
+        v3: hyper::body::Incoming,
+        v4: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v4 = conduit_core::telemetry::RootSpan::new(v3);
-        let v5 = crate::route_19::Next0 {
-            s_0: v0,
-            s_1: v3,
-            s_2: v2,
-            s_3: v1,
+        let v5 = conduit_core::telemetry::RootSpan::new(v4, v0);
+        let v6 = crate::route_19::Next0 {
+            s_0: v1,
+            s_1: v4,
+            s_2: v3,
+            s_3: v2,
             next: handler,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        conduit_core::telemetry::logger(v6, v4).await
+        let v7 = pavex::middleware::Next::new(v6);
+        conduit_core::telemetry::logger(v7, v5).await
     }
     pub async fn handler(
         v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,

--- a/examples/realworld/api_server_sdk/src/lib.rs
+++ b/examples/realworld/api_server_sdk/src/lib.rs
@@ -48,44 +48,15 @@ pub async fn build_application_state(
     };
     core::result::Result::Ok(v6)
 }
-<<<<<<< HEAD
 pub fn run(
     server_builder: pavex::server::Server,
-=======
-pub async fn run(
-    server_builder: pavex::hyper::server::Builder<
-        pavex::hyper::server::conn::AddrIncoming,
-    >,
->>>>>>> 649dd92 (Register telemetry middleware.)
     application_state: ApplicationState,
 ) -> Result<pavex::server::ServerHandle, pavex::Error> {
     let server_state = std::sync::Arc::new(ServerState {
         router: build_router().map_err(pavex::Error::new)?,
         application_state,
     });
-<<<<<<< HEAD
     Ok(server_builder.serve(route_request, server_state))
-=======
-    let make_service = pavex::hyper::service::make_service_fn(move |_| {
-        let server_state = server_state.clone();
-        async move {
-            Ok::<
-                _,
-                pavex::hyper::Error,
-            >(
-                pavex::hyper::service::service_fn(move |request| {
-                    let server_state = server_state.clone();
-                    async move {
-                        let response = route_request(request, server_state).await;
-                        let response = pavex::hyper::Response::from(response);
-                        Ok::<_, pavex::hyper::Error>(response)
-                    }
-                }),
-            )
-        }
-    });
-    server_builder.serve(make_service).await.map_err(pavex::Error::new)
->>>>>>> 649dd92 (Register telemetry middleware.)
 }
 fn build_router() -> Result<pavex::routing::Router<u32>, pavex::routing::InsertError> {
     let mut router = pavex::routing::Router::new();
@@ -125,11 +96,7 @@ async fn route_request(
     match route_id {
         0u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::GET => route_0::middleware_0().await,
-=======
                 &pavex::http::Method::GET => route_0::middleware_0(&request_head).await,
->>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -156,17 +123,12 @@ async fn route_request(
         }
         2u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::DELETE => route_3::middleware_0(url_params).await,
-                &pavex::http::Method::GET => route_4::middleware_0(url_params).await,
-=======
                 &pavex::http::Method::DELETE => {
                     route_3::middleware_0(url_params, &request_head).await
                 }
                 &pavex::http::Method::GET => {
                     route_4::middleware_0(url_params, &request_head).await
                 }
->>>>>>> 649dd92 (Register telemetry middleware.)
                 &pavex::http::Method::PUT => {
                     route_5::middleware_0(url_params, request_body, &request_head).await
                 }
@@ -182,13 +144,9 @@ async fn route_request(
         }
         3u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::GET => route_6::middleware_0(url_params).await,
-=======
                 &pavex::http::Method::GET => {
                     route_6::middleware_0(url_params, &request_head).await
                 }
->>>>>>> 649dd92 (Register telemetry middleware.)
                 &pavex::http::Method::POST => {
                     route_7::middleware_0(url_params, request_body, &request_head).await
                 }
@@ -204,13 +162,9 @@ async fn route_request(
         }
         4u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::DELETE => route_8::middleware_0(url_params).await,
-=======
                 &pavex::http::Method::DELETE => {
                     route_8::middleware_0(url_params, &request_head).await
                 }
->>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("DELETE");
                     pavex::response::Response::method_not_allowed()
@@ -221,17 +175,12 @@ async fn route_request(
         }
         5u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::DELETE => route_9::middleware_0(url_params).await,
-                &pavex::http::Method::POST => route_10::middleware_0(url_params).await,
-=======
                 &pavex::http::Method::DELETE => {
                     route_9::middleware_0(url_params, &request_head).await
                 }
                 &pavex::http::Method::POST => {
                     route_10::middleware_0(url_params, &request_head).await
                 }
->>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
                         "DELETE, POST",
@@ -255,13 +204,9 @@ async fn route_request(
         }
         7u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::GET => route_12::middleware_0(url_params).await,
-=======
                 &pavex::http::Method::GET => {
                     route_12::middleware_0(url_params, &request_head).await
                 }
->>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -272,17 +217,12 @@ async fn route_request(
         }
         8u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::DELETE => route_13::middleware_0(url_params).await,
-                &pavex::http::Method::POST => route_14::middleware_0(url_params).await,
-=======
                 &pavex::http::Method::DELETE => {
                     route_13::middleware_0(url_params, &request_head).await
                 }
                 &pavex::http::Method::POST => {
                     route_14::middleware_0(url_params, &request_head).await
                 }
->>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static(
                         "DELETE, POST",
@@ -295,11 +235,7 @@ async fn route_request(
         }
         9u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::GET => route_15::middleware_0().await,
-=======
                 &pavex::http::Method::GET => route_15::middleware_0(&request_head).await,
->>>>>>> 649dd92 (Register telemetry middleware.)
                 _ => {
                     let header_value = pavex::http::HeaderValue::from_static("GET");
                     pavex::response::Response::method_not_allowed()
@@ -310,11 +246,7 @@ async fn route_request(
         }
         10u32 => {
             match &request_head.method {
-<<<<<<< HEAD
-                &pavex::http::Method::GET => route_16::middleware_0().await,
-=======
                 &pavex::http::Method::GET => route_16::middleware_0(&request_head).await,
->>>>>>> 649dd92 (Register telemetry middleware.)
                 &pavex::http::Method::PUT => {
                     route_17::middleware_0(request_body, &request_head).await
                 }
@@ -330,15 +262,9 @@ async fn route_request(
             match &request_head.method {
                 &pavex::http::Method::POST => {
                     route_18::middleware_0(
-<<<<<<< HEAD
-                            &server_state.application_state.s1,
-                            request_body,
-                            &server_state.application_state.s0,
-=======
                             &server_state.application_state.s0,
                             &server_state.application_state.s1,
                             request_body,
->>>>>>> 649dd92 (Register telemetry middleware.)
                             &request_head,
                         )
                         .await
@@ -355,15 +281,9 @@ async fn route_request(
             match &request_head.method {
                 &pavex::http::Method::POST => {
                     route_19::middleware_0(
-<<<<<<< HEAD
-                            &server_state.application_state.s1,
-                            request_body,
-                            &server_state.application_state.s0,
-=======
                             &server_state.application_state.s0,
                             &server_state.application_state.s1,
                             request_body,
->>>>>>> 649dd92 (Register telemetry middleware.)
                             &request_head,
                         )
                         .await
@@ -380,14 +300,6 @@ async fn route_request(
     }
 }
 pub mod route_0 {
-<<<<<<< HEAD
-    pub async fn middleware_0() -> pavex::response::Response {
-        let v0 = crate::route_0::Next0 {
-            next: handler,
-        };
-        let v1 = pavex::middleware::Next::new(v0);
-        conduit_core::telemetry::logger(v1).await
-=======
     pub async fn middleware_0(
         v0: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
@@ -397,7 +309,6 @@ pub mod route_0 {
         };
         let v3 = pavex::middleware::Next::new(v2);
         conduit_core::telemetry::logger(v3, v1).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::status::ping();
@@ -424,14 +335,6 @@ pub mod route_1 {
     pub async fn middleware_0(
         v0: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_1::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v1 = conduit_core::telemetry::RootSpan::new(v0);
         let v2 = crate::route_1::Next0 {
             s_0: v0,
@@ -439,7 +342,6 @@ pub mod route_1 {
         };
         let v3 = pavex::middleware::Next::new(v2);
         conduit_core::telemetry::logger(v3, v1).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(v0: &pavex::request::RequestHead) -> pavex::response::Response {
         let v1 = pavex::extract::query::QueryParams::extract(v0);
@@ -479,29 +381,17 @@ pub mod route_1 {
 }
 pub mod route_2 {
     pub async fn middleware_0(
-<<<<<<< HEAD
         v0: hyper::body::Incoming,
-        v1: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v2 = crate::route_2::Next0 {
-=======
-        v0: hyper::Body,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_2::Next0 {
->>>>>>> 649dd92 (Register telemetry middleware.)
             s_0: v0,
             s_1: v1,
             next: handler,
         };
-<<<<<<< HEAD
-        let v3 = pavex::middleware::Next::new(v2);
-        conduit_core::telemetry::logger(v3).await
-=======
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -543,15 +433,9 @@ pub mod route_2 {
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-<<<<<<< HEAD
         s_0: hyper::body::Incoming,
         s_1: &'a pavex::request::RequestHead,
         next: fn(hyper::body::Incoming, &'a pavex::request::RequestHead) -> T,
-=======
-        s_0: hyper::Body,
-        s_1: &'a pavex::request::RequestHead,
-        next: fn(hyper::Body, &'a pavex::request::RequestHead) -> T,
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     impl<'a, T> std::future::IntoFuture for Next0<'a, T>
     where
@@ -569,14 +453,6 @@ pub mod route_3 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_3::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_3::Next0 {
             s_0: v0,
@@ -584,7 +460,6 @@ pub mod route_3 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -606,14 +481,14 @@ pub mod route_3 {
         let v3 = conduit_core::routes::articles::delete_article(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'b, 'a, T>
+    pub struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -629,14 +504,6 @@ pub mod route_4 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_4::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_4::Next0 {
             s_0: v0,
@@ -644,7 +511,6 @@ pub mod route_4 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -666,14 +532,14 @@ pub mod route_4 {
         let v3 = conduit_core::routes::articles::get_article(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'b, 'a, T>
+    pub struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -687,18 +553,11 @@ pub mod route_4 {
 pub mod route_5 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
-<<<<<<< HEAD
         v1: hyper::body::Incoming,
-        v2: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v3 = crate::route_5::Next0 {
-=======
-        v1: hyper::Body,
         v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v3 = conduit_core::telemetry::RootSpan::new(v2);
         let v4 = crate::route_5::Next0 {
->>>>>>> 649dd92 (Register telemetry middleware.)
             s_0: v1,
             s_1: v0,
             s_2: v2,
@@ -758,7 +617,6 @@ pub mod route_5 {
         let v10 = conduit_core::routes::articles::update_article(v9, v7);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v10)
     }
-<<<<<<< HEAD
     pub struct Next0<'b, 'a, 'c, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
@@ -768,26 +626,11 @@ pub mod route_5 {
         s_2: &'c pavex::request::RequestHead,
         next: fn(
             hyper::body::Incoming,
-=======
-    pub struct Next0<'a, 'b, 'c, T>
-    where
-        T: std::future::Future<Output = pavex::response::Response>,
-    {
-        s_0: hyper::Body,
-        s_1: pavex::extract::route::RawRouteParams<'a, 'b>,
-        s_2: &'c pavex::request::RequestHead,
-        next: fn(
-            hyper::Body,
->>>>>>> 649dd92 (Register telemetry middleware.)
             pavex::extract::route::RawRouteParams<'a, 'b>,
             &'c pavex::request::RequestHead,
         ) -> T,
     }
-<<<<<<< HEAD
     impl<'b, 'a, 'c, T> std::future::IntoFuture for Next0<'b, 'a, 'c, T>
-=======
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
->>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -803,14 +646,6 @@ pub mod route_6 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_6::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_6::Next0 {
             s_0: v0,
@@ -818,7 +653,6 @@ pub mod route_6 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -861,18 +695,11 @@ pub mod route_6 {
 pub mod route_7 {
     pub async fn middleware_0(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
-<<<<<<< HEAD
         v1: hyper::body::Incoming,
-        v2: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v3 = crate::route_7::Next0 {
-=======
-        v1: hyper::Body,
         v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v3 = conduit_core::telemetry::RootSpan::new(v2);
         let v4 = crate::route_7::Next0 {
->>>>>>> 649dd92 (Register telemetry middleware.)
             s_0: v1,
             s_1: v0,
             s_2: v2,
@@ -932,7 +759,6 @@ pub mod route_7 {
         let v10 = conduit_core::routes::articles::publish_comment(v9, v7);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v10)
     }
-<<<<<<< HEAD
     pub struct Next0<'b, 'a, 'c, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
@@ -942,26 +768,11 @@ pub mod route_7 {
         s_2: &'c pavex::request::RequestHead,
         next: fn(
             hyper::body::Incoming,
-=======
-    pub struct Next0<'a, 'b, 'c, T>
-    where
-        T: std::future::Future<Output = pavex::response::Response>,
-    {
-        s_0: hyper::Body,
-        s_1: pavex::extract::route::RawRouteParams<'a, 'b>,
-        s_2: &'c pavex::request::RequestHead,
-        next: fn(
-            hyper::Body,
->>>>>>> 649dd92 (Register telemetry middleware.)
             pavex::extract::route::RawRouteParams<'a, 'b>,
             &'c pavex::request::RequestHead,
         ) -> T,
     }
-<<<<<<< HEAD
     impl<'b, 'a, 'c, T> std::future::IntoFuture for Next0<'b, 'a, 'c, T>
-=======
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
->>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -977,14 +788,6 @@ pub mod route_8 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_8::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_8::Next0 {
             s_0: v0,
@@ -992,7 +795,6 @@ pub mod route_8 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1014,22 +816,14 @@ pub mod route_8 {
         let v3 = conduit_core::routes::articles::delete_comment(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-<<<<<<< HEAD
-    pub struct Next0<'b, 'a, T>
-=======
     pub struct Next0<'a, 'b, T>
->>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-<<<<<<< HEAD
-    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
-=======
     impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
->>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1045,14 +839,6 @@ pub mod route_9 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_9::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_9::Next0 {
             s_0: v0,
@@ -1060,7 +846,6 @@ pub mod route_9 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1105,14 +890,6 @@ pub mod route_10 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_10::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_10::Next0 {
             s_0: v0,
@@ -1120,7 +897,6 @@ pub mod route_10 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1142,14 +918,14 @@ pub mod route_10 {
         let v3 = conduit_core::routes::articles::favorite_article(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'a, 'b, T>
+    pub struct Next0<'b, 'a, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1164,14 +940,6 @@ pub mod route_11 {
     pub async fn middleware_0(
         v0: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_11::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v1 = conduit_core::telemetry::RootSpan::new(v0);
         let v2 = crate::route_11::Next0 {
             s_0: v0,
@@ -1179,7 +947,6 @@ pub mod route_11 {
         };
         let v3 = pavex::middleware::Next::new(v2);
         conduit_core::telemetry::logger(v3, v1).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(v0: &pavex::request::RequestHead) -> pavex::response::Response {
         let v1 = pavex::extract::query::QueryParams::extract(v0);
@@ -1222,14 +989,6 @@ pub mod route_12 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_12::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_12::Next0 {
             s_0: v0,
@@ -1237,7 +996,6 @@ pub mod route_12 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1259,22 +1017,14 @@ pub mod route_12 {
         let v3 = conduit_core::routes::profiles::get_profile(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-<<<<<<< HEAD
-    pub struct Next0<'a, 'b, T>
-=======
     pub struct Next0<'b, 'a, T>
->>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-<<<<<<< HEAD
-    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
-=======
     impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
->>>>>>> 649dd92 (Register telemetry middleware.)
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1290,14 +1040,6 @@ pub mod route_13 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_13::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_13::Next0 {
             s_0: v0,
@@ -1305,7 +1047,6 @@ pub mod route_13 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1350,14 +1091,6 @@ pub mod route_14 {
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-<<<<<<< HEAD
-        let v1 = crate::route_14::Next0 {
-            s_0: v0,
-            next: handler,
-        };
-        let v2 = pavex::middleware::Next::new(v1);
-        conduit_core::telemetry::logger(v2).await
-=======
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_14::Next0 {
             s_0: v0,
@@ -1365,7 +1098,6 @@ pub mod route_14 {
         };
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: pavex::extract::route::RawRouteParams<'_, '_>,
@@ -1387,14 +1119,14 @@ pub mod route_14 {
         let v3 = conduit_core::routes::profiles::follow_profile(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'a, 'b, T>
+    pub struct Next0<'b, 'a, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1406,14 +1138,6 @@ pub mod route_14 {
     }
 }
 pub mod route_15 {
-<<<<<<< HEAD
-    pub async fn middleware_0() -> pavex::response::Response {
-        let v0 = crate::route_15::Next0 {
-            next: handler,
-        };
-        let v1 = pavex::middleware::Next::new(v0);
-        conduit_core::telemetry::logger(v1).await
-=======
     pub async fn middleware_0(
         v0: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
@@ -1423,7 +1147,6 @@ pub mod route_15 {
         };
         let v3 = pavex::middleware::Next::new(v2);
         conduit_core::telemetry::logger(v3, v1).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::tags::get_tags();
@@ -1447,14 +1170,6 @@ pub mod route_15 {
     }
 }
 pub mod route_16 {
-<<<<<<< HEAD
-    pub async fn middleware_0() -> pavex::response::Response {
-        let v0 = crate::route_16::Next0 {
-            next: handler,
-        };
-        let v1 = pavex::middleware::Next::new(v0);
-        conduit_core::telemetry::logger(v1).await
-=======
     pub async fn middleware_0(
         v0: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
@@ -1464,7 +1179,6 @@ pub mod route_16 {
         };
         let v3 = pavex::middleware::Next::new(v2);
         conduit_core::telemetry::logger(v3, v1).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler() -> pavex::response::Response {
         let v0 = conduit_core::routes::users::get_user();
@@ -1489,29 +1203,17 @@ pub mod route_16 {
 }
 pub mod route_17 {
     pub async fn middleware_0(
-<<<<<<< HEAD
         v0: hyper::body::Incoming,
-        v1: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v2 = crate::route_17::Next0 {
-=======
-        v0: hyper::Body,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v2 = conduit_core::telemetry::RootSpan::new(v1);
         let v3 = crate::route_17::Next0 {
->>>>>>> 649dd92 (Register telemetry middleware.)
             s_0: v0,
             s_1: v1,
             next: handler,
         };
-<<<<<<< HEAD
-        let v3 = pavex::middleware::Next::new(v2);
-        conduit_core::telemetry::logger(v3).await
-=======
         let v4 = pavex::middleware::Next::new(v3);
         conduit_core::telemetry::logger(v4, v2).await
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     pub async fn handler(
         v0: hyper::body::Incoming,
@@ -1553,15 +1255,9 @@ pub mod route_17 {
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-<<<<<<< HEAD
         s_0: hyper::body::Incoming,
         s_1: &'a pavex::request::RequestHead,
         next: fn(hyper::body::Incoming, &'a pavex::request::RequestHead) -> T,
-=======
-        s_0: hyper::Body,
-        s_1: &'a pavex::request::RequestHead,
-        next: fn(hyper::Body, &'a pavex::request::RequestHead) -> T,
->>>>>>> 649dd92 (Register telemetry middleware.)
     }
     impl<'a, T> std::future::IntoFuture for Next0<'a, T>
     where
@@ -1576,21 +1272,9 @@ pub mod route_17 {
 }
 pub mod route_18 {
     pub async fn middleware_0(
-<<<<<<< HEAD
-        v0: &jsonwebtoken::EncodingKey,
-        v1: hyper::body::Incoming,
-        v2: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
-        v3: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v4 = crate::route_18::Next0 {
-            s_0: v2,
-            s_1: v3,
-            s_2: v1,
-            s_3: v0,
-=======
         v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         v1: &jsonwebtoken::EncodingKey,
-        v2: hyper::Body,
+        v2: hyper::body::Incoming,
         v3: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v4 = conduit_core::telemetry::RootSpan::new(v3);
@@ -1599,7 +1283,6 @@ pub mod route_18 {
             s_1: v3,
             s_2: v2,
             s_3: v1,
->>>>>>> 649dd92 (Register telemetry middleware.)
             next: handler,
         };
         let v6 = pavex::middleware::Next::new(v5);
@@ -1664,20 +1347,12 @@ pub mod route_18 {
     {
         s_0: &'a sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         s_1: &'b pavex::request::RequestHead,
-<<<<<<< HEAD
         s_2: hyper::body::Incoming,
-=======
-        s_2: hyper::Body,
->>>>>>> 649dd92 (Register telemetry middleware.)
         s_3: &'c jsonwebtoken::EncodingKey,
         next: fn(
             &'a sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
             &'b pavex::request::RequestHead,
-<<<<<<< HEAD
             hyper::body::Incoming,
-=======
-            hyper::Body,
->>>>>>> 649dd92 (Register telemetry middleware.)
             &'c jsonwebtoken::EncodingKey,
         ) -> T,
     }
@@ -1694,21 +1369,9 @@ pub mod route_18 {
 }
 pub mod route_19 {
     pub async fn middleware_0(
-<<<<<<< HEAD
-        v0: &jsonwebtoken::EncodingKey,
-        v1: hyper::body::Incoming,
-        v2: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
-        v3: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v4 = crate::route_19::Next0 {
-            s_0: v2,
-            s_1: v3,
-            s_2: v1,
-            s_3: v0,
-=======
         v0: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         v1: &jsonwebtoken::EncodingKey,
-        v2: hyper::Body,
+        v2: hyper::body::Incoming,
         v3: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
         let v4 = conduit_core::telemetry::RootSpan::new(v3);
@@ -1717,7 +1380,6 @@ pub mod route_19 {
             s_1: v3,
             s_2: v2,
             s_3: v1,
->>>>>>> 649dd92 (Register telemetry middleware.)
             next: handler,
         };
         let v6 = pavex::middleware::Next::new(v5);
@@ -1782,20 +1444,12 @@ pub mod route_19 {
     {
         s_0: &'a sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         s_1: &'b pavex::request::RequestHead,
-<<<<<<< HEAD
         s_2: hyper::body::Incoming,
-=======
-        s_2: hyper::Body,
->>>>>>> 649dd92 (Register telemetry middleware.)
         s_3: &'c jsonwebtoken::EncodingKey,
         next: fn(
             &'a sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
             &'b pavex::request::RequestHead,
-<<<<<<< HEAD
             hyper::body::Incoming,
-=======
-            hyper::Body,
->>>>>>> 649dd92 (Register telemetry middleware.)
             &'c jsonwebtoken::EncodingKey,
         ) -> T,
     }

--- a/examples/realworld/conduit_core/src/telemetry.rs
+++ b/examples/realworld/conduit_core/src/telemetry.rs
@@ -38,13 +38,12 @@ impl RootSpan {
             user_agent.original = %user_agent,
             http.response.status_code = tracing::field::Empty,
             http.route = %matched_route,
+            http.target = %request_head.uri.path_and_query().map(|p| p.as_str()).unwrap_or(""),
             // 👇 fields that we can't fill out _yet_ because we don't have access to connection info
-            //   nor the pattern that actually matched the request in the router.
             //
             // http.scheme = %$crate::root_span_macro::private::http_scheme(connection_info.scheme()),
             // http.host = %connection_info.host(),
             // http.client_ip = %$request.connection_info().realip_remote_addr().unwrap_or(""),
-            // http.target = %$request.uri().path_and_query().map(|p| p.as_str()).unwrap_or(""),
         );
         Self(span)
     }

--- a/examples/realworld/conduit_core/src/telemetry.rs
+++ b/examples/realworld/conduit_core/src/telemetry.rs
@@ -1,7 +1,58 @@
+use pavex::http::Version;
 use pavex::middleware::Next;
+use pavex::request::RequestHead;
 use pavex::response::Response;
+use std::borrow::Cow;
 use std::future::IntoFuture;
 use tokio::task::JoinHandle;
+
+/// A root span is the top-level *logical* span for an incoming request.  
+///
+/// It is not necessarily the top-level *physical* span, as it may be a child of
+/// another span (e.g. a span representing the underlying HTTP connection).
+///
+/// We use the root span to attach as much information as possible about the
+/// incoming request, and to record the final outcome of the request (success or
+/// failure).  
+pub struct RootSpan(tracing::Span);
+
+impl RootSpan {
+    pub fn new(request_head: &RequestHead) -> Self {
+        let user_agent = request_head
+            .headers
+            .get("User-Agent")
+            .map(|h| h.to_str().unwrap_or_default())
+            .unwrap_or_default();
+
+        let span = tracing::info_span!(
+            "HTTP request",
+            http.method = %request_head.method,
+            http.flavor = %http_flavor(request_head.version),
+            http.user_agent = %user_agent,
+            http.status_code = tracing::field::Empty,
+            // 👇 fields that we can't fill out _yet_ because we don't have access to connection info
+            //   nor the pattern that actually matched the request in the router.
+            //
+            // http.route = %http_route,
+            // http.scheme = %$crate::root_span_macro::private::http_scheme(connection_info.scheme()),
+            // http.host = %connection_info.host(),
+            // http.client_ip = %$request.connection_info().realip_remote_addr().unwrap_or(""),
+            // http.target = %$request.uri().path_and_query().map(|p| p.as_str()).unwrap_or(""),
+        );
+        Self(span)
+    }
+}
+
+fn http_flavor(version: Version) -> Cow<'static, str> {
+    match version {
+        Version::HTTP_09 => "0.9".into(),
+        Version::HTTP_10 => "1.0".into(),
+        Version::HTTP_11 => "1.1".into(),
+        Version::HTTP_2 => "2.0".into(),
+        Version::HTTP_3 => "3.0".into(),
+        other => format!("{other:?}").into(),
+    }
+}
 
 pub async fn logger<T>(next: Next<T>) -> Response
 where

--- a/examples/realworld/conduit_core/src/telemetry.rs
+++ b/examples/realworld/conduit_core/src/telemetry.rs
@@ -1,3 +1,4 @@
+use pavex::extract::route::MatchedRouteTemplate;
 use pavex::http::Version;
 use pavex::middleware::Next;
 use pavex::request::RequestHead;
@@ -23,7 +24,7 @@ impl RootSpan {
     ///
     /// We follow OpenTelemetry's HTTP semantic conventions as closely as
     /// possible for field naming.
-    pub fn new(request_head: &RequestHead) -> Self {
+    pub fn new(request_head: &RequestHead, matched_route: MatchedRouteTemplate) -> Self {
         let user_agent = request_head
             .headers
             .get("User-Agent")
@@ -36,10 +37,10 @@ impl RootSpan {
             http.flavor = %http_flavor(request_head.version),
             user_agent.original = %user_agent,
             http.response.status_code = tracing::field::Empty,
+            http.route = %matched_route,
             // 👇 fields that we can't fill out _yet_ because we don't have access to connection info
             //   nor the pattern that actually matched the request in the router.
             //
-            // http.route = %http_route,
             // http.scheme = %$crate::root_span_macro::private::http_scheme(connection_info.scheme()),
             // http.host = %connection_info.host(),
             // http.client_ip = %$request.connection_info().realip_remote_addr().unwrap_or(""),

--- a/libs/pavex/src/extract/route/matched_route.rs
+++ b/libs/pavex/src/extract/route/matched_route.rs
@@ -20,6 +20,11 @@ use std::fmt::Formatter;
 ///
 /// Then [`MatchedRouteTemplate`] will be set to `/home/:home_id` for a `GET /home/123` request.
 ///
+/// # Framework primitive
+///
+/// `MatchedRouteTemplate` is a framework primitive—you don't need to register any constructor
+/// with `Blueprint` to use it in your application.
+///
 /// # Use cases
 ///
 /// The primary use case for [`MatchedRouteTemplate`] is telemetry—logging, metrics, etc.  
@@ -27,6 +32,7 @@ use std::fmt::Formatter;
 /// your metrics and making it easier to aggregate them.
 ///
 /// [`Blueprint`]: crate::blueprint::Blueprint
+#[doc(alias("MatchedPath"))]
 pub struct MatchedRouteTemplate(&'static str);
 
 impl MatchedRouteTemplate {

--- a/libs/pavex/src/extract/route/matched_route.rs
+++ b/libs/pavex/src/extract/route/matched_route.rs
@@ -1,0 +1,30 @@
+use std::fmt::Formatter;
+
+#[derive(Debug, Clone, Copy)]
+pub struct MatchedRouteTemplate(&'static str);
+
+impl MatchedRouteTemplate {
+    /// Create a new matched route from a route template.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pavex::extract::route::MatchedRouteTemplate;
+    ///
+    /// let matched_route = MatchedRouteTemplate::new("/home/:home_id");
+    /// ```
+    pub fn new(route: &'static str) -> Self {
+        Self(route)
+    }
+
+    /// Get a reference to the underlying route template.
+    pub fn inner(self) -> &'static str {
+        self.0
+    }
+}
+
+impl std::fmt::Display for MatchedRouteTemplate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/libs/pavex/src/extract/route/matched_route.rs
+++ b/libs/pavex/src/extract/route/matched_route.rs
@@ -1,6 +1,32 @@
 use std::fmt::Formatter;
 
 #[derive(Debug, Clone, Copy)]
+/// The route template that matched for the incoming request.
+///
+/// # Example
+///
+/// If you configure your [`Blueprint`] like this:
+///
+/// ```rust
+/// use pavex::{f, blueprint::{Blueprint, router::GET}};
+/// # use pavex::{request::RequestHead, response::Response};
+/// # fn get_home(request: RequestHead) -> Response { todo!() }
+/// # fn main() {
+/// # let mut bp = Blueprint::new();
+///
+/// bp.route(GET, "/home/:home_id", f!(crate::get_home));
+/// # }
+/// ```
+///
+/// Then [`MatchedRouteTemplate`] will be set to `/home/:home_id` for a `GET /home/123` request.
+///
+/// # Use cases
+///
+/// The primary use case for [`MatchedRouteTemplate`] is telemetry—logging, metrics, etc.  
+/// It lets you strip away the dynamic parts of the request path, thus reducing the cardinality of
+/// your metrics and making it easier to aggregate them.
+///
+/// [`Blueprint`]: crate::blueprint::Blueprint
 pub struct MatchedRouteTemplate(&'static str);
 
 impl MatchedRouteTemplate {

--- a/libs/pavex/src/extract/route/mod.rs
+++ b/libs/pavex/src/extract/route/mod.rs
@@ -32,6 +32,7 @@
 //!
 //! [`RouteParams`]: struct@RouteParams
 
+pub use matched_route::MatchedRouteTemplate;
 /// Derive (de)serialization logic for a type that is going to be used to extract route parameters.
 ///
 /// This macro derives [`StructuralDeserialize`], [`serde::Serialize`] and [`serde::Deserialize`]
@@ -74,5 +75,6 @@ pub use route_params::RouteParams;
 
 mod deserializer;
 pub mod errors;
+mod matched_route;
 mod raw_route_params;
 mod route_params;

--- a/libs/pavex/src/extract/route/mod.rs
+++ b/libs/pavex/src/extract/route/mod.rs
@@ -1,5 +1,16 @@
 //! Extract data from the URL of incoming requests.
 //!
+//! # Overview
+//!
+//! When it comes to route information, there are two important extractors to be aware of:
+//!
+//! - [`RouteParams`]: extract route parameters from the URL of incoming requests
+//! - [`MatchedRouteTemplate`]: extract the route template that matched for the incoming request
+//!
+//! Check out their documentation for more details.
+//!
+//! # Example: route parameters
+//!
 //! ```rust
 //! use pavex::f;
 //! use pavex::blueprint::{router::GET, Blueprint, constructor::Lifecycle};

--- a/libs/pavex/src/extract/route/raw_route_params.rs
+++ b/libs/pavex/src/extract/route/raw_route_params.rs
@@ -24,6 +24,8 @@ use matchit::{Params, ParamsIter};
 /// }
 /// ```
 ///
+/// # Framework primitive
+///
 /// `RawRouteParams` is a framework primitive—you don't need to register any constructor
 /// with `Blueprint` to use it in your application.
 ///

--- a/libs/pavexc/src/compiler/app.rs
+++ b/libs/pavexc/src/compiler/app.rs
@@ -200,6 +200,7 @@ impl App {
             &self.codegen_deps,
             &self.component_db,
             &self.computation_db,
+            &self.framework_item_db,
         )?;
         Ok(GeneratedApp {
             lib_rs,


### PR DESCRIPTION
Now that the middleware infrastructure is in place, I can resume working on the Realworld implementation. In particular, on the logging middleware.

This PR fleshes out the primary fields, following OpenTelemetry's naming convention.  
It adds a new primitive extractor, `MatchedRouteTemplate`, in order to fulfil the requirements.

A few things are still missing though:

- Connection-level information, which is currently unavailable since we aren't propagating it down from the `Server`;
- Middlewares do not run if an incoming request fails to match one of the handlers that have been registered against the `Blueprint`. In order words, you get no logs for `404 Not Found` requests or for `405 Method Not Allowed`.

I'll try to lift both limitations in a follow-up PR.