### PR TITLE
Quick doc formatting fix

### DIFF
--- a/docs/getting_started/quickstart/index.md
+++ b/docs/getting_started/quickstart/index.md
@@ -1,9 +1,9 @@
 # Project setup
 
-!!! warning "Prerequisites"
+## Prerequisites
 
-    Make sure you've installed all the [required tools](../index.md) before starting
-    this tutorial.
+ Make sure you've installed all the [required tools](../index.md) before starting
+ this tutorial.
 
 ## Create a new Pavex project
 


### PR DESCRIPTION
The link to main doc index from the quickstart wasn't rendering, and a warning might be overkill anyway.