### PR TITLE
Keep ANSI colors for errors in the documentation

### DIFF
--- a/doc_examples/quickstart/05-error.snap
+++ b/doc_examples/quickstart/05-error.snap
@@ -1,23 +1,23 @@
-ERROR: 
-  × I can't invoke your request handler, `demo::routes::greet::greet`, because it needs an
-  │ instance of `demo::user_agent::UserAgent` as input, but I can't find a constructor for that
-  │ type.
-  │
-  │     ╭─[demo/src/blueprint.rs:13:1]
-  │  13 │     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
-  │  14 │     bp.route(GET, "/api/greet/:name", f!(crate::routes::greet::greet));
-  │     ·                                       ───────────────┬───────────────
-  │     ·            The request handler was registered here ──╯
-  │  15 │     bp
-  │     ╰────
-  │     ╭─[demo/src/routes/greet.rs:10:1]
-  │  10 │ 
-  │  11 │ pub fn greet(params: RouteParams<GreetParams>, user_agent: UserAgent) -> Response {
-  │     ·                                                            ────┬────
-  │     ·               I don't know how to construct an instance of this input parameter
-  │  12 │     if let UserAgent::Unknown = user_agent {
-  │     ╰────
-  │   help: Register a constructor for `demo::user_agent::UserAgent`
+[31m[1mERROR[0m[39m: 
+  [31m×[0m I can't invoke your request handler, `demo::routes::greet::greet`, because it needs an
+  [31m│[0m instance of `demo::user_agent::UserAgent` as input, but I can't find a constructor for that
+  [31m│[0m type.
+  [31m│[0m
+  [31m│[0m     ╭─[[36;1;4mdemo/src/blueprint.rs[0m:13:1]
+  [31m│[0m  [2m13[0m │     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
+  [31m│[0m  [2m14[0m │     bp.route(GET, "/api/greet/:name", f!(crate::routes::greet::greet));
+  [31m│[0m     · [35;1m                                      ───────────────┬───────────────[0m
+  [31m│[0m     ·            [35;1mThe request handler was registered here ──╯[0m
+  [31m│[0m  [2m15[0m │     bp
+  [31m│[0m     ╰────
+  [31m│[0m     ╭─[[36;1;4mdemo/src/routes/greet.rs[0m:10:1]
+  [31m│[0m  [2m10[0m │ 
+  [31m│[0m  [2m11[0m │ pub fn greet(params: RouteParams<GreetParams>, user_agent: UserAgent) -> Response {
+  [31m│[0m     · [35;1m                                                           ────┬────[0m
+  [31m│[0m     ·               [35;1mI don't know how to construct an instance of this input parameter[0m
+  [31m│[0m  [2m12[0m │     if let UserAgent::Unknown = user_agent {
+  [31m│[0m     ╰────
+  [31m│[0m [36m  help: [0mRegister a constructor for `demo::user_agent::UserAgent`
 
 Error: `pavex_cli` exited with a non-zero status code: 1
 error: Failed to run `bp`, the code generator for package `demo_server_sdk`

--- a/doc_examples/quickstart/07-error.snap
+++ b/doc_examples/quickstart/07-error.snap
@@ -1,16 +1,16 @@
-ERROR: 
-  × You registered a constructor that returns a `Result`, but you did not register an error
-  │ handler for it. If I don't have an error handler, I don't know what to do with the error when
-  │ the constructor fails!
-  │
-  │     ╭─[demo/src/blueprint.rs:11:1]
-  │  11 │     bp.constructor(
-  │  12 │         f!(crate::user_agent::UserAgent::extract),
-  │     ·         ────────────────────┬────────────────────
-  │     ·                             ╰── The fallible constructor was registered here
-  │  13 │         Lifecycle::RequestScoped,
-  │     ╰────
-  │   help: Add an error handler via `.error_handler`
+[31m[1mERROR[0m[39m: 
+  [31m×[0m You registered a constructor that returns a `Result`, but you did not register an error
+  [31m│[0m handler for it. If I don't have an error handler, I don't know what to do with the error when
+  [31m│[0m the constructor fails!
+  [31m│[0m
+  [31m│[0m     ╭─[[36;1;4mdemo/src/blueprint.rs[0m:11:1]
+  [31m│[0m  [2m11[0m │     bp.constructor(
+  [31m│[0m  [2m12[0m │         f!(crate::user_agent::UserAgent::extract),
+  [31m│[0m     · [35;1m        ────────────────────┬────────────────────[0m
+  [31m│[0m     ·                             [35;1m╰── The fallible constructor was registered here[0m
+  [31m│[0m  [2m13[0m │         Lifecycle::RequestScoped,
+  [31m│[0m     ╰────
+  [31m│[0m [36m  help: [0mAdd an error handler via `.error_handler`
 
 Error: `pavex_cli` exited with a non-zero status code: 1
 error: Failed to run `bp`, the code generator for package `demo_server_sdk`

--- a/doc_examples/tutorial_generator/src/main.rs
+++ b/doc_examples/tutorial_generator/src/main.rs
@@ -274,7 +274,7 @@ fn main() -> Result<(), anyhow::Error> {
             }
         }
     }
-  
+
     if !errors.is_empty() {
         eprintln!("One or more snapshots didn't match the expected value.");
         for error in errors {
@@ -318,7 +318,10 @@ fn clean_up() {
 
 fn run_script(script: &str) -> Result<ScriptOutcome, anyhow::Error> {
     let mut options = ScriptOptions::new();
-    let env_vars = HashMap::from([("PAVEX_TTY_WIDTH".to_string(), "100".to_string())]);
+    let env_vars = HashMap::from([
+        ("PAVEX_TTY_WIDTH".to_string(), "100".to_string()),
+        ("PAVEX_COLOR".to_string(), "always".to_string()),
+    ]);
     options.env_vars = Some(env_vars);
 
     run_script::run(script, &Default::default(), &options)

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,2 +1,3 @@
 FROM squidfunk/mkdocs-material:9
 RUN pip install mkdocs-awesome-pages-plugin
+RUN pip install pygments_ansi_color

--- a/docs/ansi.css
+++ b/docs/ansi.css
@@ -1,0 +1,33 @@
+.highlight .-Color-Red, .highlight .-Color-Bold-Red {
+    color: var(--md-code-hl-special-color);
+}
+
+.highlight .-Color-Magenta, .highlight .-Color-Bold-Magenta {
+    color: var(--md-code-hl-function-color);
+}
+
+.highlight .-Color-Yellow, .highlight .-Color-Bold-Yellow {
+    /* We don't have anything yellow-ish, we go for violet */
+    color: var(--md-code-hl-constant-color);
+}
+
+.highlight .-Color-Cyan, .highlight .-Color-Bold-Cyan {
+    color: var(--md-code-hl-keyword-color);
+}
+
+.highlight .-Color-Blue, .highlight .-Color-Bold-Blue {
+    /* We treat Cyan and Blue the same */
+    color: var(--md-code-hl-keyword-color);
+}
+
+.highlight .-Color-Green, .highlight .-Color-Bold-Green {
+    color: var(--md-code-hl-string-color);
+}
+
+.highlight .-Color-Bold {
+    font-weight: bold;
+}
+
+.highlight .-Color-Faint {
+    font-weight: lighter;
+}

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -140,6 +140,7 @@ body.
 
 Create a new module, `greet.rs`, in the `demo/src/routes` folder:
 
+
 --8<-- "doc_examples/quickstart/02-new_submodule.snap"
 
 --8<-- "doc_examples/quickstart/02-route_def.snap"
@@ -244,7 +245,7 @@ Let's find out!
 
 If you try to build the project now, you'll get an error from Pavex:
 
-```text
+```ansi-color
 --8<-- "doc_examples/quickstart/05-error.snap"
 ```
 
@@ -291,7 +292,7 @@ Let's change the signature of `UserAgent::extract` to return a `Result` instead:
 
 If you try to build the project now, you'll get an error from Pavex:
 
-```text
+```ansi-color
 --8<-- "doc_examples/quickstart/07-error.snap"
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,3 +56,5 @@ theme:
 exclude_docs: |
   README.md
   Dockerfile
+extra_css:
+  - ansi.css


### PR DESCRIPTION
It took a bit of fiddling, but we now have ANSI colors in the mkdocs documentation 🖌️ 
They're not 100% faithful to what you see in the terminal, but they significantly improve readability.

<img width="1238" alt="immagine" src="https://github.com/LukeMathWalker/pavex/assets/20745048/109a2af7-2768-4ff6-9a90-5c6913c1d79e">

