### PR TITLE
Make sure error outputs are what we expect

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Generate quickstart tutorial
         run: |
           cd doc_examples/quickstart
-          tutorial_generator
+          tutorial_generator --verify
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/doc_examples/quickstart/.gitignore
+++ b/doc_examples/quickstart/.gitignore
@@ -1,3 +1,4 @@
 *
+!*.snap
 !*.patch
 !tutorial.yml

--- a/doc_examples/quickstart/05-error.snap
+++ b/doc_examples/quickstart/05-error.snap
@@ -1,0 +1,23 @@
+ERROR: 
+  × I can't invoke your request handler, `demo::routes::greet::greet`, because it needs an
+  │ instance of `demo::user_agent::UserAgent` as input, but I can't find a constructor for that
+  │ type.
+  │
+  │     ╭─[demo/src/blueprint.rs:14:1]
+  │  14 │     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
+  │  15 │     bp.route(GET, "/api/greet/:name", f!(crate::routes::greet::greet));
+  │     ·                                       ───────────────┬───────────────
+  │     ·                                                      ╰── The request handler was registered here
+  │  16 │     bp
+  │     ╰────
+  │     ╭─[demo/src/routes/greet.rs:13:1]
+  │  13 │ 
+  │  14 │ pub fn greet(params: RouteParams<GreetParams>, user_agent: UserAgent) -> Response {
+  │     ·                                                            ────┬────
+  │     ·                                                                ╰── I don't know how to construct an instance of this input parameter
+  │  15 │     if let UserAgent::Unknown = user_agent {
+  │     ╰────
+  │   help: Register a constructor for `demo::user_agent::UserAgent`
+
+Error: `pavex_cli` exited with a non-zero status code: 1
+error: Failed to run `bp`, the code generator for package `demo_server_sdk`

--- a/doc_examples/quickstart/07-error.snap
+++ b/doc_examples/quickstart/07-error.snap
@@ -1,0 +1,16 @@
+ERROR: 
+  × You registered a constructor that returns a `Result`, but you did not register an error
+  │ handler for it. If I don't have an error handler, I don't know what to do with the error when
+  │ the constructor fails!
+  │
+  │     ╭─[demo/src/blueprint.rs:12:1]
+  │  12 │     bp.constructor(
+  │  13 │         f!(crate::user_agent::UserAgent::extract),
+  │     ·         ────────────────────┬────────────────────
+  │     ·                             ╰── The fallible constructor was registered here
+  │  14 │         Lifecycle::RequestScoped,
+  │     ╰────
+  │   help: Add an error handler via `.error_handler`
+
+Error: `pavex_cli` exited with a non-zero status code: 1
+error: Failed to run `bp`, the code generator for package `demo_server_sdk`

--- a/doc_examples/quickstart/tutorial.yml
+++ b/doc_examples/quickstart/tutorial.yml
@@ -10,14 +10,14 @@ steps:
   - patch: "05-bis.patch"
     commands:
       - command: "cargo px c -q"
-        outcome: "failure"
-        save_at: "05-error.txt"
+        expected_outcome: "failure"
+        expected_output_at: "05-error.snap"
   - patch: "06.patch"
   - patch: "07.patch"
     commands:
       - command: "cargo px c -q"
-        outcome: "failure"
-        save_at: "07-error.txt"
+        expected_outcome: "failure"
+        expected_output_at: "07-error.snap"
   - patch: "08.patch"
   - patch: "09.patch"
   - patch: "10.patch"

--- a/doc_examples/tutorial_generator/Cargo.lock
+++ b/doc_examples/tutorial_generator/Cargo.lock
@@ -21,10 +21,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "equivalent"
@@ -83,6 +102,12 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -203,6 +228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+
+[[package]]
 name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,11 +249,13 @@ name = "tutorial_generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "console",
  "fs-err",
  "run_script",
  "serde",
  "serde_path_to_error",
  "serde_yaml",
+ "similar",
 ]
 
 [[package]]
@@ -230,6 +263,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -242,3 +281,69 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/doc_examples/tutorial_generator/Cargo.toml
+++ b/doc_examples/tutorial_generator/Cargo.toml
@@ -10,3 +10,5 @@ serde_yaml = "0.9.27"
 serde_path_to_error = "0.1"
 serde = { version = "1", features = ["derive"] }
 run_script = "0.10"
+similar = { version = "2.3", features = ["inline"] }
+console = "0.15.1"

--- a/doc_examples/tutorial_generator/src/main.rs
+++ b/doc_examples/tutorial_generator/src/main.rs
@@ -1,7 +1,11 @@
+use std::collections::HashMap;
 use std::io::Write;
+use std::time::Duration;
 
 use anyhow::Context;
+use console::style;
 use run_script::types::ScriptOptions;
+use similar::{Algorithm, ChangeTag, TextDiff};
 
 #[derive(Debug, serde::Deserialize)]
 struct TutorialManifest {
@@ -20,8 +24,8 @@ struct Step {
 #[derive(Debug, serde::Deserialize)]
 struct StepCommand {
     command: String,
-    outcome: StepCommandOutcome,
-    save_at: String,
+    expected_outcome: StepCommandOutcome,
+    expected_output_at: String,
 }
 
 #[derive(Debug, serde::Deserialize, Eq, PartialEq)]
@@ -32,6 +36,14 @@ enum StepCommandOutcome {
 }
 
 fn main() -> Result<(), anyhow::Error> {
+    // Check if we have a `--verify` flag
+    let verify = {
+        let mut args = std::env::args();
+        // Skip the first argument, which is the path to the executable
+        let _ = args.next();
+        args.next().as_deref() == Some("--verify")
+    };
+
     let tutorial_manifest = fs_err::read_to_string("tutorial.yml")
         .context("Failed to open the tutorial manifest file. Are you in the right directory?")?;
     let deserializer = serde_yaml::Deserializer::from_str(&tutorial_manifest);
@@ -42,45 +54,26 @@ fn main() -> Result<(), anyhow::Error> {
 
     // Boostrap the project
     println!("Running bootstrap script");
-    let (code, output, error) = run_script::run(
-        &tutorial_manifest.bootstrap,
-        &Default::default(),
-        &ScriptOptions::new(),
-    )
-    .expect("Failed to run the boostrap script");
-    if code != 0 {
-        eprintln!("Failed to run the boostrap script");
-        eprintln!("Exit Code: {}", code);
-        eprintln!("Output: {}", output);
-        eprintln!("Error: {}", error);
-        std::process::exit(1);
-    }
+    let script_outcome =
+        run_script(&tutorial_manifest.bootstrap).context("Failed to run the boostrap script")?;
+    script_outcome.exit_on_failure("Failed to run the boostrap script");
 
     // Apply the patches
     let mut previous_dir = tutorial_manifest.starter_project_folder;
     for step in &tutorial_manifest.steps {
         println!("Applying patch: {}", step.patch);
         let next_dir = patch_directory_name(&step.patch);
-        let (code, output, error) = run_script::run(
-            &format!(
-                r#"cp -r {previous_dir} {next_dir}
+        let script_outcome = run_script(&format!(
+            r#"cp -r {previous_dir} {next_dir}
             cd {next_dir} && patch -p1 < ../{} && git add . && git commit -am "{}""#,
-                step.patch, step.patch
-            ),
-            &Default::default(),
-            &ScriptOptions::new(),
-        )
-        .expect("Failed to run patch");
-        if code != 0 {
-            eprintln!("Failed to run patch");
-            eprintln!("Exit Code: {}", code);
-            eprintln!("Output: {}", output);
-            eprintln!("Error: {}", error);
-            std::process::exit(1);
-        }
+            step.patch, step.patch
+        ))
+        .context("Failed to apply patch")?;
+        script_outcome.exit_on_failure("Failed to apply patch");
         previous_dir = next_dir.to_string();
     }
 
+    let mut errors = vec![];
     for step in &tutorial_manifest.steps {
         for command in &step.commands {
             println!(
@@ -88,35 +81,54 @@ fn main() -> Result<(), anyhow::Error> {
                 step.patch, command.command
             );
             let patch_dir = patch_directory_name(&step.patch);
-            let (code, output, error) = run_script::run(
-                &format!(r#"cd {patch_dir} && {}"#, command.command),
-                &Default::default(),
-                &ScriptOptions::new(),
-            )
-            .expect("Failed to run command");
 
-            if command.outcome == StepCommandOutcome::Success && code != 0 {
-                eprintln!("Failed to run command which should have succeeded");
-                eprintln!("Exit Code: {}", code);
-                eprintln!("Output: {}", output);
-                eprintln!("Error: {}", error);
-                std::process::exit(1);
-            } else if command.outcome == StepCommandOutcome::Failure && code == 0 {
-                eprintln!("Command succeeded when it should have failed");
-                eprintln!("Exit Code: {}", code);
-                eprintln!("Output: {}", output);
-                eprintln!("Error: {}", error);
-                std::process::exit(1);
+            assert!(
+                command.expected_output_at.ends_with(".snap"),
+                "All expected output file must use the `.snap` file extension"
+            );
+
+            let script_outcome = run_script(&format!(r#"cd {patch_dir} && {}"#, command.command))?;
+
+            if command.expected_outcome == StepCommandOutcome::Success {
+                script_outcome.exit_on_failure("Failed to run command which should have succeeded");
+            } else if command.expected_outcome == StepCommandOutcome::Failure {
+                script_outcome.exit_on_success("Command succeeded when it should have failed");
             }
 
-            let mut file = fs_err::File::create(&command.save_at).expect("Failed to create file");
-            let contents = match command.outcome {
-                StepCommandOutcome::Success => output,
-                StepCommandOutcome::Failure => error,
+            let output = match command.expected_outcome {
+                StepCommandOutcome::Success => script_outcome.output,
+                StepCommandOutcome::Failure => script_outcome.error,
             };
-            file.write_all(contents.as_bytes())
-                .expect("Failed to write to file");
+            if verify {
+                let expected_output = fs_err::read_to_string(&command.expected_output_at)
+                    .context("Failed to read file")?;
+                if expected_output != output {
+                    let mut err_msg = format!(
+                        "Expected output did not match actual output for patch {} (command: `{}`).\n",
+                        step.patch,
+                        command.command,
+                    );
+                    print_changeset(&expected_output, &output, &mut err_msg)?;
+                    errors.push(err_msg);
+                }
+            } else {
+                let mut options = fs_err::OpenOptions::new();
+                options.write(true).create(true).truncate(true);
+                let mut file = options
+                    .open(&command.expected_output_at)
+                    .context("Failed to open/create expectation file")?;
+                file.write_all(output.as_bytes())
+                    .expect("Failed to write to expectation file");
+            }
         }
+    }
+
+    if !errors.is_empty() {
+        eprintln!("One or more snapshots didn't match the expected value.");
+        for error in errors {
+            eprintln!("{}", error);
+        }
+        std::process::exit(1);
     }
 
     Ok(())
@@ -138,6 +150,7 @@ fn clean_up() {
             let path = entry.path();
             let file_name = path.file_name().unwrap().to_str().unwrap();
             !file_name.ends_with(".patch")
+                && !file_name.ends_with(".snap")
                 && file_name != "tutorial.yml"
                 && file_name != ".gitignore"
         })
@@ -149,4 +162,142 @@ fn clean_up() {
                 fs_err::remove_file(entry.path()).expect("Failed to remove a file")
             }
         });
+}
+
+fn run_script(script: &str) -> Result<ScriptOutcome, anyhow::Error> {
+    let mut options = ScriptOptions::new();
+    let env_vars = HashMap::from([("PAVEX_TTY_WIDTH".to_string(), "100".to_string())]);
+    options.env_vars = Some(env_vars);
+
+    run_script::run(script, &Default::default(), &options)
+        .map(|(code, output, error)| ScriptOutcome {
+            code,
+            output,
+            error,
+        })
+        .context("Failed to run script")
+}
+
+struct ScriptOutcome {
+    code: i32,
+    output: String,
+    error: String,
+}
+
+impl ScriptOutcome {
+    fn exit_on_failure(&self, error_msg: &str) {
+        if self.code != 0 {
+            self.exit(error_msg);
+        }
+    }
+
+    fn exit_on_success(&self, error_msg: &str) {
+        if self.code == 0 {
+            self.exit(error_msg);
+        }
+    }
+
+    fn exit(&self, error_msg: &str) -> ! {
+        eprintln!("{error_msg}");
+        eprintln!("Exit Code: {}", self.code);
+        eprintln!("Output: {}", self.output);
+        eprintln!("Error: {}", self.error);
+        std::process::exit(1);
+    }
+}
+
+pub fn print_changeset(
+    old: &str,
+    new: &str,
+    buffer: &mut impl std::fmt::Write,
+) -> Result<(), anyhow::Error> {
+    let width: usize = 100;
+    let diff = TextDiff::configure()
+        .algorithm(Algorithm::Patience)
+        .timeout(Duration::from_millis(500))
+        .diff_lines(old, new);
+    writeln!(buffer, "{:─^1$}", "", width)?;
+
+    if !old.is_empty() {
+        writeln!(buffer, "{}", style("-old snapshot").red())?;
+        writeln!(buffer, "{}", style("+new results").green())?;
+    } else {
+        writeln!(buffer, "{}", style("+new results").green())?;
+    }
+
+    writeln!(buffer, "────────────┬{:─^1$}", "", width.saturating_sub(13))?;
+    let mut has_changes = false;
+    for (idx, group) in diff.grouped_ops(4).iter().enumerate() {
+        if idx > 0 {
+            writeln!(buffer, "┈┈┈┈┈┈┈┈┈┈┈┈┼{:┈^1$}", "", width.saturating_sub(13))?;
+        }
+        for op in group {
+            for change in diff.iter_inline_changes(op) {
+                match change.tag() {
+                    ChangeTag::Insert => {
+                        has_changes = true;
+                        write!(
+                            buffer,
+                            "{:>5} {:>5} │{}",
+                            "",
+                            style(change.new_index().unwrap()).cyan().dim().bold(),
+                            style("+").green(),
+                        )?;
+                        for &(emphasized, change) in change.values() {
+                            if emphasized {
+                                write!(buffer, "{}", style(change).green().underlined())?;
+                            } else {
+                                write!(buffer, "{}", style(change).green())?;
+                            }
+                        }
+                    }
+                    ChangeTag::Delete => {
+                        has_changes = true;
+                        write!(
+                            buffer,
+                            "{:>5} {:>5} │{}",
+                            style(change.old_index().unwrap()).cyan().dim(),
+                            "",
+                            style("-").red(),
+                        )?;
+                        for &(emphasized, change) in change.values() {
+                            if emphasized {
+                                write!(buffer, "{}", style(change).red().underlined())?;
+                            } else {
+                                write!(buffer, "{}", style(change).red())?;
+                            }
+                        }
+                    }
+                    ChangeTag::Equal => {
+                        write!(
+                            buffer,
+                            "{:>5} {:>5} │ ",
+                            style(change.old_index().unwrap()).cyan().dim(),
+                            style(change.new_index().unwrap()).cyan().dim().bold(),
+                        )?;
+                        for &(_, change) in change.values() {
+                            write!(buffer, "{}", style(change).dim())?;
+                        }
+                    }
+                }
+                if change.missing_newline() {
+                    writeln!(buffer,)?;
+                }
+            }
+        }
+    }
+
+    if !has_changes {
+        writeln!(
+            buffer,
+            "{:>5} {:>5} │{}",
+            "",
+            style("-").dim(),
+            style(" snapshots are matching").cyan(),
+        )?;
+    }
+
+    writeln!(buffer, "────────────┴{:─^1$}", "", width.saturating_sub(13),)?;
+
+    Ok(())
 }

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -278,7 +278,7 @@ Let's find out!
 If you try to build the project now, you'll get an error from Pavex:
 
 ```text
---8<-- "doc_examples/quickstart/05-error.txt"
+--8<-- "doc_examples/quickstart/05-error.snap"
 ```
 
 Pavex cannot do miracles, nor does it want to: it only knows how to construct a type if you tell it how to do so.
@@ -336,7 +336,7 @@ Let's change the signature of `UserAgent::extract` to return a `Result` instead:
 If you try to build the project now, you'll get an error from Pavex:
 
 ```text
---8<-- "doc_examples/quickstart/07-error.txt"
+--8<-- "doc_examples/quickstart/07-error.snap"
 ```
 
 Pavex is complaining: you can register a fallible constructor, but you must also register an error handler for it.

--- a/libs/pavex_cli/src/main.rs
+++ b/libs/pavex_cli/src/main.rs
@@ -7,15 +7,14 @@ use anyhow::Context;
 use cargo_generate::{GenerateArgs, TemplatePath};
 use clap::{Parser, Subcommand};
 use owo_colors::OwoColorize;
+use pavex::blueprint::Blueprint;
+use pavexc::App;
 use supports_color::Stream;
 use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
-
-use pavex::blueprint::Blueprint;
-use pavexc::App;
 
 #[derive(Parser)]
 #[clap(author, version = VERSION, about, long_about = None)]
@@ -120,6 +119,14 @@ fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
         } else {
             handler = handler.without_cause_chain()
         };
+        // This is an undocumented feature that allows us to force set the width of the
+        // terminal as seen by the graphical error handler.
+        // This is useful for testing/doc-generation purposes.
+        if let Ok(width) = std::env::var("PAVEX_TTY_WIDTH") {
+            if let Ok(width) = width.parse::<usize>() {
+                handler = handler.width(width);
+            }
+        }
         match cli.color {
             Color::Auto => {}
             Color::Always => {


### PR DESCRIPTION
I've added a `--verify` mode to `tutorial_generator`: expected error outputs are now committed to `.git` and we verify, in CI, that the auto-generated ones match what we expect.

This ensures that we never see again a regression like the one we fixed in #113: the step was failing as expected but with a completely different error from the one we wanted.