### PR TITLE
Introduce ByteUnit

### DIFF
--- a/doc_examples/guide/dependency_injection/cookbook/project/Cargo.lock
+++ b/doc_examples/guide/dependency_injection/cookbook/project/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -669,6 +670,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/doc_examples/guide/request_data/buffered_body/project-custom_limit.snap
+++ b/doc_examples/guide/request_data/buffered_body/project-custom_limit.snap
@@ -2,10 +2,11 @@
 use pavex::blueprint::{constructor::Lifecycle, Blueprint};
 use pavex::f;
 use pavex::request::body::BodySizeLimit;
+use pavex::unit::ToByteUnit;
 
 pub fn body_size_limit() -> BodySizeLimit {
     BodySizeLimit::Enabled {
-        max_n_bytes: 10_485_760, // 10 MBs
+        max_size: 2.megabytes(),
     }
 }
 

--- a/doc_examples/guide/request_data/buffered_body/project-granular_limits.snap
+++ b/doc_examples/guide/request_data/buffered_body/project-granular_limits.snap
@@ -2,6 +2,7 @@
 use pavex::blueprint::{constructor::Lifecycle, router::POST, Blueprint};
 use pavex::f;
 use pavex::request::body::BodySizeLimit;
+use pavex::unit::ToByteUnit;
 
 pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
@@ -21,7 +22,7 @@ fn upload_bp() -> Blueprint {
 
 pub fn upload_size_limit() -> BodySizeLimit {
     BodySizeLimit::Enabled {
-        max_n_bytes: 1_073_741_824, // 1GB
+        max_size: 1.gigabytes(),
     }
 }
 ```

--- a/doc_examples/guide/request_data/buffered_body/project/Cargo.lock
+++ b/doc_examples/guide/request_data/buffered_body/project/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -670,6 +671,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/doc_examples/guide/request_data/buffered_body/project/src/custom_limit/blueprint.rs
+++ b/doc_examples/guide/request_data/buffered_body/project/src/custom_limit/blueprint.rs
@@ -1,10 +1,11 @@
 use pavex::blueprint::{constructor::Lifecycle, Blueprint};
 use pavex::f;
 use pavex::request::body::BodySizeLimit;
+use pavex::unit::ToByteUnit;
 
 pub fn body_size_limit() -> BodySizeLimit {
     BodySizeLimit::Enabled {
-        max_n_bytes: 10_485_760, // 10 MBs
+        max_size: 2.megabytes(),
     }
 }
 

--- a/doc_examples/guide/request_data/buffered_body/project/src/granular_limits/blueprint.rs
+++ b/doc_examples/guide/request_data/buffered_body/project/src/granular_limits/blueprint.rs
@@ -1,6 +1,7 @@
 use pavex::blueprint::{constructor::Lifecycle, router::POST, Blueprint};
 use pavex::f;
 use pavex::request::body::BodySizeLimit;
+use pavex::unit::ToByteUnit;
 
 pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
@@ -20,6 +21,6 @@ fn upload_bp() -> Blueprint {
 
 pub fn upload_size_limit() -> BodySizeLimit {
     BodySizeLimit::Enabled {
-        max_n_bytes: 1_073_741_824, // 1GB
+        max_size: 1.gigabytes(),
     }
 }

--- a/doc_examples/guide/request_data/buffered_body/tutorial.yml
+++ b/doc_examples/guide/request_data/buffered_body/tutorial.yml
@@ -9,7 +9,7 @@ snippets:
     hl_lines: [ 4 ]
   - name: "custom_limit"
     source_path: "src/custom_limit/blueprint.rs"
-    ranges: [ "0..13", "19..20" ]
+    ranges: [ "0..14", "20..21" ]
   - name: "no_limit"
     source_path: "src/no_limit/blueprint.rs"
     ranges: [ "0..11", "17..18" ]

--- a/doc_examples/guide/request_data/json/project/Cargo.lock
+++ b/doc_examples/guide/request_data/json/project/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -670,6 +671,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/doc_examples/guide/request_data/path/project/Cargo.lock
+++ b/doc_examples/guide/request_data/path/project/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -670,6 +671,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/doc_examples/guide/request_data/query/project/Cargo.lock
+++ b/doc_examples/guide/request_data/query/project/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -670,6 +671,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/doc_examples/guide/request_data/query_params/project/Cargo.lock
+++ b/doc_examples/guide/request_data/query_params/project/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -670,6 +671,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/doc_examples/guide/request_data/request_target/project/Cargo.lock
+++ b/doc_examples/guide/request_data/request_target/project/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -669,6 +670,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/doc_examples/guide/request_data/route_params/project/Cargo.lock
+++ b/doc_examples/guide/request_data/route_params/project/Cargo.lock
@@ -394,6 +394,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -670,6 +671,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2068,6 +2068,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -3374,6 +3375,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -23,6 +23,7 @@ paste = "1"
 tracing = "0.1"
 http-body-util = "0.1"
 pin-project-lite = "0.2"
+ubyte = { version = "0.10.4", features = ["serde"] }
 
 # Route parameters
 matchit = { git = "https://github.com/ibraheemdev/matchit", branch = "master" }

--- a/libs/pavex/src/lib.rs
+++ b/libs/pavex/src/lib.rs
@@ -22,3 +22,4 @@ pub mod router;
 pub mod serialization;
 #[cfg(feature = "server")]
 pub mod server;
+pub mod unit;

--- a/libs/pavex/src/request/body/errors.rs
+++ b/libs/pavex/src/request/body/errors.rs
@@ -1,5 +1,6 @@
 //! Errors that can occur while extracting information from the request body.
 use crate::response::Response;
+use ubyte::ByteUnit;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -61,7 +62,7 @@ impl ExtractBufferedBodyError {
 /// The request body is larger than the maximum size limit enforced by this server.
 pub struct SizeLimitExceeded {
     /// The maximum size limit enforced by this server.
-    pub max_n_bytes: usize,
+    pub max_size: ByteUnit,
     /// The value of the `Content-Length` header for the request that breached the body
     /// size limit.  
     ///

--- a/libs/pavex/src/request/body/limit.rs
+++ b/libs/pavex/src/request/body/limit.rs
@@ -1,6 +1,8 @@
 use crate::blueprint::constructor::{Constructor, Lifecycle};
 use crate::blueprint::Blueprint;
 use crate::f;
+use crate::unit::ByteUnit;
+use ubyte::ToByteUnit;
 
 #[derive(Debug, Clone, Copy)]
 /// An upper limit on the size of incoming request bodies.  
@@ -10,7 +12,7 @@ pub enum BodySizeLimit {
     /// There is an active limit on the size of incoming request bodies.
     Enabled {
         /// The maximum size of incoming request bodies, in bytes.
-        max_n_bytes: usize,
+        max_size: ByteUnit,
     },
     /// There is no limit on the size of incoming request bodies.
     Disabled,
@@ -29,7 +31,7 @@ impl BodySizeLimit {
 impl Default for BodySizeLimit {
     fn default() -> Self {
         Self::Enabled {
-            max_n_bytes: 2_097_152, // 2 MBs
+            max_size: 2.megabytes(),
         }
     }
 }

--- a/libs/pavex/src/unit.rs
+++ b/libs/pavex/src/unit.rs
@@ -1,0 +1,2 @@
+//! Type-safe wrappers for working with measurable quantities (e.g. bytes).
+pub use ubyte::{ByteUnit, ToByteUnit};

--- a/libs/pavex_macros/tests/fail/serde_conflict.stderr
+++ b/libs/pavex_macros/tests/fail/serde_conflict.stderr
@@ -1,8 +1,8 @@
-error: `RouteParams` does not support `serde` attributes on the top-level struct or any of its fields.
+error: `PathParams` does not support `serde` attributes on the top-level struct or any of its fields.
 
-       `RouteParams` takes care of deriving `serde::Serialize` and `serde::Deserialize` for your struct, using the default configuration. This allow Pavex to determine, at code-generation time, if the route params can be successfully extracted from the URL of incoming requests for the relevant routes (e.g. do you have a named field that doesn't map to any of the registered route parameters?).
+       `PathParams` takes care of deriving `serde::Serialize` and `serde::Deserialize` for your struct, using the default configuration. This allow Pavex to determine, at code-generation time, if the route params can be successfully extracted from the URL of incoming requests for the relevant routes (e.g. do you have a named field that doesn't map to any of the registered route parameters?).
 
-       If the default `serde` configuration won't work for your case, you should not derive `RouteParams` and opt instead for implementing `serde::Serialize` and `serde::Deserialize` directly for your struct (either manually or using a derive with custom attributes).
+       If the default `serde` configuration won't work for your case, you should not derive `PathParams` and opt instead for implementing `serde::Serialize` and `serde::Deserialize` directly for your struct (either manually or using a derive with custom attributes).
        Keep in mind that by going down this route you give up compile-time checking of the route parameters!
  --> tests/fail/serde_conflict.rs:3:1
   |

--- a/libs/pavex_macros/tests/fail/serde_conflict_after_route_params_without_attributes.stderr
+++ b/libs/pavex_macros/tests/fail/serde_conflict_after_route_params_without_attributes.stderr
@@ -1,8 +1,8 @@
 error[E0119]: conflicting implementations of trait `Deserialize<'_>` for type `MyStruct`
  --> tests/fail/serde_conflict_after_route_params_without_attributes.rs:1:1
   |
-1 | #[pavex_macros::RouteParams]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyStruct`
+1 | #[pavex_macros::PathParams]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyStruct`
 2 | #[derive(serde::Deserialize)]
   |          ------------------ first implementation here
   |

--- a/libs/pavex_macros/tests/fail/serde_conflict_before_route_params_without_attributes.stderr
+++ b/libs/pavex_macros/tests/fail/serde_conflict_before_route_params_without_attributes.stderr
@@ -3,7 +3,7 @@ error[E0119]: conflicting implementations of trait `Deserialize<'_>` for type `M
   |
 1 | #[derive(serde::Deserialize)]
   |          ------------------ first implementation here
-2 | #[pavex_macros::RouteParams]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyStruct`
+2 | #[pavex_macros::PathParams]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyStruct`
   |
   = note: this error originates in the derive macro `serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Manipulating bytes as `usize`s is... clunky. 
I find myself commenting on relevant lines with the value converted in the most relevant unit (e.g. MB or GB). That's a clear-cut code smell if I've ever seen one.

We introduce `ByteUnit` by re-exporting from the `ubyte` crate. It is used in [`rocket`](https://api.rocket.rs/master/rocket/data/struct.ByteUnit.html) and it fits our needs perfectly.

⚠️ Breaking change: I renamed `max_n_bytes` to `max_size` in `BodySizeLimit`. The type has also changed from `usize` to `ByteUnit`. This impacts you if you were registering a custom constructor for `BodySizeLimit`. The same applies to the `SizeLimitExceeded` error.