### PR TITLE
docs: Don't recommend building the CLI from source to new users

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -45,12 +45,17 @@ Pavex relies on `nightly` to perform code generation and compile-time reflection
 Pavex provides a command-line interface to scaffold new projects and work with existing ones.  
 To install it, execute the following command:
 
-```bash
-cargo install --locked \
-  --git "https://github.com/LukeMathWalker/pavex.git" \
-  --branch "main" \
-  pavex_cli
-```
+=== "shell"
+
+    ```bash
+    curl --proto '=https' --tlsv1.2 -LsSf https://pavex.dev/releases/download/latest/pavex_cli-installer.sh | sh
+    ```
+
+=== "powershell"
+
+    ```powershell
+    irm https://pavex.dev/releases/download/latest/pavex_cli-installer.ps1 | iex
+    ```
 
 You can check that it's been installed correctly by running:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,8 @@ markdown_extensions:
   - attr_list
   - md_in_html
   - footnotes
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
In the docs we now link to the installers created by `cargo-dist`, which will automatically detect the user's platform and download the most appropriate CLI artifact.
All scripts and artefacts are stored alongside their respective GitHub releases, but we proxy through https://pavex.dev/ to get shorter URLs and a way to target `latest`.