### PR TITLE
Explain how to set configuration values via env variables.

### DIFF
--- a/examples/starter/server/src/configuration/schema.rs
+++ b/examples/starter/server/src/configuration/schema.rs
@@ -73,7 +73,7 @@ impl Config {
         let figment = Figment::new()
             .merge(Yaml::file(base_filepath))
             .merge(Yaml::file(profile_filepath))
-            .merge(Env::prefixed("APP_"));
+            .merge(Env::prefixed("APP_").split("__"));
 
         let configuration: Config = figment
             .extract()

--- a/libs/pavexc_cli/template/.env
+++ b/libs/pavexc_cli/template/.env
@@ -1,1 +1,5 @@
 APP_PROFILE=dev
+# All env variables must be prefixed with `APP_` to be picked up at runtime.
+# To set a nested field you need to use `__` as separator.
+# For example, to set `Config.server.port` via an env variable
+# it'd have to be named `APP_SERVER__PORT`.

--- a/libs/pavexc_cli/template/server/src/configuration/schema.rs
+++ b/libs/pavexc_cli/template/server/src/configuration/schema.rs
@@ -73,7 +73,7 @@ impl Config {
         let figment = Figment::new()
             .merge(Yaml::file(base_filepath))
             .merge(Yaml::file(profile_filepath))
-            .merge(Env::prefixed("APP_"));
+            .merge(Env::prefixed("APP_").split("__"));
 
         let configuration: Config = figment
             .extract()


### PR DESCRIPTION
In particular, allow setting single fields of a nested configuration struct using `split`.