### PR TITLE
Add support for non-standard HTTP methods.

### DIFF
--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/http_method_routing_variants/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/http_method_routing_variants/expectations/app.rs
@@ -26,15 +26,17 @@ fn build_router() -> matchit::Router<u32> {
     let mut router = matchit::Router::new();
     router.insert("/any", 0u32).unwrap();
     router.insert("/connect", 1u32).unwrap();
-    router.insert("/delete", 2u32).unwrap();
-    router.insert("/get", 3u32).unwrap();
-    router.insert("/head", 4u32).unwrap();
-    router.insert("/mixed", 5u32).unwrap();
-    router.insert("/options", 6u32).unwrap();
-    router.insert("/patch", 7u32).unwrap();
-    router.insert("/post", 8u32).unwrap();
-    router.insert("/put", 9u32).unwrap();
-    router.insert("/trace", 10u32).unwrap();
+    router.insert("/custom", 2u32).unwrap();
+    router.insert("/delete", 3u32).unwrap();
+    router.insert("/get", 4u32).unwrap();
+    router.insert("/head", 5u32).unwrap();
+    router.insert("/mixed", 6u32).unwrap();
+    router.insert("/mixed_with_custom", 7u32).unwrap();
+    router.insert("/options", 8u32).unwrap();
+    router.insert("/patch", 9u32).unwrap();
+    router.insert("/post", 10u32).unwrap();
+    router.insert("/put", 11u32).unwrap();
+    router.insert("/trace", 12u32).unwrap();
     router
 }
 async fn route_request(
@@ -49,7 +51,7 @@ async fn route_request(
         Ok(m) => m,
         Err(_) => {
             let allowed_methods = pavex::router::AllowedMethods::new(vec![]);
-            return route_11::handler(&allowed_methods).await;
+            return route_13::handler(&allowed_methods).await;
         }
     };
     let route_id = matched_route.value;
@@ -66,44 +68,58 @@ async fn route_request(
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::CONNECT],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
         2u32 => {
+            match &request_head.method {
+                s if s.as_str() == "CUSTOM" => route_11::handler().await,
+                _ => {
+                    let allowed_methods = pavex::router::AllowedMethods::new(
+                        vec![
+                            pavex::http::Method::try_from("CUSTOM")
+                            .expect("Failed to parse custom method")
+                        ],
+                    );
+                    route_13::handler(&allowed_methods).await
+                }
+            }
+        }
+        3u32 => {
             match &request_head.method {
                 &pavex::http::Method::DELETE => route_1::handler().await,
                 _ => {
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::DELETE],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
-        3u32 => {
+        4u32 => {
             match &request_head.method {
                 &pavex::http::Method::GET => route_2::handler().await,
                 _ => {
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::GET],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
-        4u32 => {
+        5u32 => {
             match &request_head.method {
                 &pavex::http::Method::HEAD => route_3::handler().await,
                 _ => {
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::HEAD],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
-        5u32 => {
+        6u32 => {
             match &request_head.method {
                 &pavex::http::Method::PATCH | &pavex::http::Method::POST => {
                     route_10::handler().await
@@ -112,62 +128,82 @@ async fn route_request(
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::PATCH, pavex::http::Method::POST],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
-        6u32 => {
+        7u32 => {
+            match &request_head.method {
+                &pavex::http::Method::GET => route_12::handler().await,
+                s if s.as_str() == "CUSTOM" || s.as_str() == "HEY" => {
+                    route_12::handler().await
+                }
+                _ => {
+                    let allowed_methods = pavex::router::AllowedMethods::new(
+                        vec![
+                            pavex::http::Method::try_from("CUSTOM")
+                            .expect("Failed to parse custom method"),
+                            pavex::http::Method::GET,
+                            pavex::http::Method::try_from("HEY")
+                            .expect("Failed to parse custom method")
+                        ],
+                    );
+                    route_13::handler(&allowed_methods).await
+                }
+            }
+        }
+        8u32 => {
             match &request_head.method {
                 &pavex::http::Method::OPTIONS => route_4::handler().await,
                 _ => {
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::OPTIONS],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
-        7u32 => {
+        9u32 => {
             match &request_head.method {
                 &pavex::http::Method::PATCH => route_5::handler().await,
                 _ => {
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::PATCH],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
-        8u32 => {
+        10u32 => {
             match &request_head.method {
                 &pavex::http::Method::POST => route_6::handler().await,
                 _ => {
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::POST],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
-        9u32 => {
+        11u32 => {
             match &request_head.method {
                 &pavex::http::Method::PUT => route_7::handler().await,
                 _ => {
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::PUT],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
-        10u32 => {
+        12u32 => {
             match &request_head.method {
                 &pavex::http::Method::TRACE => route_8::handler().await,
                 _ => {
                     let allowed_methods = pavex::router::AllowedMethods::new(
                         vec![pavex::http::Method::TRACE],
                     );
-                    route_11::handler(&allowed_methods).await
+                    route_13::handler(&allowed_methods).await
                 }
             }
         }
@@ -241,6 +277,18 @@ pub mod route_10 {
     }
 }
 pub mod route_11 {
+    pub async fn handler() -> pavex::response::Response {
+        let v0 = app::handler();
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v0)
+    }
+}
+pub mod route_12 {
+    pub async fn handler() -> pavex::response::Response {
+        let v0 = app::handler();
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v0)
+    }
+}
+pub mod route_13 {
     pub async fn handler(
         v0: &pavex::router::AllowedMethods,
     ) -> pavex::response::Response {

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/http_method_routing_variants/expectations/diagnostics.dot
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/http_method_routing_variants/expectations/diagnostics.dot
@@ -18,6 +18,20 @@ digraph "* /connect - 0" {
     3 -> 0 [ ]
 }
 
+digraph "CUSTOM /custom - 0" {
+    0 [ label = "app::handler() -> pavex::response::Response"]
+    1 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    0 -> 1 [ ]
+}
+
+digraph "* /custom - 0" {
+    0 [ label = "pavex::router::default_fallback(&pavex::router::AllowedMethods) -> pavex::response::Response"]
+    2 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    3 [ label = "&pavex::router::AllowedMethods"]
+    0 -> 2 [ ]
+    3 -> 0 [ ]
+}
+
 digraph "DELETE /delete - 0" {
     0 [ label = "app::handler() -> pavex::response::Response"]
     1 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
@@ -67,6 +81,20 @@ digraph "PATCH | POST /mixed - 0" {
 }
 
 digraph "* /mixed - 0" {
+    0 [ label = "pavex::router::default_fallback(&pavex::router::AllowedMethods) -> pavex::response::Response"]
+    2 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    3 [ label = "&pavex::router::AllowedMethods"]
+    0 -> 2 [ ]
+    3 -> 0 [ ]
+}
+
+digraph "CUSTOM | GET | HEY /mixed_with_custom - 0" {
+    0 [ label = "app::handler() -> pavex::response::Response"]
+    1 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    0 -> 1 [ ]
+}
+
+digraph "* /mixed_with_custom - 0" {
     0 [ label = "pavex::router::default_fallback(&pavex::router::AllowedMethods) -> pavex::response::Response"]
     2 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     3 [ label = "&pavex::router::AllowedMethods"]

--- a/libs/pavex_cli/tests/ui_tests/blueprint/router/http_method_routing_variants/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/router/http_method_routing_variants/lib.rs
@@ -1,8 +1,9 @@
-use pavex::f;
 use pavex::blueprint::{
     router::{MethodGuard, ANY, CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE},
     Blueprint,
 };
+use pavex::f;
+use pavex::http::Method;
 
 pub fn handler() -> pavex::response::Response {
     todo!()
@@ -21,8 +22,20 @@ pub fn blueprint() -> Blueprint {
     bp.route(TRACE, "/trace", f!(crate::handler));
     bp.route(ANY, "/any", f!(crate::handler));
     bp.route(
-        MethodGuard::new([pavex::http::Method::PATCH, pavex::http::Method::POST]),
+        MethodGuard::new([Method::PATCH, Method::POST]),
         "/mixed",
+        f!(crate::handler),
+    );
+    let custom_method = Method::from_bytes(b"CUSTOM").unwrap();
+    let custom2_method = Method::from_bytes(b"HEY").unwrap();
+    bp.route(
+        MethodGuard::new(vec![custom_method.clone()]),
+        "/custom",
+        f!(crate::handler),
+    );
+    bp.route(
+        MethodGuard::new(vec![custom_method, custom2_method, Method::GET]),
+        "/mixed_with_custom",
         f!(crate::handler),
     );
     bp


### PR DESCRIPTION
Custom methods were allowed by `MethodGuard`, but they weren't tested (and they didn't work).
This PR fixes it.