### PR TITLE
Add a Form extractor

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2041,6 +2041,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "form_urlencoded",
  "fs-err",
  "futures-util",
  "http 1.0.0",

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -35,6 +35,9 @@ serde_html_form = "0.2"
 serde_json = "1"
 serde_path_to_error = "0.1"
 
+# Form body extractor
+form_urlencoded = "1.2"
+
 # Blueprint builder
 indexmap = { version = "2", features = ["serde"] }
 fs-err = "2.7.0"

--- a/libs/pavex/src/request/body/buffered_body.rs
+++ b/libs/pavex/src/request/body/buffered_body.rs
@@ -14,7 +14,7 @@ use super::{
 /// Buffer the entire body of an incoming request in memory.
 ///
 /// `BufferedBody` is the ideal building block for _other_ extractors that need to
-/// have the entire body available in memory to do their job (e.g. [`JsonBody`](super::JsonBody)).  
+/// have the entire body available in memory to do their job (e.g. [`JsonBody`](super::JsonBody)).
 ///
 /// It can also be useful if you need to access the raw bytes of the body ahead of deserialization
 /// (e.g. to compute its hash as a step of a signature verification process).
@@ -71,7 +71,7 @@ use super::{
 /// # Body size limit
 ///
 /// To prevent denial-of-service attacks, Pavex enforces an upper limit on the body size when
-/// trying to buffer it in memory. The default limit is 2 MBs.  
+/// trying to buffer it in memory. The default limit is 2 MBs.
 ///
 /// [`BufferedBody::extract`] will return the [`SizeLimitExceeded`](ExtractBufferedBodyError::SizeLimitExceeded) error variant if the limit is exceeded.
 ///
@@ -98,7 +98,7 @@ use super::{
 /// }
 /// ```
 ///
-/// You can also disable the limit entirely:  
+/// You can also disable the limit entirely:
 ///
 /// ```rust
 /// use pavex::f;
@@ -119,7 +119,7 @@ use super::{
 /// ```
 ///
 /// There might be situations where you want granular control instead of having
-/// a single global limit for all incoming requests.  
+/// a single global limit for all incoming requests.
 /// You can leverage nesting for this purpose:
 ///
 /// ```rust
@@ -242,9 +242,11 @@ impl From<BufferedBody> for Bytes {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
     use http::HeaderMap;
+    use http_body_util::Full;
 
-    use crate::request::RequestHead;
+    use crate::request::{body::BufferedBody, RequestHead};
 
     // No headers.
     fn dummy_request_head() -> RequestHead {

--- a/libs/pavex/src/request/body/form.rs
+++ b/libs/pavex/src/request/body/form.rs
@@ -1,0 +1,305 @@
+use http::HeaderMap;
+use serde::Deserialize;
+
+use crate::request::RequestHead;
+
+use super::{
+    buffered_body::BufferedBody,
+    errors::{
+        ExtractFormBodyError, FormContentTypeMismatch, FormDeserializationError,
+        MissingFormContentType,
+    },
+};
+
+#[doc(alias = "Form")]
+#[derive(Debug)]
+/// Parse the body of an incoming request as an application/x-www-form-urlencoded form.
+///
+/// # Sections
+///
+/// - [Example](#example)
+/// - [Installation](#installtion)
+/// - [Avoiding allocations](#avoiding-allocations)
+/// - [Body size limit](#body-size-limit)
+///
+/// # Example
+///
+/// ```rust
+/// use pavex::request::body::FormBody;
+///
+/// // You must derive `serde::Deserialize` for the type you want to extract,
+/// // in this case `HomeListing`.
+/// #[derive(serde::Deserialize)]
+/// pub struct HomeListing {
+///     address: String,
+///     price: u64,
+/// }
+///
+/// // The `Form` extractor deserializes the request body into
+/// // the type you specified—`HomeListing` in this case.
+/// pub fn get_home(body: &FormBody<HomeListing>) -> String {
+///     format!(
+///         "The home you want to sell for {} is located at {}",
+///         body.0.price,
+///         body.0.address
+///     )
+/// }
+/// ```
+///
+/// # Installation
+///
+/// First of all, you need the register the default constructor and error handler for
+/// `FormBody` in your `Blueprint`:
+///
+/// ```rust
+/// use pavex::f;
+/// use pavex::blueprint::{Blueprint, constructor::Lifecycle};
+///
+/// fn blueprint() -> Blueprint {
+///    let mut bp = Blueprint::new();
+///    // Register the default constructor and error handler for `FormBody`.
+///    bp.constructor(
+///         f!(pavex::request::body::FormBody::extract),
+///         Lifecycle::RequestScoped,
+///     ).error_handler(
+///         f!(pavex::request::body::errors::ExtractFormBodyError::into_response)
+///     );
+///     // [...]
+///     bp
+/// }
+/// ```
+///
+/// You can then use the `FormBody` extractor as input to your route handlers and constructors.
+///
+/// # Avoiding allocations
+///
+/// If you want to minimize memory usage, you can try to avoid unnecessary memory allocations when
+/// deserializing string-like fields from the body of the incoming request.
+/// Pavex supports this use case—you can borrow from the request body instead of having to
+/// allocate a brand new string.
+///
+/// It is not always possible to avoid allocations, though.
+/// In particular, Pavex *must* allocate a new `String` if the Form string you are trying to
+/// deserialize contains percent-encoded characters.
+/// Using a `&str` in this case would result in a runtime error when attempting the deserialization.
+///
+/// Given the above, we recommend using `Cow<'_, str>` as field type: it borrows from the request
+/// body if possible, and allocates a new `String` only if strictly necessary.
+///
+/// ```rust
+/// use pavex::request::body::FormBody;
+/// use std::borrow::Cow;
+///
+/// #[derive(serde::Deserialize)]
+/// pub struct Payee<'a> {
+///     name: Cow<'a, str>,
+/// }
+///
+/// pub fn get_payee(body: &FormBody<Payee<'_>>) -> String {
+///    format!("The payee's name is {}", body.0.name)
+/// }
+/// ```
+///
+/// # Body size limit
+///
+/// The `FormBody` extractor buffers the entire body in memory before
+/// attempting to deserialize it.
+///
+/// To prevent denial-of-service attacks, Pavex enforces an upper limit on the body size.
+/// The limit is enforced by the [`BufferedBody`] extractor,
+/// which is injected as one of the inputs of [`FormBody::extract`]. Check out [`BufferedBody`]'s
+/// documentation for more details on the size limit (and how to configure it).
+///
+/// [`BufferedBody`]: super::buffered_body::BufferedBody
+pub struct FormBody<T>(pub T);
+
+impl<T> FormBody<T> {
+    /// The default constructor for [`FormBody`].
+    ///
+    /// The extraction can fail for a number of reasons:
+    ///
+    /// - the `Content-Type` is missing
+    /// - the `Content-Type` header is not set to `application/x-www-form-urlencoded`
+    /// - the request body is not a valid form
+    ///
+    /// In all of the above cases, an [`ExtractFormBodyError`] is returned.
+    // # Implementation notes
+    //
+    // We are using two separate lifetimes here to make it clear to the compiler
+    // that `FormBody` doesn't borrow from `RequestHead`.
+    pub fn extract<'head, 'body>(
+        request_head: &'head RequestHead,
+        buffered_body: &'body BufferedBody,
+    ) -> Result<Self, ExtractFormBodyError>
+    where
+        T: Deserialize<'body>,
+    {
+        check_form_content_type(&request_head.headers)?;
+        let deserializer = serde_html_form::Deserializer::new(form_urlencoded::parse(
+            buffered_body.bytes.as_ref(),
+        ));
+        let body = serde_path_to_error::deserialize(deserializer)
+            .map_err(|e| FormDeserializationError { source: e })?;
+        Ok(FormBody(body))
+    }
+}
+
+/// Check that the `Content-Type` header is set to `application/x-www-form-urlencoded`.
+///
+/// Return an error otherwise.
+fn check_form_content_type(headers: &HeaderMap) -> Result<(), ExtractFormBodyError> {
+    let Some(content_type) = headers.get(http::header::CONTENT_TYPE) else {
+        return Err(MissingFormContentType.into());
+    };
+    let Ok(content_type) = content_type.to_str() else {
+        return Err(MissingFormContentType.into());
+    };
+
+    let Ok(mime) = content_type.parse::<mime::Mime>() else {
+        return Err(FormContentTypeMismatch {
+            actual: content_type.to_string(),
+        }
+        .into());
+    };
+
+    let is_form_content_type =
+        mime.type_() == mime::APPLICATION && mime.subtype() == mime::WWW_FORM_URLENCODED;
+    if !is_form_content_type {
+        return Err(FormContentTypeMismatch {
+            actual: content_type.to_string(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::request::body::FormBody;
+
+    #[test]
+    fn missing_content_type() {
+        let headers = http::HeaderMap::new();
+        let err = super::check_form_content_type(&headers).unwrap_err();
+        insta::assert_display_snapshot!(err, @"The `Content-Type` header is missing. This endpoint expects requests with a `Content-Type` header set to `application/x-www-form-urlencoded`");
+        insta::assert_debug_snapshot!(err, @r###"
+        MissingContentType(
+            MissingFormContentType,
+        )
+        "###);
+    }
+
+    #[test]
+    fn content_type_is_not_valid_mime() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::CONTENT_TYPE, "hello world".parse().unwrap());
+
+        let err = super::check_form_content_type(&headers).unwrap_err();
+        insta::assert_display_snapshot!(err, @"The `Content-Type` header was set to `hello world`. This endpoint expects requests with a `Content-Type` header set to `application/x-www-form-urlencoded`");
+        insta::assert_debug_snapshot!(err, @r###"
+        ContentTypeMismatch(
+            FormContentTypeMismatch {
+                actual: "hello world",
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn content_type_is_not_form() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        );
+
+        let err = super::check_form_content_type(&headers).unwrap_err();
+        insta::assert_display_snapshot!(err, @"The `Content-Type` header was set to `application/json`. This endpoint expects requests with a `Content-Type` header set to `application/x-www-form-urlencoded`");
+        insta::assert_debug_snapshot!(err, @r###"
+        ContentTypeMismatch(
+            FormContentTypeMismatch {
+                actual: "application/json",
+            },
+        )
+        "###);
+    }
+
+    #[test]
+    fn content_type_is_form() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded".parse().unwrap(),
+        );
+
+        let outcome = super::check_form_content_type(&headers);
+        assert!(outcome.is_ok());
+    }
+
+    #[test]
+    fn form_content_type_with_charset() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded; charset=utf-8"
+                .parse()
+                .unwrap(),
+        );
+
+        let outcome = super::check_form_content_type(&headers);
+        assert!(outcome.is_ok());
+    }
+
+    #[test]
+    /// Let's check the error quality when the request body is missing
+    /// a required field.
+    fn missing_form_field() {
+        // Arrange
+        #[derive(serde::Deserialize, Debug)]
+        #[allow(dead_code)]
+        struct BodySchema {
+            name: String,
+            surname: String,
+            age: u8,
+        }
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded".parse().unwrap(),
+        );
+        let request_head = crate::request::RequestHead {
+            headers,
+            method: http::Method::GET,
+            uri: "/".parse().unwrap(),
+            version: http::Version::HTTP_11,
+        };
+        let body = "name=John%20Doe&age=43".to_string();
+
+        // Act
+        let buffered_body = crate::request::body::BufferedBody { bytes: body.into() };
+        let outcome: Result<FormBody<BodySchema>, _> =
+            FormBody::extract(&request_head, &buffered_body);
+
+        // Assert
+        let err = outcome.unwrap_err();
+        insta::assert_display_snapshot!(err, @r###"
+        Failed to deserialize the body as a form.
+        missing field `surname`
+        "###);
+        insta::assert_debug_snapshot!(err, @r###"
+        DeserializationError(
+            FormDeserializationError {
+                source: Error {
+                    path: Path {
+                        segments: [],
+                    },
+                    original: Error(
+                        "missing field `surname`",
+                    ),
+                },
+            },
+        )
+        "###);
+    }
+}

--- a/libs/pavex/src/request/body/mod.rs
+++ b/libs/pavex/src/request/body/mod.rs
@@ -10,19 +10,22 @@
 //! 2. [`BufferedBody`] takes a [`RawIncomingBody`] and buffers it in memory.
 //!   It also makes sure to enforce sane limits on the size of the body to avoid resource
 //!   exhaustion attacks.
-//!   You can use this type to extract the body of incoming requests as a bytes buffer.  
-//! 3. Deserializers.  
+//!   You can use this type to extract the body of incoming requests as a bytes buffer.
+//! 3. Deserializers.
 //!    They take a [`BufferedBody`] as input and pass it over to a deserializer for a certain
 //!    format (e.g. JSON) to extract the body as a structured type (e.g. a struct).
-//!    Pavex provides [`JsonBody`] as an example of such a deserializer for JSON.  
+//!    Pavex provides [`JsonBody`] and [`FormBody`] as examples of such
+//!    deserializers for JSON and form data respectively.
 
 pub use buffered_body::BufferedBody;
+pub use form::FormBody;
 pub use json::JsonBody;
 pub use limit::BodySizeLimit;
 pub use raw_body::RawIncomingBody;
 
 mod buffered_body;
 pub mod errors;
+mod form;
 mod json;
 mod limit;
 mod raw_body;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added an extractor for application/x-www-form-urlencoded requests. This feels common enough that it might warrant inclusion in the framework, but I'll be happy to move it into a third-party package instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
