### PR TITLE
Download prebuilt for "tag" toolchains

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2364,6 +2364,7 @@ dependencies = [
  "remove_dir_all",
  "semver",
  "serde",
+ "serde_json",
  "sha2",
  "supports-color",
  "tar",
@@ -3879,6 +3880,8 @@ dependencies = [
  "once_cell",
  "rustls",
  "rustls-webpki",
+ "serde",
+ "serde_json",
  "url",
  "webpki-roots",
 ]

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -34,7 +34,7 @@ xz2 = "0.1.7"
 tar = "0.4.40"
 bytes = "1.5.0"
 tempfile = "3"
-ureq = "2.9.1"
+ureq = { version = "2.9.1", features = ["json"] }
 remove_dir_all = "0.8.2"
 config = { version = "0.13.4", features = [] }
 libc = { version = "0.2.152", features = [] }
@@ -43,6 +43,7 @@ cargo-like-utils = "0.1.0"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8.8"
 semver = { version = "1.0.21", features = ["serde"] }
+serde_json = "1.0.111"
 
 [dev-dependencies]
 pavex_test_runner = { path = "../pavex_test_runner" }

--- a/libs/pavex_cli/src/cargo_install.rs
+++ b/libs/pavex_cli/src/cargo_install.rs
@@ -9,6 +9,8 @@ pub enum Source {
 
 pub enum GitSourceRevision {
     Rev(String),
+    Tag(String),
+    Branch(String),
 }
 
 /// Install a single binary via `cargo install` and copy it to the specified destination path.
@@ -37,6 +39,14 @@ pub fn cargo_install(
                 GitSourceRevision::Rev(rev) => {
                     cmd.arg("--rev");
                     cmd.arg(&rev);
+                }
+                GitSourceRevision::Tag(tag) => {
+                    cmd.arg("--tag");
+                    cmd.arg(&tag);
+                }
+                GitSourceRevision::Branch(branch) => {
+                    cmd.arg("--branch");
+                    cmd.arg(&branch);
                 }
             }
         }

--- a/libs/pavex_cli/src/pavexc/install.rs
+++ b/libs/pavex_cli/src/pavexc/install.rs
@@ -158,14 +158,15 @@ pub(super) fn install(
     };
 
     if try_prebuilt {
+        let _ = shell.status("Downloading", format!("prebuilt `pavexc@{version}` binary"));
         match download_prebuilt(pavexc_cli_path, version) {
             Ok(_) => {
+                let _ = shell.status("Downloaded", format!("prebuilt `pavexc@{version}` binary"));
                 return Ok(());
             }
             Err(e) => {
-                let _ = shell.warn(
-                    "Failed to download prebuilt `pavexc` binary: {e}.\nI'll try to build it from source instead.",
-                );
+                let _ =
+                    shell.warn("Download failed: {e}.\nI'll try to build it from source instead.");
                 tracing::warn!(
                     error.msg = %e,
                     error.cause = ?e,

--- a/libs/pavex_cli/src/pavexc/install.rs
+++ b/libs/pavex_cli/src/pavexc/install.rs
@@ -166,7 +166,7 @@ pub(super) fn install(
             }
             Err(e) => {
                 let _ =
-                    shell.warn("Download failed: {e}.\nI'll try to build it from source instead.");
+                    shell.warn("Download failed: {e}.\nI'll try compiling from source instead.");
                 tracing::warn!(
                     error.msg = %e,
                     error.cause = ?e,
@@ -176,7 +176,9 @@ pub(super) fn install(
         }
     }
 
+    let _ = shell.status("Compiling", format!("`pavexc@{version}` from source"));
     cargo_install(install_source, "pavexc", "pavexc_cli", pavexc_cli_path)?;
+    let _ = shell.status("Compiled", format!("`pavexc@{version}` from source"));
     Ok(())
 }
 

--- a/libs/pavex_cli/src/pavexc/install.rs
+++ b/libs/pavex_cli/src/pavexc/install.rs
@@ -1,9 +1,85 @@
 use crate::cargo_install::{cargo_install, GitSourceRevision, Source};
 use crate::pavexc::prebuilt::download_prebuilt;
 use cargo_like_utils::shell::Shell;
-use guppy::graph::{ExternalSource, GitReq, PackageSource};
+use guppy::graph::PackageSource;
 use guppy::Version;
 use std::path::{Path, PathBuf};
+
+pub enum InstallSource {
+    /// Install the binary from the current workspace.
+    Workspace,
+    /// Install the binary from the specified path.
+    Path(PathBuf),
+    /// Install the binary from the specified external source.
+    External(ExternalSource),
+}
+
+pub enum ExternalSource {
+    Registry {
+        url: String,
+    },
+    Git {
+        repository: String,
+        req: GitReq,
+        resolved: Option<String>,
+    },
+}
+
+pub enum GitReq {
+    Tag(String),
+    Rev(String),
+    Branch(String),
+}
+
+impl<'a> TryFrom<PackageSource<'a>> for InstallSource {
+    type Error = InstallError;
+
+    fn try_from(value: PackageSource<'a>) -> Result<Self, Self::Error> {
+        match value {
+            PackageSource::Workspace(_) => Ok(InstallSource::Workspace),
+            PackageSource::Path(p) => Ok(InstallSource::Path(p.as_std_path().to_path_buf())),
+            PackageSource::External(s) => {
+                let parsed = value.parse_external();
+                let Some(parsed) = parsed else {
+                    return Err(InstallError::InvalidSource(InvalidSourceError {
+                        package_source: s.to_string(),
+                    }));
+                };
+                match parsed {
+                    guppy::graph::ExternalSource::Registry(c) => {
+                        Ok(InstallSource::External(ExternalSource::Registry {
+                            url: c.strip_prefix("registry+").unwrap_or(c).into(),
+                        }))
+                    }
+                    guppy::graph::ExternalSource::Git {
+                        repository,
+                        req,
+                        resolved,
+                    } => Ok(InstallSource::External(ExternalSource::Git {
+                        repository: repository.into(),
+                        req: match req {
+                            guppy::graph::GitReq::Branch(b) => GitReq::Branch(b.into()),
+                            guppy::graph::GitReq::Tag(t) => GitReq::Tag(t.into()),
+                            guppy::graph::GitReq::Rev(r) => GitReq::Rev(r.into()),
+                            guppy::graph::GitReq::Default => GitReq::Branch("main".to_string()),
+                            _ => {
+                                return Err(InstallError::UnsupportedSource(
+                                    UnsupportedSourceError {
+                                        package_source: format!("an unknown `git` source ({s})",),
+                                    },
+                                ))
+                            }
+                        },
+                        resolved: Some(resolved.into()),
+                    })),
+                    _ => Err(InstallError::UnsupportedSource(UnsupportedSourceError {
+                        package_source: s.to_string(),
+                    })),
+                }
+            }
+        }
+    }
+}
 
 /// Given the version and source for the `pavex` library crate, install the corresponding
 /// `pavexc` binary crate at the specified path.
@@ -11,118 +87,95 @@ pub(super) fn install(
     shell: &mut Shell,
     pavexc_cli_path: &Path,
     version: &Version,
-    package_source: &PackageSource,
+    install_source: &InstallSource,
 ) -> Result<(), InstallError> {
-    match package_source {
-        PackageSource::Workspace(_) => {
+    let (try_prebuilt, install_source) = match install_source {
+        InstallSource::Workspace => {
             if !pavexc_cli_path.exists() {
                 return Err(InstallError::NoWorkspaceBinary(NoWorkspaceBinaryError {
                     pavexc_expected_path: pavexc_cli_path.to_path_buf(),
                 }));
+            } else {
+                return Ok(());
             }
         }
-        PackageSource::Path(p) => {
+        InstallSource::Path(p) => {
             let workspace_root = p
                 .parent()
                 .expect("pavex's source path has to have a parent");
             if !pavexc_cli_path.exists() {
                 return Err(InstallError::NoLocalBinary(NoLocalBinaryError {
-                    pavex_source_path: p.as_std_path().to_path_buf(),
+                    pavex_source_path: p.to_owned(),
                     pavexc_expected_path: pavexc_cli_path.to_path_buf(),
-                    workspace_path: workspace_root.as_std_path().to_path_buf(),
+                    workspace_path: workspace_root.to_path_buf(),
                 }));
+            } else {
+                return Ok(());
             }
         }
-        PackageSource::External(_) => {
-            let parsed = package_source.parse_external();
-            let Some(parsed) = parsed else {
-                return Err(InstallError::InvalidSource(InvalidSourceError {
-                    package_source: package_source.to_string(),
-                    version: version.to_owned(),
+        InstallSource::External(ExternalSource::Registry { url }) => {
+            if url != guppy::graph::ExternalSource::CRATES_IO_URL {
+                return Err(InstallError::UnsupportedSource(UnsupportedSourceError {
+                    package_source: format!("a private registry ({})", url),
                 }));
+            }
+            (
+                true,
+                Source::CratesIo {
+                    version: version.to_string(),
+                },
+            )
+        }
+        InstallSource::External(ExternalSource::Git {
+            repository,
+            req,
+            resolved,
+        }) => {
+            let mut try_prebuilt = false;
+            if repository == "https://github.com/LukeMathWalker/pavex" {
+                if let GitReq::Tag(tag) = req {
+                    if tag == version.to_string().as_str() {
+                        try_prebuilt = true;
+                    }
+                }
+            }
+            let git_source = match resolved {
+                None => match req {
+                    GitReq::Tag(tag) => GitSourceRevision::Tag(tag.into()),
+                    GitReq::Rev(rev) => GitSourceRevision::Rev(rev.into()),
+                    GitReq::Branch(branch) => GitSourceRevision::Branch(branch.into()),
+                },
+                Some(r) => GitSourceRevision::Rev(r.into()),
             };
-            match parsed {
-                ExternalSource::Registry(c) => {
-                    if !package_source.is_crates_io() {
-                        return Err(InstallError::UnsupportedSource(UnsupportedSourceError {
-                            package_source: format!(
-                                "a private registry ({})",
-                                c.strip_prefix("registry+").unwrap_or(c)
-                            ),
-                            version: version.to_owned(),
-                        }));
-                    }
+            (
+                try_prebuilt,
+                Source::Git {
+                    url: repository.into(),
+                    rev: git_source,
+                },
+            )
+        }
+    };
 
-                    match download_prebuilt(pavexc_cli_path, version) {
-                        Ok(_) => {
-                            return Ok(());
-                        }
-                        Err(e) => {
-                            let _ = shell.warn(
-                                "Failed to download prebuilt `pavexc` binary. I'll try to build it from source instead.",
-                            );
-                            tracing::warn!(
-                                error.msg = %e,
-                                error.cause = ?e,
-                                "Failed to download prebuilt `pavexc` binary. I'll try to build it from source instead.",
-                            );
-                        }
-                    }
-
-                    cargo_install(
-                        Source::CratesIo {
-                            version: version.to_string(),
-                        },
-                        "pavexc",
-                        "pavexc_cli",
-                        pavexc_cli_path,
-                    )?;
-                }
-                ExternalSource::Git {
-                    repository,
-                    req,
-                    resolved,
-                } => {
-                    if repository == "https://github.com/LukeMathWalker/pavex" {
-                        if let GitReq::Tag(tag) = req {
-                            if tag == version.to_string() {
-                                match download_prebuilt(pavexc_cli_path, version) {
-                                    Ok(_) => {
-                                        return Ok(());
-                                    }
-                                    Err(e) => {
-                                        let _ = shell.warn(
-                                            "Failed to download prebuilt `pavexc` binary. I'll try to build it from source instead.",
-                                        );
-                                        tracing::warn!(
-                                            error.msg = %e,
-                                            error.cause = ?e,
-                                            "Failed to download prebuilt `pavexc` binary. I'll try to build it from source instead.",
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    cargo_install(
-                        Source::Git {
-                            url: repository.into(),
-                            rev: GitSourceRevision::Rev(resolved.into()),
-                        },
-                        "pavexc",
-                        "pavexc_cli",
-                        pavexc_cli_path,
-                    )?;
-                }
-                _ => {
-                    return Err(InstallError::UnsupportedSource(UnsupportedSourceError {
-                        package_source: package_source.to_string(),
-                        version: version.to_owned(),
-                    }));
-                }
+    if try_prebuilt {
+        match download_prebuilt(pavexc_cli_path, version) {
+            Ok(_) => {
+                return Ok(());
+            }
+            Err(e) => {
+                let _ = shell.warn(
+                    "Failed to download prebuilt `pavexc` binary. I'll try to build it from source instead.",
+                );
+                tracing::warn!(
+                    error.msg = %e,
+                    error.cause = ?e,
+                    "Failed to download prebuilt `pavexc` binary. I'll try to build it from source instead.",
+                );
             }
         }
     }
+
+    cargo_install(install_source, "pavexc", "pavexc_cli", pavexc_cli_path)?;
     Ok(())
 }
 
@@ -141,17 +194,15 @@ pub enum InstallError {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("`pavex` can't automatically install `pavexc@{version}` from {package_source}")]
+#[error("`pavex` can't automatically install `pavexc` from {package_source}")]
 pub struct UnsupportedSourceError {
     pub(crate) package_source: String,
-    pub(crate) version: Version,
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("`pavex` doesn't recognise `{package_source}` as a valid source to install `pavexc@{version}` from")]
+#[error("`pavex` doesn't recognise `{package_source}` as a valid source to install `pavexc` from")]
 pub struct InvalidSourceError {
     pub(crate) package_source: String,
-    pub(crate) version: Version,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/libs/pavex_cli/src/pavexc/install.rs
+++ b/libs/pavex_cli/src/pavexc/install.rs
@@ -164,7 +164,7 @@ pub(super) fn install(
             }
             Err(e) => {
                 let _ = shell.warn(
-                    "Failed to download prebuilt `pavexc` binary. I'll try to build it from source instead.",
+                    "Failed to download prebuilt `pavexc` binary: {e}.\nI'll try to build it from source instead.",
                 );
                 tracing::warn!(
                     error.msg = %e,

--- a/libs/pavex_cli/src/pavexc/location.rs
+++ b/libs/pavex_cli/src/pavexc/location.rs
@@ -30,7 +30,6 @@ pub(super) fn path_from_graph(
             let Some(parsed) = parsed else {
                 return Ok(Err(UnsupportedSourceError {
                     package_source: package_source.to_string(),
-                    version: version.to_owned(),
                 }));
             };
             match parsed {
@@ -41,7 +40,6 @@ pub(super) fn path_from_graph(
                                 "a private registry ({})",
                                 c.strip_prefix("registry+").unwrap_or(c)
                             ),
-                            version: version.to_owned(),
                         }));
                     }
                     Ok(Ok(toolchains_locator
@@ -60,7 +58,6 @@ pub(super) fn path_from_graph(
                 _ => {
                     return Ok(Err(UnsupportedSourceError {
                         package_source: package_source.to_string(),
-                        version: version.to_owned(),
                     }));
                 }
             }

--- a/libs/pavex_cli/src/pavexc/prebuilt.rs
+++ b/libs/pavex_cli/src/pavexc/prebuilt.rs
@@ -11,7 +11,7 @@ pub(super) fn download_prebuilt(
 ) -> Result<(), DownloadPrebuiltError> {
     let host_triple = get_host_triple()?;
     let url_prefix =
-        format!("https://github.com/LukeMathWalker/pavex/releases/download/{version}/pavex_cli-{host_triple}");
+        format!("https://github.com/LukeMathWalker/pavex/releases/download/{version}/pavexc_cli-{host_triple}");
     let download_url = match host_triple.as_str() {
         "x86_64-unknown-linux-gnu" | "x86_64-apple-darwin" | "aarch64-apple-darwin" => {
             format!("{url_prefix}.tar.xz")


### PR DESCRIPTION
Using the CLI's commit SHA as the "default" toolchain forces `pavex` to always compile `pavexc` from source when executing `pavex new` for the first time. That's not ideal.

The install module has been restructured to allow downloading from a `git` source even if we don't know its SHA. We'll switch to crates.io once Pavex is published there.

Miscellaneous improvements:
- Shell messages explaining to the user what's happening
- Fixed download URL for prebuilt `pavexc`