### PR TITLE
Add wrapping behaviour to code labels

### DIFF
--- a/doc_examples/quickstart/05-error.snap
+++ b/doc_examples/quickstart/05-error.snap
@@ -7,14 +7,14 @@ ERROR:
   │  13 │     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
   │  14 │     bp.route(GET, "/api/greet/:name", f!(crate::routes::greet::greet));
   │     ·                                       ───────────────┬───────────────
-  │     ·                                                      ╰── The request handler was registered here
+  │     ·            The request handler was registered here ──╯
   │  15 │     bp
   │     ╰────
   │     ╭─[demo/src/routes/greet.rs:10:1]
   │  10 │ 
   │  11 │ pub fn greet(params: RouteParams<GreetParams>, user_agent: UserAgent) -> Response {
   │     ·                                                            ────┬────
-  │     ·                                                                ╰── I don't know how to construct an instance of this input parameter
+  │     ·               I don't know how to construct an instance of this input parameter
   │  12 │     if let UserAgent::Unknown = user_agent {
   │     ╰────
   │   help: Register a constructor for `demo::user_agent::UserAgent`

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -263,7 +263,8 @@ dependencies = [
 [[package]]
 name = "cargo-generate"
 version = "0.18.5"
-source = "git+https://github.com/LukeMathWalker/cargo-generate?branch=main#3bf2c4b88732a9e5f6247997dbcc83f0feb9b9ef"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2885ae054e000b117515ab33e91c10eca90c2788a7baec1b97ada1f1f51e57"
 dependencies = [
  "anyhow",
  "auth-git2",

--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/cannot_return_the_unit_type/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/cannot_return_the_unit_type/expectations/stderr.txt
@@ -6,7 +6,7 @@
   [31m│[0m  [2m44[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m45[0m │     bp.constructor(f!(crate::constructor), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ───────────┬──────────[0m
-  [31m│[0m     ·                               [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                               [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m46[0m │     bp.constructor(
   [31m│[0m     ╰────
 
@@ -19,7 +19,7 @@
   [31m│[0m  [2m46[0m │     bp.constructor(
   [31m│[0m  [2m47[0m │         f!(crate::fallible_constructor_building_unit),
   [31m│[0m     · [35;1m        ──────────────────────┬──────────────────────[0m
-  [31m│[0m     ·                               [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                               [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m48[0m │         Lifecycle::RequestScoped,
   [31m│[0m     ╰────
 
@@ -33,7 +33,7 @@
   [31m│[0m  [2m56[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m  [2m57[0m │     bp.route(GET, "/unit", f!(crate::unit_handler));
   [31m│[0m     · [35;1m                           ───────────┬───────────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m58[0m │     bp.route(GET, "/fallible_unit", f!(crate::fallible_unit_handler))
   [31m│[0m     ╰────
 
@@ -47,7 +47,7 @@
   [31m│[0m  [2m57[0m │     bp.route(GET, "/unit", f!(crate::unit_handler));
   [31m│[0m  [2m58[0m │     bp.route(GET, "/fallible_unit", f!(crate::fallible_unit_handler))
   [31m│[0m     · [35;1m                                    ────────────────┬───────────────[0m
-  [31m│[0m     ·                                                     [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·          [35;1mThe request handler was registered here ──╯[0m
   [31m│[0m  [2m59[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
 
@@ -61,7 +61,7 @@
   [31m│[0m  [2m52[0m │ 
   [31m│[0m  [2m53[0m │     bp.wrap(f!(crate::unit_wrapping_middleware));
   [31m│[0m     · [35;1m            ─────────────────┬─────────────────[0m
-  [31m│[0m     ·                              [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                              [35;1m╰── The wrapping middleware was registered here[0m
   [31m│[0m  [2m54[0m │     bp.wrap(f!(crate::fallible_wrapping_middleware))
   [31m│[0m     ╰────
 
@@ -75,7 +75,7 @@
   [31m│[0m  [2m53[0m │     bp.wrap(f!(crate::unit_wrapping_middleware));
   [31m│[0m  [2m54[0m │     bp.wrap(f!(crate::fallible_wrapping_middleware))
   [31m│[0m     · [35;1m            ───────────────────┬───────────────────[0m
-  [31m│[0m     ·                                [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                                [35;1m╰── The wrapping middleware was registered here[0m
   [31m│[0m  [2m55[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
 
@@ -89,7 +89,7 @@
   [31m│[0m  [2m54[0m │     bp.wrap(f!(crate::fallible_wrapping_middleware))
   [31m│[0m  [2m55[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
   [31m│[0m  [2m56[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
 
@@ -103,7 +103,7 @@
   [31m│[0m  [2m58[0m │     bp.route(GET, "/fallible_unit", f!(crate::fallible_unit_handler))
   [31m│[0m  [2m59[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
   [31m│[0m  [2m60[0m │     bp
   [31m│[0m     ╰────
 
@@ -117,6 +117,6 @@
   [31m│[0m  [2m50[0m │     bp.constructor(f!(crate::fallible_constructor), Lifecycle::RequestScoped)
   [31m│[0m  [2m51[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
   [31m│[0m  [2m52[0m │ 
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/cannot_return_the_unit_type/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/cannot_return_the_unit_type/expectations/stderr.txt
@@ -33,7 +33,7 @@
   [31m│[0m  [2m56[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m  [2m57[0m │     bp.route(GET, "/unit", f!(crate::unit_handler));
   [31m│[0m     · [35;1m                           ───────────┬───────────[0m
-  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
+  [31m│[0m     ·                  [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m58[0m │     bp.route(GET, "/fallible_unit", f!(crate::fallible_unit_handler))
   [31m│[0m     ╰────
 
@@ -47,7 +47,7 @@
   [31m│[0m  [2m57[0m │     bp.route(GET, "/unit", f!(crate::unit_handler));
   [31m│[0m  [2m58[0m │     bp.route(GET, "/fallible_unit", f!(crate::fallible_unit_handler))
   [31m│[0m     · [35;1m                                    ────────────────┬───────────────[0m
-  [31m│[0m     ·          [35;1mThe request handler was registered here ──╯[0m
+  [31m│[0m     ·           [35;1mThe request handler was registered here ──╯[0m
   [31m│[0m  [2m59[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
 
@@ -61,7 +61,7 @@
   [31m│[0m  [2m52[0m │ 
   [31m│[0m  [2m53[0m │     bp.wrap(f!(crate::unit_wrapping_middleware));
   [31m│[0m     · [35;1m            ─────────────────┬─────────────────[0m
-  [31m│[0m     ·                              [35;1m╰── The wrapping middleware was registered here[0m
+  [31m│[0m     ·                [35;1mThe wrapping middleware was registered here[0m
   [31m│[0m  [2m54[0m │     bp.wrap(f!(crate::fallible_wrapping_middleware))
   [31m│[0m     ╰────
 
@@ -75,7 +75,7 @@
   [31m│[0m  [2m53[0m │     bp.wrap(f!(crate::unit_wrapping_middleware));
   [31m│[0m  [2m54[0m │     bp.wrap(f!(crate::fallible_wrapping_middleware))
   [31m│[0m     · [35;1m            ───────────────────┬───────────────────[0m
-  [31m│[0m     ·                                [35;1m╰── The wrapping middleware was registered here[0m
+  [31m│[0m     ·                [35;1mThe wrapping middleware was registered here[0m
   [31m│[0m  [2m55[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
 
@@ -89,7 +89,7 @@
   [31m│[0m  [2m54[0m │     bp.wrap(f!(crate::fallible_wrapping_middleware))
   [31m│[0m  [2m55[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
+  [31m│[0m     ·                   [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m56[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
 
@@ -103,7 +103,7 @@
   [31m│[0m  [2m58[0m │     bp.route(GET, "/fallible_unit", f!(crate::fallible_unit_handler))
   [31m│[0m  [2m59[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
+  [31m│[0m     ·                   [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m60[0m │     bp
   [31m│[0m     ╰────
 
@@ -117,6 +117,6 @@
   [31m│[0m  [2m50[0m │     bp.constructor(f!(crate::fallible_constructor), Lifecycle::RequestScoped)
   [31m│[0m  [2m51[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
+  [31m│[0m     ·                   [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m52[0m │ 
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/output_type_must_implement_into_response/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/output_type_must_implement_into_response/expectations/stderr.txt
@@ -7,7 +7,7 @@
   [31m│[0m  [2m37[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
   [31m│[0m     · [35;1m                           ─────────┬────────[0m
-  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
+  [31m│[0m     ·                  [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m39[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
@@ -37,7 +37,7 @@
   [31m│[0m  [2m34[0m │     bp.wrap(f!(crate::wrapping_middleware))
   [31m│[0m  [2m35[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
+  [31m│[0m     ·                   [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m36[0m │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
@@ -52,7 +52,7 @@
   [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
   [31m│[0m  [2m39[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
+  [31m│[0m     ·                   [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m40[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
@@ -67,7 +67,7 @@
   [31m│[0m  [2m36[0m │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
   [31m│[0m  [2m37[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
+  [31m│[0m     ·                   [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for

--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/output_type_must_implement_into_response/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/output_type_must_implement_into_response/expectations/stderr.txt
@@ -7,7 +7,7 @@
   [31m│[0m  [2m37[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
   [31m│[0m     · [35;1m                           ─────────┬────────[0m
-  [31m│[0m     ·                                     [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m39[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
@@ -22,7 +22,7 @@
   [31m│[0m  [2m33[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m34[0m │     bp.wrap(f!(crate::wrapping_middleware))
   [31m│[0m     · [35;1m            ───────────────┬──────────────[0m
-  [31m│[0m     ·                            [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                            [35;1m╰── The wrapping middleware was registered here[0m
   [31m│[0m  [2m35[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
@@ -37,7 +37,7 @@
   [31m│[0m  [2m34[0m │     bp.wrap(f!(crate::wrapping_middleware))
   [31m│[0m  [2m35[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
   [31m│[0m  [2m36[0m │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
@@ -52,7 +52,7 @@
   [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
   [31m│[0m  [2m39[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
   [31m│[0m  [2m40[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for
@@ -67,7 +67,7 @@
   [31m│[0m  [2m36[0m │     bp.constructor(f!(crate::request_scoped), Lifecycle::RequestScoped)
   [31m│[0m  [2m37[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
   [31m│[0m  [2m38[0m │     bp.route(GET, "/home", f!(crate::handler))
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mImplement `pavex::response::IntoResponse` for

--- a/libs/pavex_cli/tests/ui_tests/blueprint/constructors/constructors_input_parameters_cannot_be_generic/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/constructors/constructors_input_parameters_cannot_be_generic/expectations/stderr.txt
@@ -9,14 +9,14 @@
   [31m│[0m  [2m27[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m28[0m │     bp.constructor(f!(crate::generic_constructor), Lifecycle::RequestScoped);
   [31m│[0m     · [35;1m                   ───────────────┬──────────────[0m
-  [31m│[0m     ·                                   [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                                   [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m29[0m │     bp.constructor(
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn generic_constructor<T>(generic_input: GenericType<T>) -> u8 {
   [31m│[0m    · [35;1m                           ┬[0m[33;1m                                    ─┬[0m
-  [31m│[0m    ·                            [35;1m│[0m                                     [33;1m╰── [33;1m..because it is not used here[0m[0m
-  [31m│[0m    ·                            [35;1m╰── [35;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                            [35;1m│[0m     [33;1m..because it is not used here ──╯[0m
+  [31m│[0m    ·                            [35;1m╰── I can't infer this..[0m
   [31m│[0m  [2m2[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic
@@ -37,15 +37,15 @@
   [31m│[0m  [2m29[0m │     bp.constructor(
   [31m│[0m  [2m30[0m │         f!(crate::doubly_generic_constructor),
   [31m│[0m     · [35;1m        ──────────────────┬──────────────────[0m
-  [31m│[0m     ·                           [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                           [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m31[0m │         Lifecycle::RequestScoped,
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn doubly_generic_constructor<T, S>(i1: GenericType<T>, i2: GenericType<S>) -> u16 {
   [31m│[0m    · [35;1m                                  ┬[0m[33;1m  ┬[0m[32;1m                                             ─┬─[0m
-  [31m│[0m    ·                                   [35;1m│[0m  [33;1m│[0m                                              [32;1m╰── [32;1m..because they are not used here[0m[0m
-  [31m│[0m    ·                                   [35;1m│[0m  [33;1m╰── [33;1mI can't infer this..[0m[0m
-  [31m│[0m    ·                                   [35;1m╰── [35;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                                   [35;1m│[0m  [33;1m│[0m           [32;1m..because they are not used here ──╯[0m
+  [31m│[0m    ·                                   [35;1m│[0m  [33;1m╰── I can't infer this..[0m
+  [31m│[0m    ·                                   [35;1m╰── I can't infer this..[0m
   [31m│[0m  [2m2[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic
@@ -66,22 +66,22 @@
   [31m│[0m  [2m33[0m │     bp.constructor(
   [31m│[0m  [2m34[0m │         f!(crate::triply_generic_constructor),
   [31m│[0m     · [35;1m        ──────────────────┬──────────────────[0m
-  [31m│[0m     ·                           [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                           [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m35[0m │         Lifecycle::RequestScoped,
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn triply_generic_constructor<T, S, U>(
   [31m│[0m    · [35;1m                                  ┬[0m[33;1m  ┬[0m[32;1m  ┬[0m
-  [31m│[0m    ·                                   [35;1m│[0m  [33;1m│[0m  [32;1m╰── [32;1mI can't infer this..[0m[0m
-  [31m│[0m    ·                                   [35;1m│[0m  [33;1m╰── [33;1mI can't infer this..[0m[0m
-  [31m│[0m    ·                                   [35;1m╰── [35;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                                   [35;1m│[0m  [33;1m│[0m  [32;1m╰── I can't infer this..[0m
+  [31m│[0m    ·                                   [35;1m│[0m  [33;1m╰── I can't infer this..[0m
+  [31m│[0m    ·                                   [35;1m╰── I can't infer this..[0m
   [31m│[0m  [2m2[0m │     i1: GenericType<T>,
   [31m│[0m    ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:4:1]
   [31m│[0m  [2m4[0m │     i3: GenericType<U>,
   [31m│[0m  [2m5[0m │ ) -> u32 {
   [31m│[0m    · [35;1m     ─┬─[0m
-  [31m│[0m    ·       [35;1m╰── [35;1m..because they are not used here[0m[0m
+  [31m│[0m    ·       [35;1m╰── ..because they are not used here[0m
   [31m│[0m  [2m6[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic

--- a/libs/pavex_cli/tests/ui_tests/blueprint/constructors/output_type_of_constructors_cannot_be_a_naked_generic/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/constructors/output_type_of_constructors_cannot_be_a_naked_generic/expectations/stderr.txt
@@ -10,13 +10,13 @@
   [31m│[0m  [2m23[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m24[0m │     bp.constructor(f!(crate::naked), Lifecycle::RequestScoped);
   [31m│[0m     · [35;1m                   ────────┬───────[0m
-  [31m│[0m     ·                            [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                            [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m25[0m │     bp.constructor(f!(crate::fallible_naked), Lifecycle::RequestScoped)
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn naked<T>() -> T {
   [31m│[0m    · [35;1m                     ┬[0m
-  [31m│[0m    ·                      [35;1m╰── [35;1mThe invalid output type[0m[0m
+  [31m│[0m    ·                      [35;1m╰── The invalid output type[0m
   [31m│[0m  [2m2[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mCan you return a concrete type as output?
@@ -35,13 +35,13 @@
   [31m│[0m  [2m24[0m │     bp.constructor(f!(crate::naked), Lifecycle::RequestScoped);
   [31m│[0m  [2m25[0m │     bp.constructor(f!(crate::fallible_naked), Lifecycle::RequestScoped)
   [31m│[0m     · [35;1m                   ────────────┬────────────[0m
-  [31m│[0m     ·                                [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                                [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m26[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn fallible_naked<T>() -> Result<T, FallibleError> {
   [31m│[0m    · [35;1m                              ────────────┬───────────[0m
-  [31m│[0m    ·                                           [35;1m╰── [35;1mThe invalid output type[0m[0m
+  [31m│[0m    ·                                           [35;1m╰── The invalid output type[0m
   [31m│[0m  [2m2[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mCan you return a concrete type as output?

--- a/libs/pavex_cli/tests/ui_tests/blueprint/constructors/trait_constraints_on_runtime_singletons/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/constructors/trait_constraints_on_runtime_singletons/expectations/stderr.txt
@@ -5,7 +5,7 @@
   [31m│[0m  [2m52[0m │     bp.constructor(f!(crate::NonSendSingleton::new), Lifecycle::Singleton);
   [31m│[0m  [2m53[0m │     bp.constructor(f!(crate::NonCloneSingleton::new), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ────────────────┬────────────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m54[0m │     bp.constructor(f!(crate::NonSyncSingleton::new), Lifecycle::Singleton);
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAll singletons must implement the `Send`, `Sync` and `Clone` traits.
@@ -19,7 +19,7 @@
   [31m│[0m  [2m53[0m │     bp.constructor(f!(crate::NonCloneSingleton::new), Lifecycle::Singleton);
   [31m│[0m  [2m54[0m │     bp.constructor(f!(crate::NonSyncSingleton::new), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ────────────────┬───────────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m55[0m │     // The handler is needed because bounds are only checked for singletons
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAll singletons must implement the `Send`, `Sync` and `Clone` traits.
@@ -33,7 +33,7 @@
   [31m│[0m  [2m51[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m52[0m │     bp.constructor(f!(crate::NonSendSingleton::new), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ────────────────┬───────────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m53[0m │     bp.constructor(f!(crate::NonCloneSingleton::new), Lifecycle::Singleton);
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAll singletons must implement the `Send`, `Sync` and `Clone` traits.
@@ -47,7 +47,7 @@
   [31m│[0m  [2m51[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m52[0m │     bp.constructor(f!(crate::NonSendSingleton::new), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ────────────────┬───────────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The constructor was registered here[0m
   [31m│[0m  [2m53[0m │     bp.constructor(f!(crate::NonCloneSingleton::new), Lifecycle::Singleton);
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAll singletons must implement the `Send`, `Sync` and `Clone` traits.

--- a/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/cannot_register_an_error_handler_for_a_sync_infallible_constructor/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/cannot_register_an_error_handler_for_a_sync_infallible_constructor/expectations/stderr.txt
@@ -6,7 +6,7 @@
   [31m│[0m  [2m23[0m │     bp.constructor(f!(crate::infallible_constructor), Lifecycle::RequestScoped)
   [31m│[0m  [2m24[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe unnecessary error handler was registered here[0m[0m
+  [31m│[0m     ·               [35;1mThe unnecessary error handler was registered here[0m
   [31m│[0m  [2m25[0m │     bp.route(GET, "/home", f!(crate::request_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove the error handler, it is not needed. The constructor is

--- a/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/cannot_register_an_error_handler_for_a_sync_infallible_constructor/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/cannot_register_an_error_handler_for_a_sync_infallible_constructor/expectations/stderr.txt
@@ -6,7 +6,7 @@
   [31m│[0m  [2m23[0m │     bp.constructor(f!(crate::infallible_constructor), Lifecycle::RequestScoped)
   [31m│[0m  [2m24[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·               [35;1mThe unnecessary error handler was registered here[0m
+  [31m│[0m     ·             [35;1mThe unnecessary error handler was registered here[0m
   [31m│[0m  [2m25[0m │     bp.route(GET, "/home", f!(crate::request_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove the error handler, it is not needed. The constructor is

--- a/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/cannot_register_an_error_handler_for_an_async_infallible_constructor/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/cannot_register_an_error_handler_for_an_async_infallible_constructor/expectations/stderr.txt
@@ -6,7 +6,7 @@
   [31m│[0m  [2m23[0m │     bp.constructor(f!(crate::infallible_constructor), Lifecycle::RequestScoped)
   [31m│[0m  [2m24[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe unnecessary error handler was registered here[0m[0m
+  [31m│[0m     ·               [35;1mThe unnecessary error handler was registered here[0m
   [31m│[0m  [2m25[0m │     bp.route(GET, "/home", f!(crate::request_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove the error handler, it is not needed. The constructor is

--- a/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/cannot_register_an_error_handler_for_an_async_infallible_constructor/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/cannot_register_an_error_handler_for_an_async_infallible_constructor/expectations/stderr.txt
@@ -6,7 +6,7 @@
   [31m│[0m  [2m23[0m │     bp.constructor(f!(crate::infallible_constructor), Lifecycle::RequestScoped)
   [31m│[0m  [2m24[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·               [35;1mThe unnecessary error handler was registered here[0m
+  [31m│[0m     ·             [35;1mThe unnecessary error handler was registered here[0m
   [31m│[0m  [2m25[0m │     bp.route(GET, "/home", f!(crate::request_handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove the error handler, it is not needed. The constructor is

--- a/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/error_handlers_must_take_a_reference_to_the_error_as_input/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/error_handlers_must_take_a_reference_to_the_error_as_input/expectations/stderr.txt
@@ -8,6 +8,6 @@
   [31m│[0m  [2m22[0m │     bp.constructor(f!(crate::fallible_constructor), Lifecycle::RequestScoped)
   [31m│[0m  [2m23[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
+  [31m│[0m     ·                   [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m24[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/error_handlers_must_take_a_reference_to_the_error_as_input/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/error_handlers_must_take_a_reference_to_the_error_as_input/expectations/stderr.txt
@@ -8,6 +8,6 @@
   [31m│[0m  [2m22[0m │     bp.constructor(f!(crate::fallible_constructor), Lifecycle::RequestScoped)
   [31m│[0m  [2m23[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m     · [35;1m                       ────────────┬───────────[0m
-  [31m│[0m     ·                                    [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·                                    [35;1m╰── The error handler was registered here[0m
   [31m│[0m  [2m24[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/generics_in_error_handlers_must_be_tied_to_the_error/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/generics_in_error_handlers_must_be_tied_to_the_error/expectations/stderr.txt
@@ -9,7 +9,7 @@
   [31m│[0m  [2m53[0m │     bp.constructor(f!(crate::constructor1), Lifecycle::RequestScoped)
   [31m│[0m  [2m54[0m │         .error_handler(f!(crate::generic_error_handler));
   [31m│[0m     · [35;1m                       ────────────────┬───────────────[0m
-  [31m│[0m     ·                     [35;1mThe error handler was registered here[0m
+  [31m│[0m     ·                   [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m55[0m │     bp.constructor(f!(crate::constructor2), Lifecycle::RequestScoped)
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
@@ -37,7 +37,7 @@
   [31m│[0m  [2m55[0m │     bp.constructor(f!(crate::constructor2), Lifecycle::RequestScoped)
   [31m│[0m  [2m56[0m │         .error_handler(f!(crate::doubly_generic_error_handler));
   [31m│[0m     · [35;1m                       ───────────────────┬───────────────────[0m
-  [31m│[0m     ·  [35;1mThe error handler was registered here ──╯[0m
+  [31m│[0m     ·   [35;1mThe error handler was registered here ──╯[0m
   [31m│[0m  [2m57[0m │     bp.constructor(f!(crate::constructor3), Lifecycle::Transient)
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
@@ -68,7 +68,7 @@
   [31m│[0m  [2m57[0m │     bp.constructor(f!(crate::constructor3), Lifecycle::Transient)
   [31m│[0m  [2m58[0m │         .error_handler(f!(crate::triply_generic_error_handler));
   [31m│[0m     · [35;1m                       ───────────────────┬───────────────────[0m
-  [31m│[0m     ·  [35;1mThe error handler was registered here ──╯[0m
+  [31m│[0m     ·   [35;1mThe error handler was registered here ──╯[0m
   [31m│[0m  [2m59[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]

--- a/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/generics_in_error_handlers_must_be_tied_to_the_error/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/error_handlers/generics_in_error_handlers_must_be_tied_to_the_error/expectations/stderr.txt
@@ -9,14 +9,14 @@
   [31m│[0m  [2m53[0m │     bp.constructor(f!(crate::constructor1), Lifecycle::RequestScoped)
   [31m│[0m  [2m54[0m │         .error_handler(f!(crate::generic_error_handler));
   [31m│[0m     · [35;1m                       ────────────────┬───────────────[0m
-  [31m│[0m     ·                                        [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·                     [35;1mThe error handler was registered here[0m
   [31m│[0m  [2m55[0m │     bp.constructor(f!(crate::constructor2), Lifecycle::RequestScoped)
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn generic_error_handler<T>(error: &Error, generic_input: GenericType<T>) -> Response {
   [31m│[0m    · [35;1m                             ┬[0m[33;1m  ──────┬──────[0m
-  [31m│[0m    ·                              [35;1m│[0m        [33;1m╰── [33;1m..because it is not used here[0m[0m
-  [31m│[0m    ·                              [35;1m╰── [35;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                              [35;1m│[0m        [33;1m╰── ..because it is not used here[0m
+  [31m│[0m    ·                              [35;1m╰── I can't infer this..[0m
   [31m│[0m  [2m2[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic
@@ -37,17 +37,17 @@
   [31m│[0m  [2m55[0m │     bp.constructor(f!(crate::constructor2), Lifecycle::RequestScoped)
   [31m│[0m  [2m56[0m │         .error_handler(f!(crate::doubly_generic_error_handler));
   [31m│[0m     · [35;1m                       ───────────────────┬───────────────────[0m
-  [31m│[0m     ·                                           [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·  [35;1mThe error handler was registered here ──╯[0m
   [31m│[0m  [2m57[0m │     bp.constructor(f!(crate::constructor3), Lifecycle::Transient)
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn doubly_generic_error_handler<T, S>(
   [31m│[0m    · [35;1m                                    ┬[0m[33;1m  ┬[0m
-  [31m│[0m    ·                                     [35;1m│[0m  [33;1m╰── [33;1mI can't infer this..[0m[0m
-  [31m│[0m    ·                                     [35;1m╰── [35;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                                     [35;1m│[0m  [33;1m╰── I can't infer this..[0m
+  [31m│[0m    ·                                     [35;1m╰── I can't infer this..[0m
   [31m│[0m  [2m2[0m │     error: &Error,
   [31m│[0m    · [32;1m    ──────┬──────[0m
-  [31m│[0m    ·           [32;1m╰── [32;1m..because they are not used here[0m[0m
+  [31m│[0m    ·           [32;1m╰── ..because they are not used here[0m
   [31m│[0m  [2m3[0m │     i1: GenericType<T>,
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic
@@ -68,18 +68,18 @@
   [31m│[0m  [2m57[0m │     bp.constructor(f!(crate::constructor3), Lifecycle::Transient)
   [31m│[0m  [2m58[0m │         .error_handler(f!(crate::triply_generic_error_handler));
   [31m│[0m     · [35;1m                       ───────────────────┬───────────────────[0m
-  [31m│[0m     ·                                           [35;1m╰── [35;1mThe error handler was registered here[0m[0m
+  [31m│[0m     ·  [35;1mThe error handler was registered here ──╯[0m
   [31m│[0m  [2m59[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn triply_generic_error_handler<T, S, U>(
   [31m│[0m    · [35;1m                                    ┬[0m[33;1m  ┬[0m[32;1m  ┬[0m
-  [31m│[0m    ·                                     [35;1m│[0m  [33;1m│[0m  [32;1m╰── [32;1mI can't infer this..[0m[0m
-  [31m│[0m    ·                                     [35;1m│[0m  [33;1m╰── [33;1mI can't infer this..[0m[0m
-  [31m│[0m    ·                                     [35;1m╰── [35;1mI can't infer this..[0m[0m
+  [31m│[0m    ·                                     [35;1m│[0m  [33;1m│[0m  [32;1m╰── I can't infer this..[0m
+  [31m│[0m    ·                                     [35;1m│[0m  [33;1m╰── I can't infer this..[0m
+  [31m│[0m    ·                                     [35;1m╰── I can't infer this..[0m
   [31m│[0m  [2m2[0m │     error: &Error,
   [31m│[0m    · [35;1m    ──────┬──────[0m
-  [31m│[0m    ·           [35;1m╰── [35;1m..because they are not used here[0m[0m
+  [31m│[0m    ·           [35;1m╰── ..because they are not used here[0m
   [31m│[0m  [2m3[0m │     i1: GenericType<T>,
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type(s) for the problematic generic

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nest_at_prefix_is_validated/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nest_at_prefix_is_validated/expectations/stderr.txt
@@ -11,7 +11,7 @@
   [31m│[0m  [2m12[0m │     // If the prefix is not empty, it **cannot** end with a `/`
   [31m│[0m  [2m13[0m │     bp.nest_at("/api/", sub_blueprint());
   [31m│[0m     · [35;1m               ───┬───[0m
-  [31m│[0m     ·                   [35;1m╰── [35;1mThe prefix ending with a trailing '/'[0m[0m
+  [31m│[0m     ·                   [35;1m╰── The prefix ending with a trailing '/'[0m
   [31m│[0m  [2m14[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove the '/' at the end of the path prefix to fix this error: use
@@ -25,7 +25,7 @@
   [31m│[0m  [2m10[0m │     // If the prefix is not empty, it **must** start with a `/`
   [31m│[0m  [2m11[0m │     bp.nest_at("api", sub_blueprint());
   [31m│[0m     · [35;1m               ──┬──[0m
-  [31m│[0m     ·                  [35;1m╰── [35;1mThe prefix missing a leading '/'[0m[0m
+  [31m│[0m     ·                  [35;1m╰── The prefix missing a leading '/'[0m
   [31m│[0m  [2m12[0m │     // If the prefix is not empty, it **cannot** end with a `/`
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAdd a '/' at the beginning of the path prefix to fix this error: use
@@ -38,7 +38,7 @@
   [31m│[0m  [2m 8[0m │     // The prefix cannot be empty
   [31m│[0m  [2m 9[0m │     bp.nest_at("", sub_blueprint());
   [31m│[0m     · [35;1m               ─┬[0m
-  [31m│[0m     ·                 [35;1m╰── [35;1mThe empty prefix[0m[0m
+  [31m│[0m     ·                 [35;1m╰── The empty prefix[0m
   [31m│[0m  [2m10[0m │     // If the prefix is not empty, it **must** start with a `/`
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mIf you don't want to add a common prefix to all routes in the nested

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_fails_if_parent_singleton_is_overridden/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_fails_if_parent_singleton_is_overridden/expectations/stderr.txt
@@ -10,14 +10,14 @@
   [31m│[0m  [2m 8[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m 9[0m │     bp.constructor(f!(crate::singleton), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ──────────┬─────────[0m
-  [31m│[0m     ·                              [35;1m╰── [35;1mA constructor was registered here[0m[0m
+  [31m│[0m     ·                              [35;1m╰── A constructor was registered here[0m
   [31m│[0m  [2m10[0m │     bp.route(GET, "/parent", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:28:1]
   [31m│[0m  [2m28[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m29[0m │     bp.constructor(f!(crate::overridden_singleton), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ───────────────┬───────────────[0m
-  [31m│[0m     ·                                   [35;1m╰── [35;1mA constructor was registered here[0m[0m
+  [31m│[0m     ·                                   [35;1m╰── A constructor was registered here[0m
   [31m│[0m  [2m30[0m │     bp.route(GET, "/child", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mIf you want a single instance of `u64`, remove constructors for

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_fails_if_the_same_singleton_constructor_is_registered_in_different_scopes/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_fails_if_the_same_singleton_constructor_is_registered_in_different_scopes/expectations/stderr.txt
@@ -28,7 +28,7 @@
   [31m│[0m        [2m7[0m │ pub fn blueprint() -> Blueprint {
   [31m│[0m        [2m8[0m │     let mut bp = Blueprint::new();
   [31m│[0m          · [35;1m                 ────────┬───────[0m
-  [31m│[0m          ·                          [35;1m╰── Register your constructor against this blueprint[0m
+  [31m│[0m          ·              [35;1mRegister your constructor against this blueprint[0m
   [31m│[0m        [2m9[0m │     bp.constructor(f!(crate::singleton), Lifecycle::Singleton);
   [31m│[0m          ╰────
   [31m│[0m [36m  help: [0mIf you want different instances, consider creating separate newtypes

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_fails_if_the_same_singleton_constructor_is_registered_in_different_scopes/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_fails_if_the_same_singleton_constructor_is_registered_in_different_scopes/expectations/stderr.txt
@@ -10,14 +10,14 @@
   [31m│[0m  [2m 8[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m 9[0m │     bp.constructor(f!(crate::singleton), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ──────────┬─────────[0m
-  [31m│[0m     ·                              [35;1m╰── [35;1mA constructor was registered here[0m[0m
+  [31m│[0m     ·                              [35;1m╰── A constructor was registered here[0m
   [31m│[0m  [2m10[0m │     bp.route(GET, "/parent", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:24:1]
   [31m│[0m  [2m24[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m25[0m │     bp.constructor(f!(crate::singleton), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ──────────┬─────────[0m
-  [31m│[0m     ·                              [35;1m╰── [35;1mA constructor was registered here[0m[0m
+  [31m│[0m     ·                              [35;1m╰── A constructor was registered here[0m
   [31m│[0m  [2m26[0m │     bp.route(GET, "/child", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m   [36mhelp:[0m If you want to share a single instance of `u64`, remove constructors
@@ -28,7 +28,7 @@
   [31m│[0m        [2m7[0m │ pub fn blueprint() -> Blueprint {
   [31m│[0m        [2m8[0m │     let mut bp = Blueprint::new();
   [31m│[0m          · [35;1m                 ────────┬───────[0m
-  [31m│[0m          ·                          [35;1m╰── [35;1mRegister your constructor against this blueprint[0m[0m
+  [31m│[0m          ·                          [35;1m╰── Register your constructor against this blueprint[0m
   [31m│[0m        [2m9[0m │     bp.constructor(f!(crate::singleton), Lifecycle::Singleton);
   [31m│[0m          ╰────
   [31m│[0m [36m  help: [0mIf you want different instances, consider creating separate newtypes

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_hides_constructors_of_the_nested_bp_to_the_parent_bp/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_hides_constructors_of_the_nested_bp_to_the_parent_bp/expectations/stderr.txt
@@ -6,14 +6,14 @@
   [31m│[0m  [2m 9[0m │     bp.nest(sub_blueprint());
   [31m│[0m  [2m10[0m │     bp.route(GET, "/parent", f!(crate::handler));
   [31m│[0m     · [35;1m                             ─────────┬────────[0m
-  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
+  [31m│[0m     ·                  [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:25:1]
   [31m│[0m  [2m25[0m │ 
   [31m│[0m  [2m26[0m │ pub fn handler(_x: u64, _y: u32, _z: u16) -> StatusCode {
   [31m│[0m     · [35;1m                   ─┬─[0m
-  [31m│[0m     ·       [35;1mI don't know how to construct an instance of this input parameter[0m
+  [31m│[0m     ·     [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m27[0m │     todo!()
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `u64`
@@ -26,14 +26,14 @@
   [31m│[0m  [2m 9[0m │     bp.nest(sub_blueprint());
   [31m│[0m  [2m10[0m │     bp.route(GET, "/parent", f!(crate::handler));
   [31m│[0m     · [35;1m                             ─────────┬────────[0m
-  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
+  [31m│[0m     ·                  [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:25:1]
   [31m│[0m  [2m25[0m │ 
   [31m│[0m  [2m26[0m │ pub fn handler(_x: u64, _y: u32, _z: u16) -> StatusCode {
   [31m│[0m     · [35;1m                            ─┬─[0m
-  [31m│[0m     ·       [35;1mI don't know how to construct an instance of this input parameter[0m
+  [31m│[0m     ·     [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m27[0m │     todo!()
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `u32`
@@ -46,14 +46,14 @@
   [31m│[0m  [2m 9[0m │     bp.nest(sub_blueprint());
   [31m│[0m  [2m10[0m │     bp.route(GET, "/parent", f!(crate::handler));
   [31m│[0m     · [35;1m                             ─────────┬────────[0m
-  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
+  [31m│[0m     ·                  [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:25:1]
   [31m│[0m  [2m25[0m │ 
   [31m│[0m  [2m26[0m │ pub fn handler(_x: u64, _y: u32, _z: u16) -> StatusCode {
   [31m│[0m     · [35;1m                                     ─┬─[0m
-  [31m│[0m     ·       [35;1mI don't know how to construct an instance of this input parameter[0m
+  [31m│[0m     ·     [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m27[0m │     todo!()
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `u16`

--- a/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_hides_constructors_of_the_nested_bp_to_the_parent_bp/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/nesting/nesting_hides_constructors_of_the_nested_bp_to_the_parent_bp/expectations/stderr.txt
@@ -6,14 +6,14 @@
   [31m│[0m  [2m 9[0m │     bp.nest(sub_blueprint());
   [31m│[0m  [2m10[0m │     bp.route(GET, "/parent", f!(crate::handler));
   [31m│[0m     · [35;1m                             ─────────┬────────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:25:1]
   [31m│[0m  [2m25[0m │ 
   [31m│[0m  [2m26[0m │ pub fn handler(_x: u64, _y: u32, _z: u16) -> StatusCode {
   [31m│[0m     · [35;1m                   ─┬─[0m
-  [31m│[0m     ·                     [35;1m╰── [35;1mI don't know how to construct an instance of this input parameter[0m[0m
+  [31m│[0m     ·       [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m27[0m │     todo!()
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `u64`
@@ -26,14 +26,14 @@
   [31m│[0m  [2m 9[0m │     bp.nest(sub_blueprint());
   [31m│[0m  [2m10[0m │     bp.route(GET, "/parent", f!(crate::handler));
   [31m│[0m     · [35;1m                             ─────────┬────────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:25:1]
   [31m│[0m  [2m25[0m │ 
   [31m│[0m  [2m26[0m │ pub fn handler(_x: u64, _y: u32, _z: u16) -> StatusCode {
   [31m│[0m     · [35;1m                            ─┬─[0m
-  [31m│[0m     ·                              [35;1m╰── [35;1mI don't know how to construct an instance of this input parameter[0m[0m
+  [31m│[0m     ·       [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m27[0m │     todo!()
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `u32`
@@ -46,14 +46,14 @@
   [31m│[0m  [2m 9[0m │     bp.nest(sub_blueprint());
   [31m│[0m  [2m10[0m │     bp.route(GET, "/parent", f!(crate::handler));
   [31m│[0m     · [35;1m                             ─────────┬────────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:25:1]
   [31m│[0m  [2m25[0m │ 
   [31m│[0m  [2m26[0m │ pub fn handler(_x: u64, _y: u32, _z: u16) -> StatusCode {
   [31m│[0m     · [35;1m                                     ─┬─[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mI don't know how to construct an instance of this input parameter[0m[0m
+  [31m│[0m     ·       [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m27[0m │     todo!()
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `u16`

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/ambiguous_fallback/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/ambiguous_fallback/expectations/stderr.txt
@@ -13,7 +13,7 @@
   [31m│[0m  [2m26[0m │     });
   [31m│[0m  [2m27[0m │     bp.route(POST, "/users/yo", f!(crate::handler));
   [31m│[0m     · [35;1m                   ─────┬─────[0m
-  [31m│[0m     ·                         [35;1m╰── [35;1mThe route was registered here[0m[0m
+  [31m│[0m     ·                         [35;1m╰── The route was registered here[0m
   [31m│[0m  [2m28[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mYou can fix this by registering `POST /users/yo` against the nested

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/conflicting_any_and_single_method_guards/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/conflicting_any_and_single_method_guards/expectations/stderr.txt
@@ -6,14 +6,14 @@
   [31m│[0m  [2m16[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m17[0m │     bp.route(ANY, "/home", f!(crate::handler_1));
   [31m│[0m     · [35;1m                           ──────────┬─────────[0m
-  [31m│[0m     ·                                      [35;1m╰── [35;1mThe first conflicting handler[0m[0m
+  [31m│[0m     ·                                      [35;1m╰── The first conflicting handler[0m
   [31m│[0m  [2m18[0m │     bp.route(GET, "/home", f!(crate::handler_2));
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:17:1]
   [31m│[0m  [2m17[0m │     bp.route(ANY, "/home", f!(crate::handler_1));
   [31m│[0m  [2m18[0m │     bp.route(GET, "/home", f!(crate::handler_2));
   [31m│[0m     · [35;1m                           ──────────┬─────────[0m
-  [31m│[0m     ·                                      [35;1m╰── [35;1mThe second conflicting handler[0m[0m
+  [31m│[0m     ·                                      [35;1m╰── The second conflicting handler[0m
   [31m│[0m  [2m19[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mYou can only register one request handler for each path+method

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/different_fallback_for_each_method/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/different_fallback_for_each_method/expectations/stderr.txt
@@ -13,14 +13,14 @@
   [31m│[0m  [2m29[0m │         bp.route(POST, "/id", f!(crate::handler));
   [31m│[0m  [2m30[0m │         bp.fallback(f!(crate::fallback2));
   [31m│[0m     · [35;1m                    ──────────┬─────────[0m
-  [31m│[0m     ·                               [35;1m╰── [35;1mThe first fallback[0m[0m
+  [31m│[0m     ·                               [35;1m╰── The first fallback[0m
   [31m│[0m  [2m31[0m │         bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:23:1]
   [31m│[0m  [2m23[0m │         bp.route(GET, "/id", f!(crate::handler));
   [31m│[0m  [2m24[0m │         bp.fallback(f!(crate::fallback1));
   [31m│[0m     · [35;1m                    ──────────┬─────────[0m
-  [31m│[0m     ·                               [35;1m╰── [35;1mThe second fallback[0m[0m
+  [31m│[0m     ·                               [35;1m╰── The second fallback[0m
   [31m│[0m  [2m25[0m │         bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAdjust your blueprint to have the same fallback handler for all `/

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/invalid_paths/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/invalid_paths/expectations/stderr.txt
@@ -5,7 +5,7 @@
   [31m│[0m  [2m12[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m13[0m │     bp.route(ANY, "/:too:many:params", f!(crate::handler));
   [31m│[0m     · [35;1m                  ─────────┬─────────[0m
-  [31m│[0m     ·                            [35;1m╰── [35;1mThe problematic path[0m[0m
+  [31m│[0m     ·                            [35;1m╰── The problematic path[0m
   [31m│[0m  [2m14[0m │     bp.route(GET, "/*invalid_catch_all/hey", f!(crate::handler));
   [31m│[0m     ╰────
 
@@ -16,7 +16,7 @@
   [31m│[0m  [2m13[0m │     bp.route(ANY, "/:too:many:params", f!(crate::handler));
   [31m│[0m  [2m14[0m │     bp.route(GET, "/*invalid_catch_all/hey", f!(crate::handler));
   [31m│[0m     · [35;1m                  ────────────┬────────────[0m
-  [31m│[0m     ·                               [35;1m╰── [35;1mThe problematic path[0m[0m
+  [31m│[0m     ·                               [35;1m╰── The problematic path[0m
   [31m│[0m  [2m15[0m │     bp.route(GET, "/home/:id", f!(crate::handler));
   [31m│[0m     ╰────
 
@@ -28,7 +28,7 @@
   [31m│[0m  [2m16[0m │     // Route conflict with the previous one
   [31m│[0m  [2m17[0m │     bp.route(GET, "/home/:home_id", f!(crate::handler));
   [31m│[0m     · [35;1m                  ────────┬───────[0m
-  [31m│[0m     ·                           [35;1m╰── [35;1mThe problematic path[0m[0m
+  [31m│[0m     ·                           [35;1m╰── The problematic path[0m
   [31m│[0m  [2m18[0m │     // Unnamed parameter
   [31m│[0m     ╰────
 
@@ -40,6 +40,6 @@
   [31m│[0m  [2m18[0m │     // Unnamed parameter
   [31m│[0m  [2m19[0m │     bp.route(GET, "/room/:", f!(crate::handler));
   [31m│[0m     · [35;1m                  ────┬────[0m
-  [31m│[0m     ·                       [35;1m╰── [35;1mThe problematic path[0m[0m
+  [31m│[0m     ·                       [35;1m╰── The problematic path[0m
   [31m│[0m  [2m20[0m │     bp
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/route_path_is_validated/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/route_path_is_validated/expectations/stderr.txt
@@ -6,7 +6,7 @@
   [31m│[0m  [2m12[0m │     // If the path is not empty, it *must* start with a `/`
   [31m│[0m  [2m13[0m │     bp.route(GET, "api", f!(crate::handler));
   [31m│[0m     · [35;1m                  ──┬──[0m
-  [31m│[0m     ·                     [35;1m╰── [35;1mThe path missing a leading '/'[0m[0m
+  [31m│[0m     ·                     [35;1m╰── The path missing a leading '/'[0m
   [31m│[0m  [2m14[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAdd a '/' at the beginning of the route path to fix this error: use

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/structs_cannot_be_registered_as_handlers/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/structs_cannot_be_registered_as_handlers/expectations/stderr.txt
@@ -6,6 +6,6 @@
   [31m│[0m  [2m7[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m8[0m │     bp.route(GET, "/home", f!(crate::Streamer));
   [31m│[0m    · [35;1m                           ─────────┬─────────[0m
-  [31m│[0m    ·                   [35;1mIt was registered as a request handler here[0m
+  [31m│[0m    ·                 [35;1mIt was registered as a request handler here[0m
   [31m│[0m  [2m9[0m │     bp
   [31m│[0m    ╰────

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/structs_cannot_be_registered_as_handlers/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/structs_cannot_be_registered_as_handlers/expectations/stderr.txt
@@ -6,6 +6,6 @@
   [31m│[0m  [2m7[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m8[0m │     bp.route(GET, "/home", f!(crate::Streamer));
   [31m│[0m    · [35;1m                           ─────────┬─────────[0m
-  [31m│[0m    ·                                     [35;1m╰── [35;1mIt was registered as a request handler here[0m[0m
+  [31m│[0m    ·                   [35;1mIt was registered as a request handler here[0m
   [31m│[0m  [2m9[0m │     bp
   [31m│[0m    ╰────

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/cannot_have_multiple_next_inputs/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/cannot_have_multiple_next_inputs/expectations/stderr.txt
@@ -7,7 +7,7 @@
   [31m│[0m  [2m20[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m21[0m │     bp.wrap(f!(crate::mw));
   [31m│[0m     · [35;1m            ──────┬──────[0m
-  [31m│[0m     ·                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                   [35;1m╰── The wrapping middleware was registered here[0m
   [31m│[0m  [2m22[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove the extra `Next` input parameters until only one is left.

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/must_take_next_as_input/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/must_take_next_as_input/expectations/stderr.txt
@@ -7,6 +7,6 @@
   [31m│[0m  [2m14[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m15[0m │     bp.wrap(f!(crate::mw));
   [31m│[0m     · [35;1m            ──────┬──────[0m
-  [31m│[0m     ·                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                   [35;1m╰── The wrapping middleware was registered here[0m
   [31m│[0m  [2m16[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/next_must_take_a_naked_generic_parameter/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/next_must_take_a_naked_generic_parameter/expectations/stderr.txt
@@ -8,7 +8,7 @@
   [31m│[0m  [2m31[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m32[0m │     bp.wrap(f!(crate::mw));
   [31m│[0m     · [35;1m            ──────┬──────[0m
-  [31m│[0m     ·                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                   [35;1m╰── The wrapping middleware was registered here[0m
   [31m│[0m  [2m33[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mTake `Next<T>` rather than `Next<app::Custom<T>>` as input parameter

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/wrapping_middlewares_input_parameters_cannot_be_generic/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/wrapping_middlewares_input_parameters_cannot_be_generic/expectations/stderr.txt
@@ -9,7 +9,7 @@
   [31m│[0m  [2m45[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m46[0m │     bp.wrap(f!(crate::generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ───────────────────┬──────────────────[0m
-  [31m│[0m     ·                                [35;1m╰── The wrapping middleware was registered here[0m
+  [31m│[0m     ·                [35;1mThe wrapping middleware was registered here[0m
   [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
@@ -35,15 +35,15 @@
   [31m│[0m  [2m46[0m │     bp.wrap(f!(crate::generic_wrapping_middleware));
   [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ──────────────────────┬──────────────────────[0m
-  [31m│[0m     ·                  [35;1mThe wrapping middleware was registered here[0m
+  [31m│[0m     ·                [35;1mThe wrapping middleware was registered here[0m
   [31m│[0m  [2m48[0m │     bp.wrap(f!(crate::triply_generic_wrapping_middleware));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn doubly_generic_wrapping_middleware<A, T, S>(
   [31m│[0m    · [35;1m                                             ┬[0m[33;1m  ┬[0m
-  [31m│[0m    ·                                              [35;1m│[0m [33;1mThe generic parameter without a[0m
-  [31m│[0m    ·                                              [35;1m│[0m          [33;1mconcrete type[0m
-  [31m│[0m    ·                  [35;1mThe generic parameter without a concrete type[0m
+  [31m│[0m    ·                                              [35;1m│[0m[33;1mThe generic parameter without[0m
+  [31m│[0m    ·                                              [35;1m│[0m       [33;1ma concrete type[0m
+  [31m│[0m    ·                [35;1mThe generic parameter without a concrete type[0m
   [31m│[0m  [2m2[0m │     _next: Next<A>,
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete types for `T` and `S` when registering the
@@ -63,17 +63,17 @@
   [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
   [31m│[0m  [2m48[0m │     bp.wrap(f!(crate::triply_generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ──────────────────────┬──────────────────────[0m
-  [31m│[0m     ·                  [35;1mThe wrapping middleware was registered here[0m
+  [31m│[0m     ·                [35;1mThe wrapping middleware was registered here[0m
   [31m│[0m  [2m49[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn triply_generic_wrapping_middleware<A, T, S, U>(
   [31m│[0m    · [35;1m                                             ┬[0m[33;1m  ┬[0m[32;1m  ┬[0m
-  [31m│[0m    ·                                              [35;1m│[0m  [33;1m│[0m[32;1mThe generic parameter without a[0m
-  [31m│[0m    ·                                              [35;1m│[0m  [33;1m│[0m         [32;1mconcrete type[0m
-  [31m│[0m    ·                                              [35;1m│[0m [33;1mThe generic parameter without a[0m
-  [31m│[0m    ·                                              [35;1m│[0m          [33;1mconcrete type[0m
-  [31m│[0m    ·                  [35;1mThe generic parameter without a concrete type[0m
+  [31m│[0m    ·                                              [35;1m│[0m  [33;1m│[0m   [32;1mThe generic parameter[0m
+  [31m│[0m    ·                                              [35;1m│[0m  [33;1m│[0m  [32;1mwithout a concrete type[0m
+  [31m│[0m    ·                                              [35;1m│[0m[33;1mThe generic parameter without[0m
+  [31m│[0m    ·                                              [35;1m│[0m       [33;1ma concrete type[0m
+  [31m│[0m    ·                [35;1mThe generic parameter without a concrete type[0m
   [31m│[0m  [2m2[0m │     _next: Next<A>,
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete types for `T`, `S` and `U` when registering the

--- a/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/wrapping_middlewares_input_parameters_cannot_be_generic/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/wrapping_middlewares/wrapping_middlewares_input_parameters_cannot_be_generic/expectations/stderr.txt
@@ -9,13 +9,13 @@
   [31m│[0m  [2m45[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m46[0m │     bp.wrap(f!(crate::generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ───────────────────┬──────────────────[0m
-  [31m│[0m     ·                                [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                                [35;1m╰── The wrapping middleware was registered here[0m
   [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn generic_wrapping_middleware<A, T>(_next: Next<A>, generic_input: GenericType<T>) -> u8
   [31m│[0m    · [35;1m                                      ┬[0m
-  [31m│[0m    ·                                       [35;1m╰── [35;1mThe generic parameter without a concrete type[0m[0m
+  [31m│[0m    ·                                       [35;1m╰── The generic parameter without a concrete type[0m
   [31m│[0m  [2m2[0m │ where
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete type for `T` when registering the wrapping
@@ -35,14 +35,15 @@
   [31m│[0m  [2m46[0m │     bp.wrap(f!(crate::generic_wrapping_middleware));
   [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ──────────────────────┬──────────────────────[0m
-  [31m│[0m     ·                                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                  [35;1mThe wrapping middleware was registered here[0m
   [31m│[0m  [2m48[0m │     bp.wrap(f!(crate::triply_generic_wrapping_middleware));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn doubly_generic_wrapping_middleware<A, T, S>(
   [31m│[0m    · [35;1m                                             ┬[0m[33;1m  ┬[0m
-  [31m│[0m    ·                                              [35;1m│[0m  [33;1m╰── [33;1mThe generic parameter without a concrete type[0m[0m
-  [31m│[0m    ·                                              [35;1m╰── [35;1mThe generic parameter without a concrete type[0m[0m
+  [31m│[0m    ·                                              [35;1m│[0m [33;1mThe generic parameter without a[0m
+  [31m│[0m    ·                                              [35;1m│[0m          [33;1mconcrete type[0m
+  [31m│[0m    ·                  [35;1mThe generic parameter without a concrete type[0m
   [31m│[0m  [2m2[0m │     _next: Next<A>,
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete types for `T` and `S` when registering the
@@ -62,15 +63,17 @@
   [31m│[0m  [2m47[0m │     bp.wrap(f!(crate::doubly_generic_wrapping_middleware));
   [31m│[0m  [2m48[0m │     bp.wrap(f!(crate::triply_generic_wrapping_middleware));
   [31m│[0m     · [35;1m            ──────────────────────┬──────────────────────[0m
-  [31m│[0m     ·                                   [35;1m╰── [35;1mThe wrapping middleware was registered here[0m[0m
+  [31m│[0m     ·                  [35;1mThe wrapping middleware was registered here[0m
   [31m│[0m  [2m49[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:1:1]
   [31m│[0m  [2m1[0m │ pub fn triply_generic_wrapping_middleware<A, T, S, U>(
   [31m│[0m    · [35;1m                                             ┬[0m[33;1m  ┬[0m[32;1m  ┬[0m
-  [31m│[0m    ·                                              [35;1m│[0m  [33;1m│[0m  [32;1m╰── [32;1mThe generic parameter without a concrete type[0m[0m
-  [31m│[0m    ·                                              [35;1m│[0m  [33;1m╰── [33;1mThe generic parameter without a concrete type[0m[0m
-  [31m│[0m    ·                                              [35;1m╰── [35;1mThe generic parameter without a concrete type[0m[0m
+  [31m│[0m    ·                                              [35;1m│[0m  [33;1m│[0m[32;1mThe generic parameter without a[0m
+  [31m│[0m    ·                                              [35;1m│[0m  [33;1m│[0m         [32;1mconcrete type[0m
+  [31m│[0m    ·                                              [35;1m│[0m [33;1mThe generic parameter without a[0m
+  [31m│[0m    ·                                              [35;1m│[0m          [33;1mconcrete type[0m
+  [31m│[0m    ·                  [35;1mThe generic parameter without a concrete type[0m
   [31m│[0m  [2m2[0m │     _next: Next<A>,
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mSpecify the concrete types for `T`, `S` and `U` when registering the

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/control_flow/multiple_consumers_pass_takes_control_flow_into_account_for_errors/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/control_flow/multiple_consumers_pass_takes_control_flow_into_account_for_errors/expectations/stderr.txt
@@ -13,7 +13,7 @@
   [31m│[0m        [2m65[0m │         .error_handler(f!(crate::error_handler));
   [31m│[0m        [2m66[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m           ·                          [35;1m╰── The constructor was registered here[0m
   [31m│[0m        [2m67[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m Considering changing the signature of the components that consume
@@ -24,7 +24,7 @@
   [31m│[0m        [2m67[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m        [2m68[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m           · [35;1m                           ─────────┬────────[0m
-  [31m│[0m           ·                                     [35;1m╰── [35;1mOne of the consuming request handlers[0m[0m
+  [31m│[0m           ·                                     [35;1m╰── One of the consuming request handlers[0m
   [31m│[0m        [2m69[0m │     bp
   [31m│[0m           ╰────
   [31m│[0m        ☞
@@ -32,7 +32,7 @@
   [31m│[0m        [2m66[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m        [2m67[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mOne of the consuming constructors[0m[0m
+  [31m│[0m           ·                          [35;1m╰── One of the consuming constructors[0m
   [31m│[0m        [2m68[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m If `app::B` itself cannot implement `Clone`, consider wrapping it in

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/control_flow/multiple_consumers_pass_takes_control_flow_into_account_for_errors/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/control_flow/multiple_consumers_pass_takes_control_flow_into_account_for_errors/expectations/stderr.txt
@@ -24,7 +24,7 @@
   [31m│[0m        [2m67[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m        [2m68[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m           · [35;1m                           ─────────┬────────[0m
-  [31m│[0m           ·                                     [35;1m╰── One of the consuming request handlers[0m
+  [31m│[0m           ·                   [35;1mOne of the consuming request handlers[0m
   [31m│[0m        [2m69[0m │     bp
   [31m│[0m           ╰────
   [31m│[0m        ☞

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/diamond/diamond_cannot_be_solved_if_we_cannot_clone/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/diamond/diamond_cannot_be_solved_if_we_cannot_clone/expectations/stderr.txt
@@ -13,7 +13,7 @@
   [31m│[0m        [2m51[0m │     let mut bp = Blueprint::new();
   [31m│[0m        [2m52[0m │     bp.constructor(f!(crate::a), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m           ·                          [35;1m╰── The constructor was registered here[0m
   [31m│[0m        [2m53[0m │     // Being a singleton, this will be an input type of the dependency closure for the request handler
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m Considering changing the signature of `app::a`.
@@ -37,7 +37,7 @@
   [31m│[0m        [2m53[0m │     // Being a singleton, this will be an input type of the dependency closure for the request handler
   [31m│[0m        [2m54[0m │     bp.constructor(f!(crate::b), Lifecycle::Singleton);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m           ·                          [35;1m╰── The constructor was registered here[0m
   [31m│[0m        [2m55[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m Considering changing the signature of `app::b`.

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/multiple_consumers/a_non_clonable_framework_type_cannot_be_moved_twice/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/multiple_consumers/a_non_clonable_framework_type_cannot_be_moved_twice/expectations/stderr.txt
@@ -13,7 +13,7 @@
   [31m│[0m        [2m40[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m        [2m41[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mOne of the consuming constructors[0m[0m
+  [31m│[0m           ·                          [35;1m╰── One of the consuming constructors[0m
   [31m│[0m        [2m42[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m           ╰────
   [31m│[0m        ☞
@@ -21,6 +21,6 @@
   [31m│[0m        [2m39[0m │     let mut bp = Blueprint::new();
   [31m│[0m        [2m40[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mOne of the consuming constructors[0m[0m
+  [31m│[0m           ·                          [35;1m╰── One of the consuming constructors[0m
   [31m│[0m        [2m41[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           ╰────

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/multiple_consumers/a_non_clonable_input_type_cannot_be_moved_twice/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/multiple_consumers/a_non_clonable_input_type_cannot_be_moved_twice/expectations/stderr.txt
@@ -13,7 +13,7 @@
   [31m│[0m        [2m43[0m │     // `A` is a singleton, therefore it will be an input of the dependency closure for the handler
   [31m│[0m        [2m44[0m │     bp.constructor(f!(crate::a), Lifecycle::Singleton);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m           ·                          [35;1m╰── The constructor was registered here[0m
   [31m│[0m        [2m45[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m Considering changing the signature of the components that consume
@@ -24,7 +24,7 @@
   [31m│[0m        [2m45[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m        [2m46[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mOne of the consuming constructors[0m[0m
+  [31m│[0m           ·                          [35;1m╰── One of the consuming constructors[0m
   [31m│[0m        [2m47[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m           ╰────
   [31m│[0m        ☞
@@ -32,6 +32,6 @@
   [31m│[0m        [2m44[0m │     bp.constructor(f!(crate::a), Lifecycle::Singleton);
   [31m│[0m        [2m45[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mOne of the consuming constructors[0m[0m
+  [31m│[0m           ·                          [35;1m╰── One of the consuming constructors[0m
   [31m│[0m        [2m46[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           ╰────

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/multiple_consumers/a_non_clonable_type_cannot_be_moved_twice/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/multiple_consumers/a_non_clonable_type_cannot_be_moved_twice/expectations/stderr.txt
@@ -13,7 +13,7 @@
   [31m│[0m        [2m41[0m │     let mut bp = Blueprint::new();
   [31m│[0m        [2m42[0m │     bp.constructor(f!(crate::a), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m           ·                          [35;1m╰── The constructor was registered here[0m
   [31m│[0m        [2m43[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m Considering changing the signature of the components that consume
@@ -24,7 +24,7 @@
   [31m│[0m        [2m43[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m        [2m44[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mOne of the consuming constructors[0m[0m
+  [31m│[0m           ·                          [35;1m╰── One of the consuming constructors[0m
   [31m│[0m        [2m45[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m           ╰────
   [31m│[0m        ☞
@@ -32,7 +32,7 @@
   [31m│[0m        [2m42[0m │     bp.constructor(f!(crate::a), Lifecycle::RequestScoped);
   [31m│[0m        [2m43[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mOne of the consuming constructors[0m[0m
+  [31m│[0m           ·                          [35;1m╰── One of the consuming constructors[0m
   [31m│[0m        [2m44[0m │     bp.constructor(f!(crate::c), Lifecycle::RequestScoped);
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m If `app::A` itself cannot implement `Clone`, consider wrapping it in

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/transitive_borrows/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/transitive_borrows/expectations/stderr.txt
@@ -15,7 +15,7 @@
   [31m│[0m        [2m47[0m │     let mut bp = Blueprint::new();
   [31m│[0m        [2m48[0m │     bp.constructor(f!(crate::a), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m           ·                          [35;1m╰── The constructor was registered here[0m
   [31m│[0m        [2m49[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m Consider changing the signature of `app::b`.

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/triangle/triangle_cannot_be_solved_if_input_type_is_not_clonable/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/triangle/triangle_cannot_be_solved_if_input_type_is_not_clonable/expectations/stderr.txt
@@ -14,7 +14,7 @@
   [31m│[0m        [2m37[0m │     // A is a singleton, so it will be an input parameter of the dependency closure for `handler`
   [31m│[0m        [2m38[0m │     bp.constructor(f!(crate::a), Lifecycle::Singleton);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m           ·                          [35;1m╰── The constructor was registered here[0m
   [31m│[0m        [2m39[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m Consider changing the signature of `app::b`.

--- a/libs/pavex_cli/tests/ui_tests/borrow_checker/triangle/triangle_cannot_be_solved_if_type_is_not_clonable/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/borrow_checker/triangle/triangle_cannot_be_solved_if_type_is_not_clonable/expectations/stderr.txt
@@ -14,7 +14,7 @@
   [31m│[0m        [2m36[0m │     let mut bp = Blueprint::new();
   [31m│[0m        [2m37[0m │     bp.constructor(f!(crate::a), Lifecycle::RequestScoped);
   [31m│[0m           · [35;1m                   ──────┬─────[0m
-  [31m│[0m           ·                          [35;1m╰── [35;1mThe constructor was registered here[0m[0m
+  [31m│[0m           ·                          [35;1m╰── The constructor was registered here[0m
   [31m│[0m        [2m38[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m           ╰────
   [31m│[0m   [36mhelp:[0m Consider changing the signature of `app::b`.

--- a/libs/pavex_cli/tests/ui_tests/dependency_injection/lifecycles/singletons_cannot_depend_on_shorter_lifecycles/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/dependency_injection/lifecycles/singletons_cannot_depend_on_shorter_lifecycles/expectations/stderr.txt
@@ -9,14 +9,14 @@
   [31m│[0m  [2m29[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m30[0m │     bp.constructor(f!(crate::a), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ──────┬─────[0m
-  [31m│[0m     ·                          [35;1m╰── [35;1mThe singleton was registered here[0m[0m
+  [31m│[0m     ·                          [35;1m╰── The singleton was registered here[0m
   [31m│[0m  [2m31[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:30:1]
   [31m│[0m  [2m30[0m │     bp.constructor(f!(crate::a), Lifecycle::Singleton);
   [31m│[0m  [2m31[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m     · [35;1m                   ──────┬─────[0m
-  [31m│[0m     ·                          [35;1m╰── [35;1mThe request-scoped dependency was registered here[0m[0m
+  [31m│[0m     ·                          [35;1m╰── The request-scoped dependency was registered here[0m
   [31m│[0m  [2m32[0m │     bp.constructor(f!(crate::c), Lifecycle::Transient);
   [31m│[0m     ╰────
 
@@ -31,13 +31,13 @@
   [31m│[0m  [2m29[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m30[0m │     bp.constructor(f!(crate::a), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ──────┬─────[0m
-  [31m│[0m     ·                          [35;1m╰── [35;1mThe singleton was registered here[0m[0m
+  [31m│[0m     ·                          [35;1m╰── The singleton was registered here[0m
   [31m│[0m  [2m31[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:31:1]
   [31m│[0m  [2m31[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m  [2m32[0m │     bp.constructor(f!(crate::c), Lifecycle::Transient);
   [31m│[0m     · [35;1m                   ──────┬─────[0m
-  [31m│[0m     ·                          [35;1m╰── [35;1mThe transient dependency was registered here[0m[0m
+  [31m│[0m     ·                          [35;1m╰── The transient dependency was registered here[0m
   [31m│[0m  [2m33[0m │     bp.route(GET, "/", f!(crate::handler));
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/dependency_injection/lifecycles/singletons_cannot_depend_on_shorter_lifecycles/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/dependency_injection/lifecycles/singletons_cannot_depend_on_shorter_lifecycles/expectations/stderr.txt
@@ -16,7 +16,7 @@
   [31m│[0m  [2m30[0m │     bp.constructor(f!(crate::a), Lifecycle::Singleton);
   [31m│[0m  [2m31[0m │     bp.constructor(f!(crate::b), Lifecycle::RequestScoped);
   [31m│[0m     · [35;1m                   ──────┬─────[0m
-  [31m│[0m     ·                          [35;1m╰── The request-scoped dependency was registered here[0m
+  [31m│[0m     ·             [35;1mThe request-scoped dependency was registered here[0m
   [31m│[0m  [2m32[0m │     bp.constructor(f!(crate::c), Lifecycle::Transient);
   [31m│[0m     ╰────
 

--- a/libs/pavex_cli/tests/ui_tests/dependency_injection/missing_handler_dependency/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/dependency_injection/missing_handler_dependency/expectations/stderr.txt
@@ -7,14 +7,14 @@
   [31m│[0m  [2m11[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m12[0m │     bp.route(GET, "/home", f!(crate::stream_file));
   [31m│[0m     · [35;1m                           ───────────┬──────────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m13[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:5:1]
   [31m│[0m  [2m5[0m │ 
   [31m│[0m  [2m6[0m │ pub fn stream_file(_inner: PathBuf) -> pavex::response::Response {
   [31m│[0m    · [35;1m                           ───┬───[0m
-  [31m│[0m    ·                               [35;1m╰── [35;1mI don't know how to construct an instance of this input parameter[0m[0m
+  [31m│[0m    ·        [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m7[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `std::path::PathBuf`

--- a/libs/pavex_cli/tests/ui_tests/dependency_injection/missing_handler_dependency/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/dependency_injection/missing_handler_dependency/expectations/stderr.txt
@@ -7,14 +7,14 @@
   [31m│[0m  [2m11[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m12[0m │     bp.route(GET, "/home", f!(crate::stream_file));
   [31m│[0m     · [35;1m                           ───────────┬──────────[0m
-  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
+  [31m│[0m     ·                  [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m13[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:5:1]
   [31m│[0m  [2m5[0m │ 
   [31m│[0m  [2m6[0m │ pub fn stream_file(_inner: PathBuf) -> pavex::response::Response {
   [31m│[0m    · [35;1m                           ───┬───[0m
-  [31m│[0m    ·        [35;1mI don't know how to construct an instance of this input parameter[0m
+  [31m│[0m    ·      [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m7[0m │     todo!()
   [31m│[0m    ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `std::path::PathBuf`

--- a/libs/pavex_cli/tests/ui_tests/dependency_injection/pavex_honors_the_restrictions_on_generics_introduced_by_constructors/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/dependency_injection/pavex_honors_the_restrictions_on_generics_introduced_by_constructors/expectations/stderr.txt
@@ -7,14 +7,14 @@
   [31m│[0m  [2m19[0m │     bp.constructor(f!(crate::tied), Lifecycle::RequestScoped);
   [31m│[0m  [2m20[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     · [35;1m                           ─────────┬────────[0m
-  [31m│[0m     ·                                     [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m21[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:11:1]
   [31m│[0m  [2m11[0m │     // This can't be built because `tied` can only give you Tied<u8, u8> or Tied<char, char>!
   [31m│[0m  [2m12[0m │     tied: Tied<u8, char>,
   [31m│[0m     · [35;1m          ───────┬──────[0m
-  [31m│[0m     ·                  [35;1m╰── [35;1mI don't know how to construct an instance of this input parameter[0m[0m
+  [31m│[0m     ·       [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m13[0m │ ) -> pavex::response::Response {
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `app::Tied<u8, char>`

--- a/libs/pavex_cli/tests/ui_tests/dependency_injection/pavex_honors_the_restrictions_on_generics_introduced_by_constructors/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/dependency_injection/pavex_honors_the_restrictions_on_generics_introduced_by_constructors/expectations/stderr.txt
@@ -7,14 +7,14 @@
   [31m│[0m  [2m19[0m │     bp.constructor(f!(crate::tied), Lifecycle::RequestScoped);
   [31m│[0m  [2m20[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     · [35;1m                           ─────────┬────────[0m
-  [31m│[0m     ·                    [35;1mThe request handler was registered here[0m
+  [31m│[0m     ·                  [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m21[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4msrc/lib.rs[0m:11:1]
   [31m│[0m  [2m11[0m │     // This can't be built because `tied` can only give you Tied<u8, u8> or Tied<char, char>!
   [31m│[0m  [2m12[0m │     tied: Tied<u8, char>,
   [31m│[0m     · [35;1m          ───────┬──────[0m
-  [31m│[0m     ·       [35;1mI don't know how to construct an instance of this input parameter[0m
+  [31m│[0m     ·     [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m13[0m │ ) -> pavex::response::Response {
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRegister a constructor for `app::Tied<u8, char>`

--- a/libs/pavex_cli/tests/ui_tests/reflection/crate_resolution/remote_callable_paths_must_be_absolute/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/crate_resolution/remote_callable_paths_must_be_absolute/expectations/stderr.txt
@@ -5,7 +5,7 @@
   [31m│[0m  [2m10[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m11[0m │     bp.constructor(f!(new_logger), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ───────┬──────[0m
-  [31m│[0m     ·                           [35;1m╰── [35;1mThe relative import path was registered here[0m[0m
+  [31m│[0m     ·                           [35;1m╰── The relative import path was registered here[0m
   [31m│[0m  [2m12[0m │     bp.route(GET, "/home", f!(crate::handler));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mIf it is a local import, the path must start with `crate::`.

--- a/libs/pavex_cli/tests/ui_tests/reflection/invalid_callable_path/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/invalid_callable_path/expectations/stderr.txt
@@ -5,6 +5,6 @@
   [31m│[0m  [2m10[0m │     };
   [31m│[0m  [2m11[0m │     bp.route(POST, "/home", callable);
   [31m│[0m     · [35;1m                            ────┬───[0m
-  [31m│[0m     ·                  [35;1mThe invalid import path was registered here[0m
+  [31m│[0m     ·                [35;1mThe invalid import path was registered here[0m
   [31m│[0m  [2m12[0m │     bp
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/reflection/invalid_callable_path/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/invalid_callable_path/expectations/stderr.txt
@@ -5,6 +5,6 @@
   [31m│[0m  [2m10[0m │     };
   [31m│[0m  [2m11[0m │     bp.route(POST, "/home", callable);
   [31m│[0m     · [35;1m                            ────┬───[0m
-  [31m│[0m     ·                                 [35;1m╰── [35;1mThe invalid import path was registered here[0m[0m
+  [31m│[0m     ·                  [35;1mThe invalid import path was registered here[0m
   [31m│[0m  [2m12[0m │     bp
   [31m│[0m     ╰────

--- a/libs/pavex_cli/tests/ui_tests/reflection/local_callable_paths_must_be_prefixed_with_crate/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/local_callable_paths_must_be_prefixed_with_crate/expectations/stderr.txt
@@ -5,7 +5,7 @@
   [31m│[0m  [2m 9[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m10[0m │     bp.route(GET, "/home", f!(handler));
   [31m│[0m     · [35;1m                           ─────┬─────[0m
-  [31m│[0m     ·                  [35;1mThe relative import path was registered here[0m
+  [31m│[0m     ·                [35;1mThe relative import path was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mIf it is a local import, the path must start with `crate::`.

--- a/libs/pavex_cli/tests/ui_tests/reflection/local_callable_paths_must_be_prefixed_with_crate/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/local_callable_paths_must_be_prefixed_with_crate/expectations/stderr.txt
@@ -5,7 +5,7 @@
   [31m│[0m  [2m 9[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m10[0m │     bp.route(GET, "/home", f!(handler));
   [31m│[0m     · [35;1m                           ─────┬─────[0m
-  [31m│[0m     ·                                 [35;1m╰── [35;1mThe relative import path was registered here[0m[0m
+  [31m│[0m     ·                  [35;1mThe relative import path was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mIf it is a local import, the path must start with `crate::`.

--- a/libs/pavex_cli/tests/ui_tests/reflection/output_parameter_cannot_be_handled/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/output_parameter_cannot_be_handled/expectations/stderr.txt
@@ -5,13 +5,13 @@
   [31m│[0m  [2m 9[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m10[0m │     bp.route(GET, "/home", f!(crate::c));
   [31m│[0m     · [35;1m                           ──────┬─────[0m
-  [31m│[0m     ·                                  [35;1m╰── [35;1mThe request handler was registered here[0m[0m
+  [31m│[0m     ·                                  [35;1m╰── The request handler was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:3:1]
   [31m│[0m  [2m3[0m │ 
   [31m│[0m  [2m4[0m │ pub fn c() -> Box<dyn std::error::Error> {
   [31m│[0m    · [35;1m              ─────────────┬────────────[0m
-  [31m│[0m    ·                            [35;1m╰── [35;1mThe output type that I can't handle[0m[0m
+  [31m│[0m    ·                            [35;1m╰── The output type that I can't handle[0m
   [31m│[0m  [2m5[0m │     todo!()
   [31m│[0m    ╰────

--- a/libs/pavex_cli/tests/ui_tests/reflection/output_parameter_cannot_be_handled/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/output_parameter_cannot_be_handled/expectations/stderr.txt
@@ -5,7 +5,7 @@
   [31m│[0m  [2m 9[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m10[0m │     bp.route(GET, "/home", f!(crate::c));
   [31m│[0m     · [35;1m                           ──────┬─────[0m
-  [31m│[0m     ·                                  [35;1m╰── The request handler was registered here[0m
+  [31m│[0m     ·                  [35;1mThe request handler was registered here[0m
   [31m│[0m  [2m11[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m    ╭─[[36;1;4msrc/lib.rs[0m:3:1]

--- a/libs/pavex_cli/tests/ui_tests/reflection/the_path_for_generic_arguments_must_be_absolute/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/the_path_for_generic_arguments_must_be_absolute/expectations/stderr.txt
@@ -5,7 +5,7 @@
   [31m│[0m  [2m15[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m16[0m │     bp.constructor(f!(crate::new_logger::<String>), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ───────────────┬───────────────[0m
-  [31m│[0m     ·                                   [35;1m╰── [35;1mThe relative import path was registered here[0m[0m
+  [31m│[0m     ·                  [35;1mThe relative import path was registered here[0m
   [31m│[0m  [2m17[0m │     bp.route(GET, "/home", f!(crate::handler::<std::string::String>));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mIf it is a local import, the path must start with `crate::`.

--- a/libs/pavex_cli/tests/ui_tests/reflection/the_path_for_generic_arguments_must_be_absolute/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/reflection/the_path_for_generic_arguments_must_be_absolute/expectations/stderr.txt
@@ -5,7 +5,7 @@
   [31m│[0m  [2m15[0m │     let mut bp = Blueprint::new();
   [31m│[0m  [2m16[0m │     bp.constructor(f!(crate::new_logger::<String>), Lifecycle::Singleton);
   [31m│[0m     · [35;1m                   ───────────────┬───────────────[0m
-  [31m│[0m     ·                  [35;1mThe relative import path was registered here[0m
+  [31m│[0m     ·                [35;1mThe relative import path was registered here[0m
   [31m│[0m  [2m17[0m │     bp.route(GET, "/home", f!(crate::handler::<std::string::String>));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mIf it is a local import, the path must start with `crate::`.

--- a/libs/pavex_cli/tests/ui_tests/route_parameters/route_parameters_non_existing_fields/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters/route_parameters_non_existing_fields/expectations/stderr.txt
@@ -12,7 +12,7 @@
   [31m│[0m  [2m44[0m │     ));
   [31m│[0m  [2m45[0m │     bp.route(GET, "/a/:x", f!(crate::missing_one));
   [31m│[0m     · [35;1m                           ───────────┬──────────[0m
-  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::MissingOne>`[0m
+  [31m│[0m     ·       [35;1mThe request handler asking for `RouteParams<app::MissingOne>`[0m
   [31m│[0m  [2m46[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
@@ -32,7 +32,7 @@
   [31m│[0m  [2m45[0m │     bp.route(GET, "/a/:x", f!(crate::missing_one));
   [31m│[0m  [2m46[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
   [31m│[0m     · [35;1m                           ───────────┬──────────[0m
-  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::MissingTwo>`[0m
+  [31m│[0m     ·       [35;1mThe request handler asking for `RouteParams<app::MissingTwo>`[0m
   [31m│[0m  [2m47[0m │     bp.route(GET, "/c", f!(crate::no_route_params));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
@@ -48,7 +48,7 @@
   [31m│[0m  [2m46[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
   [31m│[0m  [2m47[0m │     bp.route(GET, "/c", f!(crate::no_route_params));
   [31m│[0m     · [35;1m                        ─────────────┬────────────[0m
-  [31m│[0m     ·        [35;1mThe request handler asking for `RouteParams<app::NoRouteParams>`[0m
+  [31m│[0m     ·      [35;1mThe request handler asking for `RouteParams<app::NoRouteParams>`[0m
   [31m│[0m  [2m48[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mStop trying to extract route parameters, or add them to the route

--- a/libs/pavex_cli/tests/ui_tests/route_parameters/route_parameters_non_existing_fields/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters/route_parameters_non_existing_fields/expectations/stderr.txt
@@ -12,7 +12,7 @@
   [31m│[0m  [2m44[0m │     ));
   [31m│[0m  [2m45[0m │     bp.route(GET, "/a/:x", f!(crate::missing_one));
   [31m│[0m     · [35;1m                           ───────────┬──────────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MissingOne>`[0m[0m
+  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::MissingOne>`[0m
   [31m│[0m  [2m46[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
@@ -32,7 +32,7 @@
   [31m│[0m  [2m45[0m │     bp.route(GET, "/a/:x", f!(crate::missing_one));
   [31m│[0m  [2m46[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
   [31m│[0m     · [35;1m                           ───────────┬──────────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MissingTwo>`[0m[0m
+  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::MissingTwo>`[0m
   [31m│[0m  [2m47[0m │     bp.route(GET, "/c", f!(crate::no_route_params));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mRemove or rename the fields that do not map to a valid route
@@ -48,7 +48,7 @@
   [31m│[0m  [2m46[0m │     bp.route(GET, "/b/:x", f!(crate::missing_two));
   [31m│[0m  [2m47[0m │     bp.route(GET, "/c", f!(crate::no_route_params));
   [31m│[0m     · [35;1m                        ─────────────┬────────────[0m
-  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::NoRouteParams>`[0m[0m
+  [31m│[0m     ·        [35;1mThe request handler asking for `RouteParams<app::NoRouteParams>`[0m
   [31m│[0m  [2m48[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mStop trying to extract route parameters, or add them to the route

--- a/libs/pavex_cli/tests/ui_tests/route_parameters/route_parameters_unsupported_types/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters/route_parameters_unsupported_types/expectations/stderr.txt
@@ -10,7 +10,7 @@
   [31m│[0m  [2m61[0m │     ));
   [31m│[0m  [2m62[0m │     bp.route(GET, "/a/:x", f!(crate::primitive));
   [31m│[0m     · [35;1m                           ──────────┬─────────[0m
-  [31m│[0m     ·                                      [35;1m╰── [35;1mThe request handler asking for `RouteParams<u32>`[0m[0m
+  [31m│[0m     ·               [35;1mThe request handler asking for `RouteParams<u32>`[0m
   [31m│[0m  [2m63[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -29,7 +29,7 @@
   [31m│[0m  [2m62[0m │     bp.route(GET, "/a/:x", f!(crate::primitive));
   [31m│[0m  [2m63[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
   [31m│[0m     · [35;1m                              ────────┬───────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler asking for `RouteParams<(u32, u32)>`[0m[0m
+  [31m│[0m     ·            [35;1mThe request handler asking for `RouteParams<(u32, u32)>`[0m
   [31m│[0m  [2m64[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -48,7 +48,7 @@
   [31m│[0m  [2m63[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
   [31m│[0m  [2m64[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
   [31m│[0m     · [35;1m                              ──────────┬─────────[0m
-  [31m│[0m     ·                                         [35;1m╰── [35;1mThe request handler asking for `RouteParams<&[u32]>`[0m[0m
+  [31m│[0m     ·              [35;1mThe request handler asking for `RouteParams<&[u32]>`[0m
   [31m│[0m  [2m65[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -67,7 +67,7 @@
   [31m│[0m  [2m64[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
   [31m│[0m  [2m65[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m     · [35;1m                              ───────────────────┬───────────────────[0m
-  [31m│[0m     ·                                                  [35;1m╰── [35;1mThe request handler asking for `RouteParams<&app::MyStruct>`[0m[0m
+  [31m│[0m     ·          [35;1mThe request handler asking for `RouteParams<&app::MyStruct>`[0m
   [31m│[0m  [2m66[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -86,7 +86,7 @@
   [31m│[0m  [2m65[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m  [2m66[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
   [31m│[0m     · [35;1m                              ────────┬───────[0m
-  [31m│[0m     ·                                       [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::MyEnum>`[0m[0m
+  [31m│[0m     ·           [35;1mThe request handler asking for `RouteParams<app::MyEnum>`[0m
   [31m│[0m  [2m67[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -105,7 +105,7 @@
   [31m│[0m  [2m66[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
   [31m│[0m  [2m67[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m     · [35;1m                              ───────────┬───────────[0m
-  [31m│[0m     ·                                          [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::TupleStruct>`[0m[0m
+  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::TupleStruct>`[0m
   [31m│[0m  [2m68[0m │     bp.route(GET, "/g/:x/:y", f!(crate::unit_struct));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -124,7 +124,7 @@
   [31m│[0m  [2m67[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m  [2m68[0m │     bp.route(GET, "/g/:x/:y", f!(crate::unit_struct));
   [31m│[0m     · [35;1m                              ───────────┬──────────[0m
-  [31m│[0m     ·                                          [35;1m╰── [35;1mThe request handler asking for `RouteParams<app::UnitStruct>`[0m[0m
+  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::UnitStruct>`[0m
   [31m│[0m  [2m69[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.

--- a/libs/pavex_cli/tests/ui_tests/route_parameters/route_parameters_unsupported_types/expectations/stderr.txt
+++ b/libs/pavex_cli/tests/ui_tests/route_parameters/route_parameters_unsupported_types/expectations/stderr.txt
@@ -10,7 +10,7 @@
   [31m│[0m  [2m61[0m │     ));
   [31m│[0m  [2m62[0m │     bp.route(GET, "/a/:x", f!(crate::primitive));
   [31m│[0m     · [35;1m                           ──────────┬─────────[0m
-  [31m│[0m     ·               [35;1mThe request handler asking for `RouteParams<u32>`[0m
+  [31m│[0m     ·             [35;1mThe request handler asking for `RouteParams<u32>`[0m
   [31m│[0m  [2m63[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -29,7 +29,7 @@
   [31m│[0m  [2m62[0m │     bp.route(GET, "/a/:x", f!(crate::primitive));
   [31m│[0m  [2m63[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
   [31m│[0m     · [35;1m                              ────────┬───────[0m
-  [31m│[0m     ·            [35;1mThe request handler asking for `RouteParams<(u32, u32)>`[0m
+  [31m│[0m     ·          [35;1mThe request handler asking for `RouteParams<(u32, u32)>`[0m
   [31m│[0m  [2m64[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -48,7 +48,7 @@
   [31m│[0m  [2m63[0m │     bp.route(GET, "/b/:x/:y", f!(crate::tuple));
   [31m│[0m  [2m64[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
   [31m│[0m     · [35;1m                              ──────────┬─────────[0m
-  [31m│[0m     ·              [35;1mThe request handler asking for `RouteParams<&[u32]>`[0m
+  [31m│[0m     ·            [35;1mThe request handler asking for `RouteParams<&[u32]>`[0m
   [31m│[0m  [2m65[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -67,7 +67,7 @@
   [31m│[0m  [2m64[0m │     bp.route(GET, "/c/:x/:z", f!(crate::slice_ref));
   [31m│[0m  [2m65[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m     · [35;1m                              ───────────────────┬───────────────────[0m
-  [31m│[0m     ·          [35;1mThe request handler asking for `RouteParams<&app::MyStruct>`[0m
+  [31m│[0m     ·        [35;1mThe request handler asking for `RouteParams<&app::MyStruct>`[0m
   [31m│[0m  [2m66[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -86,7 +86,7 @@
   [31m│[0m  [2m65[0m │     bp.route(GET, "/d/:x/:y", f!(crate::reference::<crate::MyStruct>));
   [31m│[0m  [2m66[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
   [31m│[0m     · [35;1m                              ────────┬───────[0m
-  [31m│[0m     ·           [35;1mThe request handler asking for `RouteParams<app::MyEnum>`[0m
+  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::MyEnum>`[0m
   [31m│[0m  [2m67[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -105,7 +105,7 @@
   [31m│[0m  [2m66[0m │     bp.route(GET, "/e/:x/:y", f!(crate::enum_));
   [31m│[0m  [2m67[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m     · [35;1m                              ───────────┬───────────[0m
-  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::TupleStruct>`[0m
+  [31m│[0m     ·       [35;1mThe request handler asking for `RouteParams<app::TupleStruct>`[0m
   [31m│[0m  [2m68[0m │     bp.route(GET, "/g/:x/:y", f!(crate::unit_struct));
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.
@@ -124,7 +124,7 @@
   [31m│[0m  [2m67[0m │     bp.route(GET, "/f/:x/:y", f!(crate::tuple_struct));
   [31m│[0m  [2m68[0m │     bp.route(GET, "/g/:x/:y", f!(crate::unit_struct));
   [31m│[0m     · [35;1m                              ───────────┬──────────[0m
-  [31m│[0m     ·         [35;1mThe request handler asking for `RouteParams<app::UnitStruct>`[0m
+  [31m│[0m     ·       [35;1mThe request handler asking for `RouteParams<app::UnitStruct>`[0m
   [31m│[0m  [2m69[0m │     bp
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mUse a plain struct with named fields to extract route parameters.

--- a/libs/pavex_miette/src/graphical_report_handler.rs
+++ b/libs/pavex_miette/src/graphical_report_handler.rs
@@ -202,7 +202,7 @@ impl GraphicalReportHandler {
             write!(header, "{}", link)?;
             writeln!(f, "{}", header)?;
         } else if let Some(code) = diagnostic.code() {
-            write!(header, "{}", code.style(severity_style),)?;
+            write!(header, "{}", code.style(severity_style), )?;
             if self.links == LinkStyle::Text && diagnostic.url().is_some() {
                 let url = diagnostic.url().unwrap(); // safe
                 write!(header, " ({})", url.style(self.theme.styles.link))?;
@@ -261,8 +261,8 @@ impl GraphicalReportHandler {
                     "  {}{}{} ",
                     char, self.theme.characters.hbar, self.theme.characters.rarrow
                 )
-                .style(severity_style)
-                .to_string();
+                    .style(severity_style)
+                    .to_string();
                 let rest_indent = format!(
                     "  {}   ",
                     if is_last {
@@ -271,8 +271,8 @@ impl GraphicalReportHandler {
                         self.theme.characters.vbar
                     }
                 )
-                .style(severity_style)
-                .to_string();
+                    .style(severity_style)
+                    .to_string();
                 let opts = textwrap::Options::new(width)
                     .initial_indent(&initial_indent)
                     .subsequent_indent(&rest_indent);
@@ -632,7 +632,7 @@ impl GraphicalReportHandler {
     }
 
     /// Returns an iterator over the visual width of each character in a line.
-    fn line_visual_char_width<'a>(&self, text: &'a str) -> impl Iterator<Item = usize> + 'a {
+    fn line_visual_char_width<'a>(&self, text: &'a str) -> impl Iterator<Item=usize> + 'a {
         let mut column = 0;
         let tab_width = self.tab_width;
         text.chars().map(move |c| {
@@ -725,8 +725,8 @@ impl GraphicalReportHandler {
                             chars.underline.to_string().repeat(num_right),
                             width = start.saturating_sub(highest),
                         )
-                        .style(hl.style)
-                        .to_string(),
+                            .style(hl.style)
+                            .to_string(),
                     );
                 }
                 highest = std::cmp::max(highest, end);
@@ -742,7 +742,7 @@ impl GraphicalReportHandler {
             Right,
         }
 
-        let post_linum_width = self.termwidth.saturating_sub(linum_width);
+        let post_linum_width = self.termwidth.saturating_sub(linum_width + 4 /*  length of "  │" */);
 
         for hl in single_liners.iter().rev() {
             if let Some(label) = &hl.label {
@@ -761,10 +761,10 @@ impl GraphicalReportHandler {
                     .saturating_sub(label_vbar_offset + 4 /*  length of "╰── " */);
                 let available_left_space = {
                     label_vbar_offset
-                        .saturating_sub(4 /*  length of "──╯" */)
+                        .saturating_sub(4 /*  length of " ──╯" */)
                         .saturating_sub(if label_index != 0 {
                             let previous_vbar_offset = vbar_offsets[label_index - 1].1;
-                            previous_vbar_offset
+                            previous_vbar_offset + 1
                         } else {
                             0
                         })
@@ -785,7 +785,7 @@ impl GraphicalReportHandler {
                 };
                 let sigil = match position {
                     LabelPosition::Right => {
-                        format!("{}{} ", chars.lbot, chars.hbar.to_string().repeat(2),)
+                        format!("{}{} ", chars.lbot, chars.hbar.to_string().repeat(2), )
                     }
                     LabelPosition::Left => {
                         format!("{}{} ", chars.hbar.to_string().repeat(2), chars.rbot)
@@ -807,7 +807,7 @@ impl GraphicalReportHandler {
                         }
 
                         let n_leading_whitespaces = match position {
-                            LabelPosition::Left => available_space - label_line.len(),
+                            LabelPosition::Left => available_space - label_line.len() + 1,
                             LabelPosition::Center => (available_space - label_line.len()) / 2,
                             LabelPosition::Right => vbar_offset - curr_offset + 1,
                         };


### PR DESCRIPTION
Our error reporter had no wrapping behaviour for code labels: they would happily go as far right as they wanted, often overflowing the assumed width of the terminal they are being printed on.

This PR changes that behaviour in two ways:
- Labels are no longer forced to be right-positioned to the code span they refer to. If it helps to keep them on one line, we now position them to the left or centred (with this order of preference).
- If they would necessarily overflow the maximum allowed width, we perform text wrapping.

Getting this right was... tricky. But we have a fairly extensive collection of error messages in our UI tests and the new version seems to work as expected.