### PR TITLE
Version management #2: self-updating and uninstalling

### DIFF
--- a/doc_examples/guide/dependency_injection/cookbook/project/Cargo.lock
+++ b/doc_examples/guide/dependency_injection/cookbook/project/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/middleware/core_concepts/project/Cargo.lock
+++ b/doc_examples/guide/middleware/core_concepts/project/Cargo.lock
@@ -382,7 +382,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/buffered_body/project/Cargo.lock
+++ b/doc_examples/guide/request_data/buffered_body/project/Cargo.lock
@@ -388,7 +388,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/json/project/Cargo.lock
+++ b/doc_examples/guide/request_data/json/project/Cargo.lock
@@ -388,7 +388,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/path/project/Cargo.lock
+++ b/doc_examples/guide/request_data/path/project/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/query/project/Cargo.lock
+++ b/doc_examples/guide/request_data/query/project/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/query_params/project/Cargo.lock
+++ b/doc_examples/guide/request_data/query_params/project/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/request_target/project/Cargo.lock
+++ b/doc_examples/guide/request_data/request_target/project/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/route_params/project/Cargo.lock
+++ b/doc_examples/guide/request_data/route_params/project/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "pavex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
  "paste",
  "path-absolutize",
  "regex",
- "remove_dir_all 0.8.2",
+ "remove_dir_all",
  "rhai",
  "sanitize-filename",
  "semver",
@@ -385,7 +385,7 @@ dependencies = [
  "config",
  "fs-err",
  "libc",
- "remove_dir_all 0.8.2",
+ "remove_dir_all",
  "serde",
  "serde_json",
  "supports-hyperlinks",
@@ -908,12 +908,6 @@ dependencies = [
  "nix",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-channel"
@@ -2008,7 +2002,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2276,7 +2270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2376,7 +2370,7 @@ dependencies = [
  "pavex_test_runner",
  "pavexc",
  "pavexc_cli_client",
- "remove_dir_all 0.8.2",
+ "remove_dir_all",
  "self-replace",
  "semver",
  "serde",
@@ -2384,7 +2378,6 @@ dependencies = [
  "sha2",
  "supports-color",
  "tar",
- "tempdir",
  "tempfile",
  "thiserror",
  "toml 0.8.8",
@@ -2733,26 +2726,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -2762,23 +2742,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2807,15 +2772,6 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2890,15 +2846,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "remove_dir_all"
@@ -3509,16 +3456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all 0.5.3",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3994,7 +3931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
  "paste",
  "path-absolutize",
  "regex",
- "remove_dir_all",
+ "remove_dir_all 0.8.2",
  "rhai",
  "sanitize-filename",
  "semver",
@@ -385,7 +385,7 @@ dependencies = [
  "config",
  "fs-err",
  "libc",
- "remove_dir_all",
+ "remove_dir_all 0.8.2",
  "serde",
  "serde_json",
  "supports-hyperlinks",
@@ -815,6 +815,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
@@ -899,6 +908,12 @@ dependencies = [
  "nix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-channel"
@@ -1200,7 +1215,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de6225e2de30b6e9bca2d9f1cc4731640fcef0fb3cabddceee366e7e85d3e94f"
 dependencies = [
- "fastrand",
+ "fastrand 2.0.1",
 ]
 
 [[package]]
@@ -1993,7 +2008,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2261,7 +2276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2361,13 +2376,15 @@ dependencies = [
  "pavex_test_runner",
  "pavexc",
  "pavexc_cli_client",
- "remove_dir_all",
+ "remove_dir_all 0.8.2",
+ "self-replace",
  "semver",
  "serde",
  "serde_json",
  "sha2",
  "supports-color",
  "tar",
+ "tempdir",
  "tempfile",
  "thiserror",
  "toml 0.8.8",
@@ -2716,13 +2733,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2732,8 +2762,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2762,6 +2807,15 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2836,6 +2890,15 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "remove_dir_all"
@@ -3115,6 +3178,17 @@ checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525db198616b2bcd0f245daf7bfd8130222f7ee6af9ff9984c19a61bf1160c55"
+dependencies = [
+ "fastrand 1.9.0",
+ "tempfile",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3435,13 +3509,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all 0.5.3",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.1",
  "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.48.0",
@@ -3910,7 +3994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/libs/pavex/tests/server.rs
+++ b/libs/pavex/tests/server.rs
@@ -112,6 +112,7 @@ impl SlowHandlerState {
 }
 
 #[tokio::test]
+#[cfg_attr(target_os = "windows", ignore = "Flaky on Windows")]
 async fn graceful() {
     let (incoming, addr) = test_incoming().await;
     let delay = Duration::from_millis(100);
@@ -182,6 +183,7 @@ async fn forced() {
 }
 
 #[tokio::test]
+#[cfg_attr(target_os = "windows", ignore = "Flaky on Windows")]
 async fn graceful_but_too_fast() {
     let (incoming, addr) = test_incoming().await;
     let delay = Duration::from_millis(200);

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -44,6 +44,8 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8.8"
 semver = { version = "1.0.21", features = ["serde"] }
 serde_json = "1.0.111"
+tempdir = { version = "0.3.7", features = [] }
+self-replace = "1.3.7"
 
 [dev-dependencies]
 pavex_test_runner = { path = "../pavex_test_runner" }

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -44,7 +44,6 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8.8"
 semver = { version = "1.0.21", features = ["serde"] }
 serde_json = "1.0.111"
-tempdir = { version = "0.3.7", features = [] }
 self-replace = "1.3.7"
 
 [dev-dependencies]

--- a/libs/pavex_cli/src/confirmation.rs
+++ b/libs/pavex_cli/src/confirmation.rs
@@ -1,0 +1,32 @@
+use anyhow::{anyhow, Context};
+use std::io::{BufRead, Write};
+
+/// Prompt the user for confirmation.
+pub fn confirm(question: &str, default: bool) -> Result<bool, anyhow::Error> {
+    write!(std::io::stdout().lock(), "{question} ")?;
+    let _ = std::io::stdout().flush();
+    let input = read_line()?;
+
+    let r = match &*input.to_lowercase() {
+        "y" | "yes" => true,
+        "n" | "no" => false,
+        "" => default,
+        _ => false,
+    };
+
+    writeln!(std::io::stdout().lock())?;
+
+    Ok(r)
+}
+
+fn read_line() -> Result<String, anyhow::Error> {
+    let stdin = std::io::stdin();
+    let stdin = stdin.lock();
+    let mut lines = stdin.lines();
+    let lines = lines.next().transpose()?;
+    match lines {
+        None => Err(anyhow!("No lines found from stdin")),
+        Some(v) => Ok(v),
+    }
+    .context("Unable to read from stdin for confirmation")
+}

--- a/libs/pavex_cli/src/env.rs
+++ b/libs/pavex_cli/src/env.rs
@@ -28,6 +28,7 @@ pub const fn commit_sha() -> &'static str {
 }
 
 /// The version of `pavex_cli` that is being used.
-pub const fn version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
+pub fn version() -> semver::Version {
+    semver::Version::parse(env!("CARGO_PKG_VERSION"))
+        .expect("CLI version is not valid according to SemVer")
 }

--- a/libs/pavex_cli/src/lib.rs
+++ b/libs/pavex_cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cargo_install;
+pub mod confirmation;
 pub mod env;
 pub mod locator;
 pub mod package_graph;

--- a/libs/pavex_cli/src/lib.rs
+++ b/libs/pavex_cli/src/lib.rs
@@ -1,7 +1,10 @@
-mod cargo_install;
+pub mod cargo_install;
 pub mod env;
 pub mod locator;
 pub mod package_graph;
 pub mod pavexc;
+pub mod prebuilt;
 pub mod state;
 pub mod toolchain;
+pub mod utils;
+pub mod version;

--- a/libs/pavex_cli/src/main.rs
+++ b/libs/pavex_cli/src/main.rs
@@ -1,18 +1,23 @@
 use anyhow::Context;
 use cargo_like_utils::shell::Shell;
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
 
 use clap::{Parser, Subcommand};
+use pavex_cli::cargo_install::{cargo_install, GitSourceRevision, Source};
 use pavex_cli::locator::PavexLocator;
 use pavex_cli::package_graph::compute_package_graph;
 use pavex_cli::pavexc::{get_or_install_from_graph, get_or_install_from_version};
+use pavex_cli::prebuilt::{download_prebuilt, PrebuiltBinaryKind};
 use pavex_cli::state::State;
+use pavex_cli::utils;
+use pavex_cli::version::latest_released_version;
 use pavexc_cli_client::commands::generate::{BlueprintArgument, GenerateError};
 use pavexc_cli_client::commands::new::NewError;
 use pavexc_cli_client::Client;
+use semver::Version;
 use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
@@ -70,27 +75,47 @@ impl FromStr for Color {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Generate application runtime code according to an application blueprint.
+    /// Generate the server SDK code for an application blueprint.
     Generate {
         /// The source path for the serialized application blueprint.
         #[clap(short, long, value_parser)]
         blueprint: PathBuf,
-        /// Optional. If provided, pavex will serialize diagnostic information about
+        /// Optional.
+        /// If provided, Pavex will serialize diagnostic information about
         /// the application to the specified path.
         #[clap(long, value_parser)]
         diagnostics: Option<PathBuf>,
-        /// The path to the directory that will contain the manifest and the source code for the generated application crate.  
-        /// If the provided path is relative, it is interpreted as relative to the root of the current workspace.
+        /// The directory that will contain the newly generated server SDK crate.
+        /// If the directory path is relative,
+        /// it is interpreted as relative to the root of the current workspace.
         #[clap(short, long, value_parser)]
         output: PathBuf,
     },
     /// Scaffold a new Pavex project at <PATH>.
     New {
-        /// The path of the new directory that will contain the project files.  
+        /// The directory that will contain the project files.
         ///
         /// If any of the intermediate directories in the path don't exist, they'll be created.
         #[arg(index = 1)]
         path: PathBuf,
+    },
+    /// Modify the installation of the Pavex CLI.
+    #[command(name = "self")]
+    Self_ {
+        #[clap(subcommand)]
+        command: SelfCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum SelfCommands {
+    /// Download and install a newer version of Pavex CLI, if available.
+    Update,
+    /// Uninstall Pavex CLI and remove all its dependencies and artifacts.
+    Uninstall {
+        /// Don't ask for confirmation before uninstalling Pavex CLI.
+        #[clap(short, long, value_parser)]
+        y: bool,
     },
 }
 
@@ -168,11 +193,15 @@ fn main() -> Result<ExitCode, miette::Error> {
             output,
         } => generate(&mut shell, client, &locator, blueprint, diagnostics, output),
         Commands::New { path } => scaffold_project(client, &locator, &mut shell, path),
+        Commands::Self_ { command } => match command {
+            SelfCommands::Update => update(&mut shell),
+            SelfCommands::Uninstall { y } => uninstall(&mut shell),
+        },
     }
-    .map_err(anyhow2miette)
+    .map_err(utils::anyhow2miette)
 }
 
-#[tracing::instrument("Generate server sdk", skip(client, locator))]
+#[tracing::instrument("Generate server sdk", skip(client, locator, shell))]
 fn generate(
     shell: &mut Shell,
     mut client: Client,
@@ -206,7 +235,7 @@ fn generate(
     }
 }
 
-#[tracing::instrument("Scaffold new project", skip(client, locator))]
+#[tracing::instrument("Scaffold new project", skip(client, locator, shell))]
 fn scaffold_project(
     mut client: Client,
     locator: &PavexLocator,
@@ -232,21 +261,75 @@ fn scaffold_project(
     }
 }
 
-fn anyhow2miette(err: anyhow::Error) -> miette::Error {
-    #[derive(Debug, miette::Diagnostic)]
-    struct InteropError(anyhow::Error);
+#[tracing::instrument("Uninstall Pavex CLI", skip(shell))]
+fn uninstall(shell: &mut Shell) -> Result<ExitCode, anyhow::Error> {
+    Ok(ExitCode::SUCCESS)
+}
 
-    impl Display for InteropError {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            self.0.fmt(f)
+#[tracing::instrument("Update Pavex CLI", skip(shell))]
+fn update(shell: &mut Shell) -> Result<ExitCode, anyhow::Error> {
+    shell.status("Checking for updates", "Pavex CLI")?;
+    let latest_version = latest_released_version()?;
+    let current_version = pavex_cli::env::version();
+    if latest_version <= current_version {
+        shell.status(
+            "Up to date",
+            format!("{current_version} is the most recent version"),
+        )?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    shell.status(
+        "Update available",
+        format!("You're running {current_version}, but {latest_version} is available"),
+    )?;
+
+    let new_cli_path = tempfile::NamedTempFile::new()
+        .context("Failed to create a temporary file to download the new Pavex CLI binary")?;
+    download_or_compile(
+        shell,
+        PrebuiltBinaryKind::Pavex,
+        &latest_version,
+        new_cli_path.path(),
+    )?;
+    self_replace::self_replace(new_cli_path.path())
+        .context("Failed to replace the current Pavex CLI with the newly downloaded version")?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+fn download_or_compile(
+    shell: &mut Shell,
+    kind: PrebuiltBinaryKind,
+    version: &Version,
+    destination: &Path,
+) -> Result<(), anyhow::Error> {
+    let _ = shell.status("Downloading", format!("prebuilt `{kind}@{version}` binary"));
+    match download_prebuilt(destination, kind, version) {
+        Ok(_) => {
+            let _ = shell.status("Downloaded", format!("prebuilt `{kind}@{version}` binary"));
+            return Ok(());
+        }
+        Err(e) => {
+            let _ = shell.warn("Download failed: {e}.\nI'll try compiling from source instead.");
+            tracing::warn!(
+                error.msg = %e,
+                error.cause = ?e,
+                "Failed to download prebuilt `{kind}` binary. I'll try to build it from source instead.",
+            );
         }
     }
 
-    impl std::error::Error for InteropError {
-        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-            self.0.source()
-        }
-    }
-
-    miette::Error::from(InteropError(err))
+    let _ = shell.status("Compiling", format!("`{kind}@{version}` from source"));
+    cargo_install(
+        Source::Git {
+            url: "https://github.com/LukeMathWalker/pavex".into(),
+            rev: GitSourceRevision::Tag(version.to_string()),
+        },
+        &kind.to_string(),
+        &format!("{kind}_cli"),
+        destination,
+    )?;
+    let _ = shell.status("Compiled", format!("`{kind}@{version}` from source"));
+    Ok(())
 }

--- a/libs/pavex_cli/src/pavexc/install.rs
+++ b/libs/pavex_cli/src/pavexc/install.rs
@@ -1,5 +1,5 @@
 use crate::cargo_install::{cargo_install, GitSourceRevision, Source};
-use crate::pavexc::prebuilt::download_prebuilt;
+use crate::prebuilt::{download_prebuilt, PrebuiltBinaryKind};
 use cargo_like_utils::shell::Shell;
 use guppy::graph::PackageSource;
 use guppy::Version;
@@ -159,7 +159,7 @@ pub(super) fn install(
 
     if try_prebuilt {
         let _ = shell.status("Downloading", format!("prebuilt `pavexc@{version}` binary"));
-        match download_prebuilt(pavexc_cli_path, version) {
+        match download_prebuilt(pavexc_cli_path, PrebuiltBinaryKind::Pavexc, version) {
             Ok(_) => {
                 let _ = shell.status("Downloaded", format!("prebuilt `pavexc@{version}` binary"));
                 return Ok(());

--- a/libs/pavex_cli/src/pavexc/mod.rs
+++ b/libs/pavex_cli/src/pavexc/mod.rs
@@ -9,7 +9,6 @@ use std::path::{Path, PathBuf};
 
 mod install;
 mod location;
-mod prebuilt;
 mod version;
 
 static PAVEX_GITHUB_URL: &str = "https://github.com/LukeMathWalker/pavex";

--- a/libs/pavex_cli/src/state.rs
+++ b/libs/pavex_cli/src/state.rs
@@ -38,9 +38,7 @@ impl State {
             Some(current_state) => Ok(current_state.toolchain),
             None => {
                 // We default to the toolchain that matches the current version of the CLI.
-                let cli_version = semver::Version::parse(version())
-                    .context("Failed to parse the current version of the CLI.")?;
-                Ok(cli_version)
+                Ok(version())
             }
         }
     }

--- a/libs/pavex_cli/src/utils.rs
+++ b/libs/pavex_cli/src/utils.rs
@@ -1,0 +1,20 @@
+use std::fmt::{Display, Formatter};
+
+pub fn anyhow2miette(err: anyhow::Error) -> miette::Error {
+    #[derive(Debug, miette::Diagnostic)]
+    struct InteropError(anyhow::Error);
+
+    impl Display for InteropError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    impl std::error::Error for InteropError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.0.source()
+        }
+    }
+
+    miette::Error::from(InteropError(err))
+}

--- a/libs/pavex_cli/src/version.rs
+++ b/libs/pavex_cli/src/version.rs
@@ -1,0 +1,24 @@
+use anyhow::Context;
+use semver::Version;
+
+/// Query GitHub's API to get the latest released version of Pavex.
+pub fn latest_released_version() -> Result<Version, anyhow::Error> {
+    #[derive(serde::Deserialize)]
+    struct Response {
+        tag_name: String,
+    }
+
+    let response = ureq::get("https://api.github.com/repos/LukeMathWalker/pavex/releases/latest")
+        .call()
+        .context("Failed to query GitHub's API for the latest release")?;
+    if response.status() < 200 || response.status() >= 300 {
+        anyhow::bail!(
+            "Failed to query GitHub's API for the latest release. It returned an error status code ({})",
+            response.status()
+        );
+    }
+    let response: Response = response.into_json()?;
+    let version = Version::parse(&response.tag_name)
+        .context("Failed to parse the version returned by GitHub's API for the latest release")?;
+    Ok(version)
+}


### PR DESCRIPTION
Another piece of the version management story: the `pavex` CLI can now install a more recent version of itself.
For completeness, we also provide an uninstall command that removes the binary as well as all the transient data that Pavex builds when compiling projects.