### PR TITLE
Nitpick on wording

### DIFF
--- a/doc_examples/quickstart/08-error_handler.snap
+++ b/doc_examples/quickstart/08-error_handler.snap
@@ -2,6 +2,6 @@
 // [...]
 pub fn invalid_user_agent(_e: &ToStrError) -> Response {
     Response::bad_request()
-        .set_typed_body("The `User-Agent` header value must be a valid UTF-8 string")
+        .set_typed_body("The `User-Agent` header value must be comprised of ASCII printable characters")
 }
 ```

--- a/docs/getting_started/quickstart/error_handling.md
+++ b/docs/getting_started/quickstart/error_handling.md
@@ -1,14 +1,14 @@
 # Error handling
 
 In `UserAgent::extract` you're only handling the happy path:
-the method panics if the `User-Agent` header is not valid UTF-8.  
+the method panics if the `User-Agent` header value is not comprised of ASCII printable characters.
 Panicking for bad user input is poor behavior: you should handle the issue gracefully and return an error instead.
 
 Let's change the signature of `UserAgent::extract` to return a `Result` instead:
 
 --8<-- "doc_examples/quickstart/07-extract.snap"
 
-1. `ToStrError` is the error type returned by `to_str` when the header value is not valid UTF-8.
+1. `ToStrError` is the error type returned by `to_str` when the header value is not comprised of ASCII printable characters.
 
 ## All errors must be handled
 


### PR DESCRIPTION
*Description of changes:*

The `to_str` method from `HeaderValue` returns the `Err` variant when the header's value is not comprised of ASCII printable characters, not when the bytes are not valid UTF-8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
