### PR TITLE
Only persist to the disk if the content has changed

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1886,6 +1886,7 @@ dependencies = [
  "pavex_matchit",
  "pavex_reflection",
  "percent-encoding",
+ "persist_if_changed",
  "pin-project-lite",
  "reqwest",
  "ron 0.8.1",

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -31,6 +31,7 @@ pin-project-lite = "0.2"
 ubyte = { version = "0.10.4", features = ["serde"] }
 pavex_bp_schema = { path = "../pavex_bp_schema", version = "0.1.15" }
 pavex_reflection = { path = "../pavex_reflection", version = "0.1.15" }
+persist_if_changed = { path = "../persist_if_changed", version = "0.1.15" }
 
 # Route parameters
 matchit = { version = "0.7", package = "pavex_matchit" }

--- a/libs/pavex/src/blueprint/blueprint.rs
+++ b/libs/pavex/src/blueprint/blueprint.rs
@@ -633,14 +633,12 @@ impl Blueprint {
 /// These are used to pass the blueprint data to Pavex's CLI.
 impl Blueprint {
     /// Serialize the [`Blueprint`] to a file in RON format.
+    ///
+    /// The file is only written to disk if the content of the blueprint has changed.
     pub fn persist(&self, filepath: &std::path::Path) -> Result<(), anyhow::Error> {
-        let mut file = fs_err::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(filepath)?;
         let config = ron::ser::PrettyConfig::new();
-        ron::ser::to_writer_pretty(&mut file, &self.schema, config)?;
+        let contents = ron::ser::to_string_pretty(&self.schema, config)?;
+        persist_if_changed::persist_if_changed(filepath, contents.as_bytes())?;
         Ok(())
     }
 

--- a/libs/pavexc/src/compiler/generated_app.rs
+++ b/libs/pavexc/src/compiler/generated_app.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use cargo_manifest::{Dependency, Edition};
@@ -128,13 +127,7 @@ impl GeneratedApp {
             }
         };
         cargo_toml.overwrite(&mut manifest);
-
-        let mut cargo_toml_file = fs_err::OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .create(true)
-            .open(&cargo_toml_path)?;
-        cargo_toml_file.write_all(manifest.to_string().as_bytes())?;
+        persist_if_changed(&cargo_toml_path, manifest.to_string().as_bytes())?;
         Ok(())
     }
 


### PR DESCRIPTION
 This allows Pavex to play nicely with tools like `cargo watch`, avoiding spurious recompilations.
