### PR TITLE
Polish docs

### DIFF
--- a/doc_examples/quickstart/02-register_new_route.snap
+++ b/doc_examples/quickstart/02-register_new_route.snap
@@ -1,17 +1,7 @@
-```rust title="app/src/blueprint.rs" hl_lines="9 10 11 12 13"
+```rust title="app/src/routes/mod.rs" hl_lines="4"
 // [...]
-pub fn blueprint() -> Blueprint {
-    let mut bp = Blueprint::new();
-    ApiKit::new().register(&mut bp);
-    telemetry::register(&mut bp);
-    AppConfig::register(&mut bp);
-
-    bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
-    bp.route(
-        GET,
-        "/api/greet/:name", /* (1)! */
-        f!(crate::routes::greet::greet),
-    );
-    bp
+pub fn register(bp: &mut Blueprint) {
+    bp.route(GET, "/api/ping", f!(self::status::ping));
+    bp.route(GET, "/api/greet/:name", f!(self::greet::greet)); // (1)!
 }
 ```

--- a/doc_examples/quickstart/02.patch
+++ b/doc_examples/quickstart/02.patch
@@ -1,19 +1,3 @@
-diff --git a/app/src/blueprint.rs b/app/src/blueprint.rs
-index f2b3732..a282fa0 100644
---- a/app/src/blueprint.rs
-+++ b/app/src/blueprint.rs
-@@ -12,5 +12,10 @@ pub fn blueprint() -> Blueprint {
-     ApplicationConfig::register(&mut bp);
-
-     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
-+    bp.route(
-+        GET,
-+        "/api/greet/:name", /* (1)! */
-+        f!(crate::routes::greet::greet),
-+    );
-     bp
- }
-
 diff --git a/app/src/routes/greet.rs b/app/src/routes/greet.rs
 new file mode 100644
 index 0000000..38ec1e3
@@ -26,9 +10,17 @@ index 0000000..38ec1e3
 +    todo!()
 +}
 diff --git a/app/src/routes/mod.rs b/app/src/routes/mod.rs
-index 822c729..d709a21 100644
+index 0472c7d..3c53d60 100644
 --- a/app/src/routes/mod.rs
 +++ b/app/src/routes/mod.rs
-@@ -1 +1,2 @@
+@@ -1,3 +1,4 @@
 +pub mod greet;
  pub mod status;
+
+ use pavex::blueprint::{router::GET, Blueprint};
+@@ -5,4 +5,5 @@ use pavex::f;
+
+ pub fn register(bp: &mut Blueprint) {
+     bp.route(GET, "/api/ping", f!(self::status::ping));
++    bp.route(GET, "/api/greet/:name", f!(self::greet::greet)); // (1)!
+ }

--- a/doc_examples/quickstart/04-register_common_invocation.snap
+++ b/doc_examples/quickstart/04-register_common_invocation.snap
@@ -3,7 +3,7 @@
 pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
     ApiKit::new().register(&mut bp);
+    telemetry::register(&mut bp);
     // [...]
-    bp
 }
 ```

--- a/doc_examples/quickstart/05-bis.patch
+++ b/doc_examples/quickstart/05-bis.patch
@@ -1,20 +1,14 @@
-diff --git a/app/src/blueprint.rs b/app/src/blueprint.rs
-index a282fa0..2067e4a 100644
---- a/app/src/blueprint.rs
-+++ b/app/src/blueprint.rs
-@@ -12,10 +12,6 @@ pub fn blueprint() -> Blueprint {
-     ApplicationConfig::register(&mut bp);
+diff --git a/app/src/routes/mod.rs b/app/src/routes/mod.rs
+index 042c06f..01a843c 100644
+--- a/app/src/routes/mod.rs
++++ b/app/src/routes/mod.rs
+@@ -6,5 +6,5 @@ use pavex::f;
 
-     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
--    bp.route(
--        GET,
--        "/api/greet/:name", /* (1)! */
--        f!(crate::routes::greet::greet),
--    );
-+    bp.route(GET, "/api/greet/:name", f!(crate::routes::greet::greet));
-     bp
+ pub fn register(bp: &mut Blueprint) {
+     bp.route(GET, "/api/ping", f!(self::status::ping));
+-    bp.route(GET, "/api/greet/:name", f!(self::greet::greet)); // (1)!
++    bp.route(GET, "/api/greet/:name", f!(self::greet::greet));
  }
-
 diff --git a/app/src/routes/greet.rs b/app/src/routes/greet.rs
 --- a/app/src/routes/greet.rs
 +++ b/app/src/routes/greet.rs

--- a/doc_examples/quickstart/05-error.snap
+++ b/doc_examples/quickstart/05-error.snap
@@ -2,12 +2,12 @@
   [31m×[0m I can't invoke your request handler, `app::routes::greet::greet`, because it needs an instance
   [31m│[0m of `app::user_agent::UserAgent` as input, but I can't find a constructor for that type.
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4mapp/src/blueprint.rs[0m:14:1]
-  [31m│[0m  [2m14[0m │     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
-  [31m│[0m  [2m15[0m │     bp.route(GET, "/api/greet/:name", f!(crate::routes::greet::greet));
-  [31m│[0m     · [35;1m                                      ───────────────┬───────────────[0m
-  [31m│[0m     ·            [35;1mThe request handler was registered here ──╯[0m
-  [31m│[0m  [2m16[0m │     bp
+  [31m│[0m     ╭─[[36;1;4mapp/src/routes/mod.rs[0m:8:1]
+  [31m│[0m  [2m 8[0m │     bp.route(GET, "/api/ping", f!(self::status::ping));
+  [31m│[0m  [2m 9[0m │     bp.route(GET, "/api/greet/:name", f!(self::greet::greet));
+  [31m│[0m     · [35;1m                                      ───────────┬──────────[0m
+  [31m│[0m     ·                                                  [35;1m╰── The request handler was registered here[0m
+  [31m│[0m  [2m10[0m │ }
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4mapp/src/routes/greet.rs[0m:10:1]
   [31m│[0m  [2m10[0m │ 

--- a/doc_examples/quickstart/06.patch
+++ b/doc_examples/quickstart/06.patch
@@ -1,15 +1,21 @@
 diff --git a/app/src/blueprint.rs b/app/src/blueprint.rs
-index 90f25e6..e03ac7c 100644
+index 979d04b..fb0ef2c 100644
 --- a/app/src/blueprint.rs
 +++ b/app/src/blueprint.rs
-@@ -11,6 +11,8 @@ pub fn blueprint() -> Blueprint {
-     telemetry::register(&mut bp);
-     AppConfig::register(&mut bp);
+@@ -1,5 +1,6 @@
+ use crate::{configuration, routes, telemetry};
+ use pavex::blueprint::Blueprint;
++use pavex::f;
+ use pavex::kit::ApiKit;
 
+ /// The main blueprint, containing all the routes, middlewares, constructors and error handlers
+@@ -9,6 +10,7 @@ pub fn blueprint() -> Blueprint {
+     ApiKit::new().register(&mut bp);
+     telemetry::register(&mut bp);
+     configuration::register(&mut bp);
 +    bp.request_scoped(f!(crate::user_agent::UserAgent::extract));
-+
-     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
-     bp.route(GET, "/api/greet/:name", f!(crate::routes::greet::greet));
+
+     routes::register(&mut bp);
      bp
 diff --git a/app/src/user_agent.rs b/app/src/user_agent.rs
 --- a/app/src/user_agent.rs

--- a/doc_examples/quickstart/07-error.snap
+++ b/doc_examples/quickstart/07-error.snap
@@ -3,12 +3,12 @@
   [31m│[0m handler for it. If I don't have an error handler, I don't know what to do with the error when
   [31m│[0m the constructor fails!
   [31m│[0m
-  [31m│[0m     ╭─[[36;1;4mapp/src/blueprint.rs[0m:13:1]
-  [31m│[0m  [2m13[0m │ 
-  [31m│[0m  [2m14[0m │     bp.request_scoped(f!(crate::user_agent::UserAgent::extract));
+  [31m│[0m     ╭─[[36;1;4mapp/src/blueprint.rs[0m:12:1]
+  [31m│[0m  [2m12[0m │     configuration::register(&mut bp);
+  [31m│[0m  [2m13[0m │     bp.request_scoped(f!(crate::user_agent::UserAgent::extract));
   [31m│[0m     · [35;1m                      ────────────────────┬────────────────────[0m
   [31m│[0m     ·                                           [35;1m╰── The fallible constructor was registered here[0m
-  [31m│[0m  [2m15[0m │ 
+  [31m│[0m  [2m14[0m │ 
   [31m│[0m     ╰────
   [31m│[0m [36m  help: [0mAdd an error handler via `.error_handler`
 

--- a/doc_examples/quickstart/08.patch
+++ b/doc_examples/quickstart/08.patch
@@ -1,17 +1,17 @@
 diff --git a/app/src/blueprint.rs b/app/src/blueprint.rs
-index e03ac7c..87475f0 100644
+index fb0ef2c..2602c1b 100644
 --- a/app/src/blueprint.rs
 +++ b/app/src/blueprint.rs
-@@ -11,7 +11,8 @@ pub fn blueprint() -> Blueprint {
+@@ -10,7 +10,8 @@ pub fn blueprint() -> Blueprint {
+     ApiKit::new().register(&mut bp);
      telemetry::register(&mut bp);
-     AppConfig::register(&mut bp);
-
+     configuration::register(&mut bp);
 -    bp.request_scoped(f!(crate::user_agent::UserAgent::extract));
 +    bp.request_scoped(f!(crate::user_agent::UserAgent::extract))
 +        .error_handler(f!(crate::user_agent::invalid_user_agent));
 
-     bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
-     bp.route(GET, "/api/greet/:name", f!(crate::routes::greet::greet));
+     routes::register(&mut bp);
+     bp
 diff --git a/app/src/user_agent.rs b/app/src/user_agent.rs
 index bb1f65b..78360bd 100644
 --- a/app/src/user_agent.rs

--- a/doc_examples/quickstart/demo-blueprint_definition.snap
+++ b/doc_examples/quickstart/demo-blueprint_definition.snap
@@ -4,9 +4,9 @@ pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
     ApiKit::new().register(&mut bp);
     telemetry::register(&mut bp);
-    AppConfig::register(&mut bp);
+    configuration::register(&mut bp);
 
-    bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
+    routes::register(&mut bp);
     bp
 }
 ```

--- a/doc_examples/quickstart/demo-route_registration.snap
+++ b/doc_examples/quickstart/demo-route_registration.snap
@@ -1,12 +1,9 @@
-```rust title="app/src/blueprint.rs" hl_lines="8"
+```rust title="app/src/routes/mod.rs" hl_lines="7"
 // [...]
-pub fn blueprint() -> Blueprint {
-    let mut bp = Blueprint::new();
-    ApiKit::new().register(&mut bp);
-    telemetry::register(&mut bp);
-    AppConfig::register(&mut bp);
+use pavex::blueprint::{router::GET, Blueprint};
+use pavex::f;
 
-    bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
-    bp
+pub fn register(bp: &mut Blueprint) {
+    bp.route(GET, "/api/ping", f!(self::status::ping));
 }
 ```

--- a/doc_examples/quickstart/demo-route_registration.snap
+++ b/doc_examples/quickstart/demo-route_registration.snap
@@ -1,4 +1,4 @@
-```rust title="app/src/routes/mod.rs" hl_lines="7"
+```rust title="app/src/routes/mod.rs" hl_lines="6"
 // [...]
 use pavex::blueprint::{router::GET, Blueprint};
 use pavex::f;

--- a/doc_examples/quickstart/tutorial.yml
+++ b/doc_examples/quickstart/tutorial.yml
@@ -4,11 +4,11 @@ starter_project_folder: demo
 snippets:
   - name: "blueprint_definition"
     source_path: "app/src/blueprint.rs"
-    ranges: [ "7..16" ]
+    ranges: [ "6..16" ]
   - name: "route_registration"
-    source_path: "app/src/blueprint.rs"
-    ranges: [ "7..16" ]
-    hl_lines: [ 8 ]
+    source_path: "app/src/routes/mod.rs"
+    ranges: [ "2.." ]
+    hl_lines: [ 6 ]
   - name: "ping_handler"
     source_path: "app/src/routes/status.rs"
     ranges: [ ".." ]
@@ -35,15 +35,15 @@ steps:
     snippets:
       - name: "new_submodule"
         source_path: "app/src/routes/mod.rs"
-        ranges: [ ".." ]
+        ranges: [ "0..2" ]
         hl_lines: [ 1 ]
       - name: "route_def"
         source_path: "app/src/routes/greet.rs"
         ranges: [ ".." ]
       - name: "register_new_route"
-        source_path: "app/src/blueprint.rs"
-        ranges: [ "7..21" ]
-        hl_lines: [ 9, 10, 11, 12, 13 ]
+        source_path: "app/src/routes/mod.rs"
+        ranges: [ "6..10" ]
+        hl_lines: [ 4 ]
     commands:
       - command: "cargo px c"
         expected_outcome: "success"
@@ -62,7 +62,7 @@ steps:
         ranges: [ ".." ]
       - name: "register_common_invocation"
         source_path: "app/src/blueprint.rs"
-        ranges: [ "7..10", "19..21" ]
+        ranges: [ "6..10", "14..15" ]
         hl_lines: [ 4 ]
     commands:
       - command: "cargo px c"
@@ -95,7 +95,7 @@ steps:
         ranges: [ "0..2", "10..23" ]
       - name: "register"
         source_path: "app/src/blueprint.rs"
-        ranges: [ "7..8", "13..14", "18..19" ]
+        ranges: [ "7..8", "12..13", "16..17" ]
         hl_lines: [ 4 ]
     commands:
       - command: "cargo px c"
@@ -116,7 +116,7 @@ steps:
         ranges: [ "21..25" ]
       - name: "register"
         source_path: "app/src/blueprint.rs"
-        ranges: [ "7..8", "13..15", "19..20" ]
+        ranges: [ "7..8", "12..14", "17..18" ]
         hl_lines: [ 5 ]
     commands:
       - command: "cargo px c"

--- a/docs/getting_started/quickstart/dependency_injection.md
+++ b/docs/getting_started/quickstart/dependency_injection.md
@@ -72,7 +72,8 @@ Now register the new constructor with the [`Blueprint`][Blueprint]:
 --8<-- "doc_examples/quickstart/06-register.snap"
 
 In [`Blueprint::request_scoped`][Blueprint::request_scoped] you must specify 
-the [fully qualified path](../../guide/dependency_injection/cookbook.md) to the constructor method, wrapped in a macro ([`f!`][f!]).
+an [unambiguous path](../../guide/dependency_injection/cookbook.md) to the constructor method,
+wrapped in the [`f!`][f!] macro.
 
 Make sure that the project compiles successfully at this point.
 

--- a/docs/getting_started/quickstart/routing.md
+++ b/docs/getting_started/quickstart/routing.md
@@ -12,7 +12,7 @@ It specifies:
 
 - The HTTP method (`GET`)
 - The path (`/api/ping`)
-- The [fully qualified path](../../guide/dependency_injection/cookbook.md) to the handler function (`self::status::ping`), wrapped in a macro ([`f!`][f!])
+- An [unambiguous path](../../guide/dependency_injection/cookbook.md) to the handler function (`self::status::ping`), wrapped in the [`f!`][f!] macro
 
 ## Request handlers
 

--- a/docs/getting_started/quickstart/routing.md
+++ b/docs/getting_started/quickstart/routing.md
@@ -12,7 +12,7 @@ It specifies:
 
 - The HTTP method (`GET`)
 - The path (`/api/ping`)
-- The [fully qualified path](../../guide/dependency_injection/cookbook.md) to the handler function (`crate::routes::status::ping`), wrapped in a macro ([`f!`][f!])
+- The [fully qualified path](../../guide/dependency_injection/cookbook.md) to the handler function (`self::status::ping`), wrapped in a macro ([`f!`][f!])
 
 ## Request handlers
 

--- a/docs/guide/dependency_injection/cookbook.md
+++ b/docs/guide/dependency_injection/cookbook.md
@@ -11,20 +11,20 @@ Use it a reference in your day-to-day Pavex development if you're not sure of th
     All the examples register constructors, but the very same `f!` invocations can be used to register 
     request handlers, error handlers, error observers and middlewares.
 
-## Fully qualified paths
+## Unambiguous paths
 
-In all the cases described in this cookbook, we'll talk about **fully qualified paths**. 
-They allow Pavex to unambiguously identify the callable you want to register.  
+In all the cases described in this cookbook, we'll talk about **unambiguous paths**. 
+They allow Pavex to identify with certainty the callable you want to register.  
 The format differs between [local items](#local-items) and [items imported from a dependency of your crate](#from-a-dependency).
 
 ### Local items
 
 If the item you want to register is defined in the current crate,
-you can use three different formats for its fully qualified path:
+you can use three different formats for its unambiguous path:
 
 - A path prefixed with `crate`, spelling out where the item is located **with respect to the root of the crate**.
 ```rust
-//! You can use `crate::my_module::handler` as a fully qualified path
+//! You can use `crate::my_module::handler` as an unambiguous path
 //! for the `handler` function from anywhere in your crate.
 
 pub mod my_module {
@@ -36,7 +36,7 @@ pub mod my_module {
 - A path prefixed with `self`, spelling out where the item is located **with respect to the root of the current module**.
 ```rust
 pub mod my_module {
-   //! From inside `my_module`, you can use `self::handler` as a fully qualified path
+   //! From inside `my_module`, you can use `self::handler` as an unambiguous path
    //! for the `handler` function.
    pub fn handler() {
       // [...]
@@ -50,7 +50,7 @@ pub fn handler() {
 }
 
 pub mod my_module {
-   //! From inside `my_module`, you can use `super::handler` as a fully qualified path
+   //! From inside `my_module`, you can use `super::handler` as an unambiguous path
    //! for the `handler` function.
 }
 ```
@@ -66,8 +66,8 @@ the crate it is defined into. E.g. `reqwest::Client`, if `reqwest` is one of you
 
 ## Free functions
 
-Free functions are the simplest case.
-You register them as constructors by passing their [fully qualified path] to the [`f!` macro][f!].
+Free functions are the simplest case.  
+You pass an [unambiguous path] to the [`f!` macro][f!] as input.
 
 --8<-- "doc_examples/guide/dependency_injection/cookbook/project-function_registration.snap"
 
@@ -75,8 +75,7 @@ You register them as constructors by passing their [fully qualified path] to the
 
 ## Static methods
 
-Static methods (1) behave exactly like free functions:
-you can register them as constructors by passing their [fully qualified path] to the [`f!` macro][f!].
+Static methods (1) behave exactly like free functions: you provide an [unambiguous path] to the [`f!` macro][f!].
 { .annotate }
 
 1. A static method is a method that doesn't take `self` (or one of its variants) as an input parameter.
@@ -88,7 +87,7 @@ you can register them as constructors by passing their [fully qualified path] to
 ## Non-static methods
 
 On the surface, non-static methods are registered in the same way as static methods: 
-by passing their [fully qualified path] to the [`f!` macro][f!].
+by passing an [unambiguous path] to the [`f!` macro][f!].
 
 --8<-- "doc_examples/guide/dependency_injection/cookbook/project-non_static_method_registration.snap"
 
@@ -156,5 +155,5 @@ when registering the constructor.
 
 
 [f!]: ../../api_reference/pavex/macro.f!.html
-[fully qualified path]: #fully-qualified-paths
+[unambiguous path]: #unambiguous-paths
 [^ufcs]: Check out the [relevant RFC](https://github.com/rust-lang/rfcs/blob/master/text/0132-ufcs.md) if you're curious.

--- a/docs/guide/dependency_injection/core_concepts/constructors.md
+++ b/docs/guide/dependency_injection/core_concepts/constructors.md
@@ -36,7 +36,7 @@ Once you have defined a constructor, you need to register it with the applicatio
 
 [`Blueprint::constructor`][Blueprint::constructor] takes two arguments:
 
-- The [fully qualified path](../cookbook.md) to the constructor, wrapped in a macro ([`f!`][f])
+- An [unambiguous path](../cookbook.md) to the constructor, wrapped in the [`f!`][f] macro.
 - The [constructor's lifecycle](#lifecycles).
 
 Alternatively, you could use [`Blueprint::request_scoped`][Blueprint::request_scoped] as 

--- a/docs/guide/errors/error_handlers.md
+++ b/docs/guide/errors/error_handlers.md
@@ -12,8 +12,7 @@ You must specify an error handler every time you register a fallible component
 
 1. Pavex will return an error during code generation if you register an error handler for an infallible component.
 
-When registering an error handler, you must provide its **[fully qualified path]**, 
-wrapped in the [`f!`][f] macro.  
+You must provide an **[unambiguous path]** to the error handler, wrapped in the [`f!`][f] macro.  
 
 !!! note "Registration syntax"
 
@@ -93,4 +92,4 @@ on the differences between the two and how to choose the right one for your use 
 [IntoResponse]: ../../../api_reference/pavex/response/trait.IntoResponse.html
 [Response]: ../../../api_reference/pavex/response/struct.Response.html
 [f]: ../../../api_reference/pavex/macro.f.html
-[fully qualified path](../dependency_injection/cookbook.md)
+[unambiguous path](../dependency_injection/cookbook.md#unambiguous-paths)

--- a/docs/guide/errors/error_observers.md
+++ b/docs/guide/errors/error_observers.md
@@ -12,8 +12,7 @@ You register an error observer using the [`Blueprint::error_observer`][Blueprint
 
 --8<-- "doc_examples/guide/errors/error_observers/project-registration.snap"
 
-When registering an error observer, you must provide its **[fully qualified path]**, wrapped in the
-[`f!`][f] macro.  
+You must provide an **[unambiguous path]** to the error observer, wrapped in the [`f!`][f] macro.  
 You can register as many error observers as you want: they'll all be called when an error occurs,
 in the order they were registered. They are invoked after the relevant error handler has been called,
 but before the response is sent back to the client.

--- a/docs/guide/middleware/index.md
+++ b/docs/guide/middleware/index.md
@@ -17,7 +17,7 @@ You register a middleware against a blueprint via the [`wrap`](crate::blueprint:
 
 --8<-- "doc_examples/guide/middleware/core_concepts/project-registration.snap"
 
-When registering a middleware, you must provide its **[fully qualified path]**, wrapped in the [`f!` macro][f].  
+You must provide an **[unambiguous path]** to the middleware, wrapped in the [`f!`][f] macro.  
 A middleware applies to all request handlers registered against the same [`Blueprint`][Blueprint].
 See the [execution order](#execution-order) section for more details.
 
@@ -145,4 +145,4 @@ First - end
 [Future]: https://doc.rust-lang.org/std/future/trait.Future.html
 [IntoFuture]: https://doc.rust-lang.org/std/future/trait.IntoFuture.html
 [Result]: https://doc.rust-lang.org/std/result/index.html
-[fully qualified path](../dependency_injection/cookbook.md)
+[unambiguous path](../dependency_injection/cookbook.md#unambiguous-paths)

--- a/docs/guide/routing/request_handlers.md
+++ b/docs/guide/routing/request_handlers.md
@@ -10,7 +10,7 @@ The request handler is in charge of building the response that will be sent back
 
 ## Registration
 
-When registering a route, you must provide the **[fully qualified path]** to the request handler:
+You must provide an **[unambiguous path]** to the request handler, wrapped in the [`f!`][f] macro.  
 
 ```rust hl_lines="6"
 --8<-- "doc_examples/guide/routing/request_handlers/intro/src/blueprint.rs"
@@ -115,4 +115,4 @@ If you want to learn more about what "blocking" means in async Rust, check out [
 [spawn_blocking]: https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html
 [f!]: ../../api_reference/pavex/macro.f.html
 [Result]: https://doc.rust-lang.org/std/result/index.html
-[fully qualified path](../dependency_injection/cookbook.md)
+[unambiguous path](../dependency_injection/cookbook.md#unambiguous-paths)

--- a/libs/pavex/src/blueprint/reflection.rs
+++ b/libs/pavex/src/blueprint/reflection.rs
@@ -33,7 +33,7 @@ pub struct RawCallable {
 // compile if the callable is generic, because the compiler would
 // demand to know the type of each generic parameter without a default.
 #[macro_export]
-/// A macro to convert a fully-qualified path into a [`RawCallable`].
+/// A macro to convert an [unambiguous path](https://pavex.dev/docs/guide/dependency_injection/cookbook/#unambiguous-paths) into a [`RawCallable`].
 ///
 /// # Guide
 ///

--- a/libs/pavexc_cli/template/app/src/blueprint.rs
+++ b/libs/pavexc_cli/template/app/src/blueprint.rs
@@ -1,6 +1,5 @@
-use crate::{configuration::AppConfig, telemetry};
-use pavex::blueprint::{router::GET, Blueprint};
-use pavex::f;
+use crate::{configuration, routes, telemetry};
+use pavex::blueprint::Blueprint;
 use pavex::kit::ApiKit;
 
 /// The main blueprint, containing all the routes, middlewares, constructors and error handlers
@@ -9,8 +8,8 @@ pub fn blueprint() -> Blueprint {
     let mut bp = Blueprint::new();
     ApiKit::new().register(&mut bp);
     telemetry::register(&mut bp);
-    AppConfig::register(&mut bp);
+    configuration::register(&mut bp);
 
-    bp.route(GET, "/api/ping", f!(crate::routes::status::ping));
+    routes::register(&mut bp);
     bp
 }

--- a/libs/pavexc_cli/template/app/src/configuration.rs
+++ b/libs/pavexc_cli/template/app/src/configuration.rs
@@ -1,44 +1,45 @@
 use pavex::blueprint::constructor::CloningStrategy;
-use pavex::blueprint::{Blueprint, linter::Lint};
+use pavex::blueprint::{linter::Lint, Blueprint};
 use pavex::f;
+
+pub fn register(bp: &mut Blueprint) {
+    // How do you add your own configuration?
+    // The starter template includes a "dummy" configuration option as
+    // a reference example.
+    //
+    // Steps:
+    //
+    // 1. Define a public struct to group related configuration values together.
+    //    E.g. `DatabaseConfig` for the host, port, username and password
+    //    for a database connection.
+    //    In this example, it's `DummyConfig`.
+    // 2. Add the struct as a field to `ApplicationConfig`.
+    //    You can see `pub dummy: DummyConfig` down there.
+    // 3. Add an accessor method that returns a reference to the sub-field.
+    //    In our example, [`AppConfig::dummy_config`].
+    // 4. Add it as a constructor in `configuratio::register`, so that
+    //    your components can inject it.
+    // 5. (Optional) Add it to the configuration files stored in the
+    //    `*_server/configuration` folder, or inject it at runtime via an
+    //    environment variable.
+    //    See `Config::load` for more details on how configuration is assembled.
+    //
+    // Feel free to delete `DummyConfig` once you get started working on your own app!
+    bp.singleton(f!(self::AppConfig::dummy_config))
+        .cloning(CloningStrategy::CloneIfNecessary)
+        .ignore(Lint::Unused);
+}
 
 #[derive(serde::Deserialize, Debug, Clone)]
 /// The configuration object holding all the values required
 /// to configure the application.
 pub struct AppConfig {
-    /// How should go about adding your own configuration?
-    /// We'll use a "dummy" configuration value to showcase how you'd go about it!
-    ///
-    /// Steps:
-    ///
-    /// 1. Define a public struct to group related configuration values together.
-    ///    E.g. `DatabaseConfig` for the host, port, username and password
-    ///    for a database connection.
-    ///    In this example, it's `DummyConfig`.
-    /// 2. Add the struct as a field to `ApplicationConfig`.
-    ///    You can see `pub dummy: DummyConfig` here.
-    /// 3. Add an accessor method that returns a reference to the sub-field.
-    ///    In our example, [`AppConfig::dummy_config`].
-    /// 4. Add it as a constructor in `ApplicationConfig::register`, so that
-    ///    your components can inject it.
-    /// 5. (Optional) Add it to the configuration files stored in the
-    ///    `*_server/configuration` folder, or inject it at runtime via an
-    ///    environment variable.
-    ///    See `Config::load` for more details on how configuration is assembled.
-    ///
-    /// Feel free to delete `DummyConfig` once you get started working on your own app!
     pub dummy: DummyConfig,
 }
 
 impl AppConfig {
     pub fn dummy_config(&self) -> &DummyConfig {
         &self.dummy
-    }
-
-    pub fn register(bp: &mut Blueprint) {
-        bp.singleton(f!(self::AppConfig::dummy_config))
-            .cloning(CloningStrategy::CloneIfNecessary)
-            .ignore(Lint::Unused);
     }
 }
 

--- a/libs/pavexc_cli/template/app/src/routes/mod.rs
+++ b/libs/pavexc_cli/template/app/src/routes/mod.rs
@@ -1,1 +1,8 @@
 pub mod status;
+
+use pavex::blueprint::{router::GET, Blueprint};
+use pavex::f;
+
+pub fn register(bp: &mut Blueprint) {
+    bp.route(GET, "/api/ping", f!(self::status::ping));
+}


### PR DESCRIPTION
Since we now support `self` and `super` paths, it doesn't make sense to call them "fully qualified path".
We retire the term in favour of **unambiguous path**.

I sneaked a little restructuring of the starter project as well (i.e. `routes::register`).