### PR TITLE
Activation key

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -150,6 +150,11 @@ jobs:
       - name: Mark pavex as executable
         if: ${{ matrix.os != 'windows-2022' }}
         run: chmod +x ${{ env.PAVEX }}
+      - name: Activate pavex
+        env:
+          PAVEX_ACTIVATION_KEY: ${{ secrets.pavex_activation_key }}
+        run: |
+          pavex self activate
       - name: Mark pavexc as executable
         if: ${{ matrix.os != 'windows-2022' }}
         run: chmod +x ${{ env.PAVEXC }}
@@ -203,6 +208,11 @@ jobs:
           path: ~/.cargo/bin
       - name: Mark pavex as executable
         run: chmod +x ~/.cargo/bin/pavex
+      - name: Activate pavex
+        env:
+          PAVEX_ACTIVATION_KEY: ${{ secrets.pavex_activation_key }}
+        run: |
+          pavex self activate
       - name: Mark pavexc as executable
         run: chmod +x ~/.cargo/bin/pavexc
       - name: Download tutorial_generator CLI artifact

--- a/doc_examples/guide/dependency_injection/cookbook/project/Cargo.lock
+++ b/doc_examples/guide/dependency_injection/cookbook/project/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/middleware/core_concepts/project/Cargo.lock
+++ b/doc_examples/guide/middleware/core_concepts/project/Cargo.lock
@@ -382,7 +382,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/buffered_body/project/Cargo.lock
+++ b/doc_examples/guide/request_data/buffered_body/project/Cargo.lock
@@ -388,7 +388,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/json/project/Cargo.lock
+++ b/doc_examples/guide/request_data/json/project/Cargo.lock
@@ -388,7 +388,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/path/project/Cargo.lock
+++ b/doc_examples/guide/request_data/path/project/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/query/project/Cargo.lock
+++ b/doc_examples/guide/request_data/query/project/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/query_params/project/Cargo.lock
+++ b/doc_examples/guide/request_data/query_params/project/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/request_target/project/Cargo.lock
+++ b/doc_examples/guide/request_data/request_target/project/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/doc_examples/guide/request_data/route_params/project/Cargo.lock
+++ b/doc_examples/guide/request_data/route_params/project/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "pavex",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "serde",
 ]

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -63,4 +63,16 @@ You can check that it's been installed correctly by running:
 pavex --version
 ```
 
+### Activation
+
+To start using your Pavex installation, you need to activate it. Execute the following command:
+
+```bash
+pavex self activate
+```
+
+It will ask you for an **activation key**.  
+You can find the activation key for the beta program in Pavex's Discord server, in the `#activation` channel. 
+You can join the beta on [pavex.dev](https://pavex.dev).
+
 If there are no errors, you're ready to [embark on your Pavex journey](learning_paths.md)!

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1010,6 +1010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1917,7 @@ dependencies = [
  "config",
  "fs-err",
  "guppy",
+ "hex",
  "libc",
  "miette",
  "pavex_miette",

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -412,6 +412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-stdin"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc126d12a0930c94c3548581294d5f19360ac02e408600b4d7619d7234e8b505"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +1923,7 @@ dependencies = [
  "cargo-like-utils",
  "cfg-if",
  "clap",
+ "clap-stdin",
  "config",
  "fs-err",
  "guppy",
@@ -1925,6 +1935,7 @@ dependencies = [
  "pavexc",
  "pavexc_cli_client",
  "remove_dir_all",
+ "secrecy",
  "self-replace",
  "semver",
  "serde",
@@ -2613,6 +2624,16 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -3840,6 +3861,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zip"

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1930,6 +1930,7 @@ dependencies = [
  "hex",
  "libc",
  "miette",
+ "owo-colors 4.0.0",
  "pavex_miette",
  "pavex_test_runner",
  "pavexc",

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -49,6 +49,7 @@ cfg-if = "1"
 hex = "0.4.3"
 secrecy = { version = "0.8.0", features = ["serde"] }
 clap-stdin = "0.4.0"
+owo-colors = "4.0.0"
 
 [dev-dependencies]
 pavex_test_runner = { path = "../pavex_test_runner" }

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -46,6 +46,7 @@ semver = { version = "1.0.21", features = ["serde"] }
 serde_json = "1.0.111"
 self-replace = "1.3.7"
 cfg-if = "1"
+hex = "0.4.3"
 
 [dev-dependencies]
 pavex_test_runner = { path = "../pavex_test_runner" }

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -47,6 +47,8 @@ serde_json = "1.0.111"
 self-replace = "1.3.7"
 cfg-if = "1"
 hex = "0.4.3"
+secrecy = { version = "0.8.0", features = ["serde"] }
+clap-stdin = "0.4.0"
 
 [dev-dependencies]
 pavex_test_runner = { path = "../pavex_test_runner" }

--- a/libs/pavex_cli/src/activation.rs
+++ b/libs/pavex_cli/src/activation.rs
@@ -11,6 +11,7 @@
 
 use crate::state::State;
 use cargo_like_utils::shell::Shell;
+use secrecy::ExposeSecret;
 use sha2::Digest;
 
 static BETA_ACTIVATION_KEY_SHA256: &str =
@@ -22,7 +23,7 @@ pub fn check_activation(state: &State, shell: &mut Shell) -> Result<(), anyhow::
     let Some(key) = key else {
         return Err(PavexMustBeActivated.into());
     };
-    let key_sha256 = sha2::Sha256::digest(key.as_bytes());
+    let key_sha256 = sha2::Sha256::digest(key.expose_secret().as_bytes());
     let key_sha256 = hex::encode(key_sha256);
     if key_sha256 != BETA_ACTIVATION_KEY_SHA256 {
         Err(InvalidActivationKey.into())

--- a/libs/pavex_cli/src/activation.rs
+++ b/libs/pavex_cli/src/activation.rs
@@ -15,7 +15,7 @@ use secrecy::{ExposeSecret, SecretString};
 use sha2::Digest;
 
 static BETA_ACTIVATION_KEY_SHA256: &str =
-    "7b027f749555e3a063b012caaa2508094eee34233f1bdc7a0b8e1f1f19627c1d";
+    "a0c04ee4345ad0900d29e9c525be9de2be44450e73f9ce2893c62eb96a66e157";
 
 /// Verify that Pavex has been correctly activated on this machine.
 pub fn check_activation(state: &State, shell: &mut Shell) -> Result<(), anyhow::Error> {

--- a/libs/pavex_cli/src/activation.rs
+++ b/libs/pavex_cli/src/activation.rs
@@ -1,0 +1,40 @@
+//! This is a temporary stop-gap solution to allow us to publish Pavex to crates.io
+//! without giving everyone access.  
+//! The "secret" product key is available in Pavex's Discord server for every person that's
+//! of the beta.
+//! That's why we just check a SHA2 hash of the key rather than doing something more robust
+//! with `argon2` or `bcrypt`.
+//!
+//! In the future we'll migrate to a more robust solution, with per-user keys,
+//! validation checks against a server at most once every X hours, etc.
+//! But this will do for now.
+
+use crate::state::State;
+use cargo_like_utils::shell::Shell;
+use sha2::Digest;
+
+static BETA_ACTIVATION_KEY_SHA256: &str =
+    "7b027f749555e3a063b012caaa2508094eee34233f1bdc7a0b8e1f1f19627c1d";
+
+/// Verify that Pavex has been correctly activated on this machine.
+pub fn check_activation(state: &State, shell: &mut Shell) -> Result<(), anyhow::Error> {
+    let key = state.get_activation_key(shell)?;
+    let Some(key) = key else {
+        return Err(PavexMustBeActivated.into());
+    };
+    let key_sha256 = sha2::Sha256::digest(key.as_bytes());
+    let key_sha256 = hex::encode(key_sha256);
+    if key_sha256 != BETA_ACTIVATION_KEY_SHA256 {
+        Err(InvalidActivationKey.into())
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Your installation of Pavex must be activated before it can be used.\nRun `pavex self activate` to fix the issue.")]
+struct PavexMustBeActivated;
+
+#[derive(thiserror::Error, Debug)]
+#[error("The activation key attached to your installation of Pavex is not valid.\nRun `pavex self activate` to fix the issue.")]
+struct InvalidActivationKey;

--- a/libs/pavex_cli/src/lib.rs
+++ b/libs/pavex_cli/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod activation;
 pub mod cargo_install;
 pub mod cli_kind;
-pub mod confirmation;
 pub mod env;
 pub mod locator;
 pub mod package_graph;
@@ -9,5 +8,6 @@ pub mod pavexc;
 pub mod prebuilt;
 pub mod state;
 pub mod toolchain;
+pub mod user_input;
 pub mod utils;
 pub mod version;

--- a/libs/pavex_cli/src/lib.rs
+++ b/libs/pavex_cli/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod activation;
 pub mod cargo_install;
 pub mod cli_kind;
 pub mod confirmation;

--- a/libs/pavex_cli/src/main.rs
+++ b/libs/pavex_cli/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use cargo_like_utils::shell::Shell;
 use std::fmt::{Display, Formatter};
-use std::io::ErrorKind;
+use std::io::{ErrorKind, IsTerminal};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
@@ -356,6 +356,18 @@ fn activate(
     let state = State::new(locator);
     let key = match key {
         None => {
+            let stdout = std::io::stdout();
+            if !stdout.is_terminal() {
+                return Err(anyhow::anyhow!(
+                    "The current terminal does not support interactive prompts. If you want to activate \
+                    Pavex in a non-interactive environment, please provide the activation key using one of \
+                    the following methods:\n\
+                    - Pass the activation key as standard input to the `pavex self activate` command (`echo \"<your-key>\" | pavex self activate` on Unix platforms)\n\
+                    - Pass the activation key as an argument to the `pavex self activate` command (`pavex self activate \"<your-key>\"`)\n\
+                    - Set the `PAVEX_ACTIVATION_KEY` environment variable"
+                ));
+            }
+
             println!();
             let mut k: Option<SecretString> = None;
             'outer: while k.is_none() {

--- a/libs/pavex_cli/src/main.rs
+++ b/libs/pavex_cli/src/main.rs
@@ -375,7 +375,7 @@ fn activate(
                     format!(
                         "Welcome to Pavex's beta program! Please enter your {}.\n{}",
                         "activation key".bold().green(),
-                        "You can find the activation key for the beta program in the #announcement \
+                        "You can find the activation key for the beta program in the #activation \
                         channel of Pavex's Discord server.\n\
                         You can join the beta program by visiting https://pavex.dev\n"
                             .dimmed()
@@ -383,7 +383,7 @@ fn activate(
                 } else {
                     format!(
                         "Welcome to Pavex's beta program! Please enter your activation key.\n\
-                        You can find the activation key for the beta program in the #announcement \
+                        You can find the activation key for the beta program in the #activation \
                         channel of Pavex's Discord server.\n\
                         You can join the beta program by visiting https://pavex.dev\n"
                     )

--- a/libs/pavex_cli/src/main.rs
+++ b/libs/pavex_cli/src/main.rs
@@ -196,11 +196,11 @@ fn main() -> Result<ExitCode, miette::Error> {
             diagnostics,
             output,
         } => {
-            check_activation(&State::new(&locator), &mut shell)?;
+            check_activation(&State::new(&locator), &mut shell).map_err(utils::anyhow2miette)?;
             generate(&mut shell, client, &locator, blueprint, diagnostics, output)
         }
         Commands::New { path } => {
-            check_activation(&State::new(&locator), &mut shell)?;
+            check_activation(&State::new(&locator), &mut shell).map_err(utils::anyhow2miette)?;
             scaffold_project(client, &locator, &mut shell, path)
         }
         Commands::Self_ { command } => {

--- a/libs/pavex_cli/src/user_input.rs
+++ b/libs/pavex_cli/src/user_input.rs
@@ -19,6 +19,18 @@ pub fn confirm(question: &str, default: bool) -> Result<bool, anyhow::Error> {
     Ok(r)
 }
 
+/// Prompt the user for input, without a default value.
+pub fn mandatory_question(question: &str) -> anyhow::Result<String> {
+    let mut input = "".to_string();
+    while input.is_empty() {
+        writeln!(std::io::stdout().lock(), "{question}")?;
+        let _ = std::io::stdout().flush();
+        input = read_line()?;
+        writeln!(std::io::stdout().lock())?;
+    }
+    Ok(input)
+}
+
 fn read_line() -> Result<String, anyhow::Error> {
     let stdin = std::io::stdin();
     let stdin = stdin.lock();

--- a/libs/pavexc_cli/src/main.rs
+++ b/libs/pavexc_cli/src/main.rs
@@ -255,7 +255,7 @@ fn scaffold_project(destination: PathBuf) -> Result<ExitCode, Box<dyn std::error
         define,
         ignore: Some(vec!["target/".into(), "Cargo.lock".into(), ".idea".into()]),
         overwrite: false,
-        verbose: true,
+        verbose: false,
     };
     generate_from_path::generate(generate_args)
         .context("Failed to scaffold the project from Pavex's default template")?;


### PR DESCRIPTION
All beta testers are currently using Pavex via `git` dependencies, either targeting a branch or a tag.  
That's... not ideal, since `cargo` doesn't really understand semver when using `git` dependencies.

To improve the experience, I want to start releasing Pavex to crates.io.  
To restrict access, this PR introduces an activation key. You'll only be prompted for this once; Pavex will remember it as you update the CLI too.

The current verification mechanism is a stop-gap solution to rush out crates.io releases. The final version will include a server with per-user keys, tied to a subscription. But since we don't want to charge closed beta testers, this is fine for now.