### PR TITLE
Use the correct binary filename on Windows.

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1906,6 +1906,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cargo-like-utils",
+ "cfg-if",
  "clap",
  "config",
  "fs-err",

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -45,6 +45,7 @@ toml = "0.8.8"
 semver = { version = "1.0.21", features = ["serde"] }
 serde_json = "1.0.111"
 self-replace = "1.3.7"
+cfg-if = "1"
 
 [dev-dependencies]
 pavex_test_runner = { path = "../pavex_test_runner" }

--- a/libs/pavex_cli/src/cli_kind.rs
+++ b/libs/pavex_cli/src/cli_kind.rs
@@ -23,8 +23,8 @@ impl CliKind {
         cfg_if::cfg_if! {
             if #[cfg(windows)] {
                 match self {
-                    CliTarget::Pavex => "pavex.exe",
-                    CliTarget::Pavexc => "pavexc.exe",
+                    CliKind::Pavex => "pavex.exe",
+                    CliKind::Pavexc => "pavexc.exe",
                 }
             } else {
                 match self {

--- a/libs/pavex_cli/src/cli_kind.rs
+++ b/libs/pavex_cli/src/cli_kind.rs
@@ -1,0 +1,37 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliKind {
+    Pavex,
+    Pavexc,
+}
+
+impl CliKind {
+    pub fn binary_target_name(self) -> &'static str {
+        match self {
+            CliKind::Pavex => "pavex",
+            CliKind::Pavexc => "pavexc",
+        }
+    }
+
+    pub fn package_name(self) -> &'static str {
+        match self {
+            CliKind::Pavex => "pavex_cli",
+            CliKind::Pavexc => "pavexc_cli",
+        }
+    }
+
+    pub fn binary_filename(self) -> &'static str {
+        cfg_if::cfg_if! {
+            if #[cfg(windows)] {
+                match self {
+                    CliTarget::Pavex => "pavex.exe",
+                    CliTarget::Pavexc => "pavexc.exe",
+                }
+            } else {
+                match self {
+                    CliKind::Pavex => "pavex",
+                    CliKind::Pavexc => "pavexc",
+                }
+            }
+        }
+    }
+}

--- a/libs/pavex_cli/src/lib.rs
+++ b/libs/pavex_cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cargo_install;
+pub mod cli_kind;
 pub mod confirmation;
 pub mod env;
 pub mod locator;

--- a/libs/pavex_cli/src/locator.rs
+++ b/libs/pavex_cli/src/locator.rs
@@ -1,3 +1,4 @@
+use crate::cli_kind::CliKind;
 use semver::Version;
 use sha2::Digest;
 use std::path::{Path, PathBuf};
@@ -122,6 +123,6 @@ impl ToolchainLocator {
 
     /// Path to the `pavexc` binary for this toolchain.
     pub fn pavexc(&self) -> PathBuf {
-        self.toolchain_dir.join("pavexc")
+        self.toolchain_dir.join(CliKind::Pavexc.binary_filename())
     }
 }

--- a/libs/pavex_cli/src/pavexc/install.rs
+++ b/libs/pavex_cli/src/pavexc/install.rs
@@ -1,5 +1,6 @@
 use crate::cargo_install::{cargo_install, GitSourceRevision, Source};
-use crate::prebuilt::{download_prebuilt, PrebuiltBinaryKind};
+use crate::cli_kind::CliKind;
+use crate::prebuilt::download_prebuilt;
 use cargo_like_utils::shell::Shell;
 use guppy::graph::PackageSource;
 use guppy::Version;
@@ -159,7 +160,7 @@ pub(super) fn install(
 
     if try_prebuilt {
         let _ = shell.status("Downloading", format!("prebuilt `pavexc@{version}` binary"));
-        match download_prebuilt(pavexc_cli_path, PrebuiltBinaryKind::Pavexc, version) {
+        match download_prebuilt(pavexc_cli_path, CliKind::Pavexc, version) {
             Ok(_) => {
                 let _ = shell.status("Downloaded", format!("prebuilt `pavexc@{version}` binary"));
                 return Ok(());
@@ -177,7 +178,7 @@ pub(super) fn install(
     }
 
     let _ = shell.status("Compiling", format!("`pavexc@{version}` from source"));
-    cargo_install(install_source, "pavexc", "pavexc_cli", pavexc_cli_path)?;
+    cargo_install(install_source, CliKind::Pavexc, pavexc_cli_path)?;
     let _ = shell.status("Compiled", format!("`pavexc@{version}` from source"));
     Ok(())
 }

--- a/libs/pavex_cli/src/pavexc/location.rs
+++ b/libs/pavex_cli/src/pavexc/location.rs
@@ -1,3 +1,4 @@
+use crate::cli_kind::CliKind;
 use crate::locator::ToolchainsLocator;
 use crate::pavexc::install::UnsupportedSourceError;
 use guppy::graph::{ExternalSource, PackageGraph, PackageSource};
@@ -15,14 +16,20 @@ pub(super) fn path_from_graph(
     match package_source {
         PackageSource::Workspace(_) => {
             let workspace_root = package_graph.workspace().root();
-            let pavexc_cli_path = workspace_root.join("target").join("release").join("pavexc");
+            let pavexc_cli_path = workspace_root
+                .join("target")
+                .join("release")
+                .join(CliKind::Pavexc.binary_filename());
             Ok(Ok(pavexc_cli_path.into_std_path_buf()))
         }
         PackageSource::Path(p) => {
             let workspace_root = p
                 .parent()
                 .expect("pavex's source path has to have a parent");
-            let pavexc_cli_path = workspace_root.join("target").join("release").join("pavexc");
+            let pavexc_cli_path = workspace_root
+                .join("target")
+                .join("release")
+                .join(CliKind::Pavexc.binary_filename());
             Ok(Ok(pavexc_cli_path.into_std_path_buf()))
         }
         PackageSource::External(_) => {


### PR DESCRIPTION
We were not considering the `.exe` extension.