### PR TITLE
Deterministic lifetime ordering

### DIFF
--- a/examples/realworld/api_server_sdk/src/lib.rs
+++ b/examples/realworld/api_server_sdk/src/lib.rs
@@ -1025,14 +1025,14 @@ pub mod route_9 {
         let v3 = conduit_core::routes::profiles::unfollow_profile(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'b, 'a, T>
+    pub struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1545,14 +1545,14 @@ pub mod route_18 {
         let v3 = conduit_core::routes::articles::list_comments(v2);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v3)
     }
-    pub struct Next0<'b, 'a, T>
+    pub struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: pavex::extract::route::RawRouteParams<'a, 'b>,
         next: fn(pavex::extract::route::RawRouteParams<'a, 'b>) -> T,
     }
-    impl<'b, 'a, T> std::future::IntoFuture for Next0<'b, 'a, T>
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1631,7 +1631,7 @@ pub mod route_19 {
         let v10 = conduit_core::routes::articles::publish_comment(v9, v7);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v10)
     }
-    pub struct Next0<'b, 'a, 'c, T>
+    pub struct Next0<'a, 'b, 'c, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -1644,7 +1644,7 @@ pub mod route_19 {
             &'c pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'b, 'a, 'c, T> std::future::IntoFuture for Next0<'b, 'a, 'c, T>
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {

--- a/libs/pavexc/src/compiler/analyses/processing_pipeline/codegen.rs
+++ b/libs/pavexc/src/compiler/analyses/processing_pipeline/codegen.rs
@@ -1,7 +1,6 @@
-use ahash::HashMap;
 use bimap::BiHashMap;
 use guppy::PackageId;
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 use syn::ItemFn;
@@ -56,7 +55,7 @@ impl RequestHandlerPipeline {
                 .map(|(name, ty_)| {
                     let mut ty_ = ty_.to_owned();
 
-                    let lifetime2binding: HashMap<_, _> = ty_
+                    let lifetime2binding: IndexMap<_, _> = ty_
                         .named_lifetime_parameters()
                         .into_iter()
                         .map(|lifetime| (lifetime, lifetime_generator.next()))

--- a/libs/pavexc/src/language/resolved_type.rs
+++ b/libs/pavexc/src/language/resolved_type.rs
@@ -6,7 +6,7 @@ use ahash::{HashMap, HashMapExt};
 use anyhow::Context;
 use bimap::BiHashMap;
 use guppy::PackageId;
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use serde::{Deserializer, Serializer};
 
 use crate::language::resolved_type::generics_equivalence::{
@@ -354,7 +354,7 @@ impl ResolvedType {
     /// Rename named lifetime parameters in this type according to the provided mapping.
     ///
     /// You don't need to provide a mapping for lifetimes that you don't want to rename.
-    pub fn rename_lifetime_parameters(&mut self, original2renamed: &HashMap<String, String>) {
+    pub fn rename_lifetime_parameters(&mut self, original2renamed: &IndexMap<String, String>) {
         match self {
             ResolvedType::ResolvedPath(t) => {
                 for arg in t.generic_arguments.iter_mut() {


### PR DESCRIPTION
The order of lifetimes in generated type definitions and impl blocks was not fully deterministic: we were iterating over the values of a `HashMap` in one of the intermediate steps for codegen.

This has now been replaced with a `IndexMap`, ensuring determinism.