### PR TITLE
Run tests for quickstart tutorial

### DIFF
--- a/doc_examples/quickstart/10-greet_test.snap
+++ b/doc_examples/quickstart/10-greet_test.snap
@@ -16,7 +16,7 @@ async fn non_utf8_user_agent_is_rejected() {
     assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
     assert_eq!(
         response.text().await.unwrap(),
-        "The `User-Agent` header value must be a valid UTF-8 string"
+        "The `User-Agent` header value can only use ASCII printable characters."
     );
 }
 ```

--- a/doc_examples/quickstart/10.patch
+++ b/doc_examples/quickstart/10.patch
@@ -23,6 +23,6 @@ index fb02807..eeb2652 100644
 +    assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
 +    assert_eq!(
 +        response.text().await.unwrap(),
-+        "The `User-Agent` header value must be a valid UTF-8 string"
++        "The `User-Agent` header value can only use ASCII printable characters."
 +    );
 +}

--- a/doc_examples/quickstart/tutorial.yml
+++ b/doc_examples/quickstart/tutorial.yml
@@ -134,7 +134,7 @@ steps:
         source_path: "server/tests/integration/greet.rs"
         ranges: [ ".." ]
     commands:
-      - command: "cargo px c"
+      - command: "cargo px t"
         expected_outcome: "success"
   - patch: "10.patch"
     snippets:
@@ -142,5 +142,5 @@ steps:
         source_path: "server/tests/integration/greet.rs"
         ranges: [ "21.." ]
     commands:
-      - command: "cargo px c"
+      - command: "cargo px t"
         expected_outcome: "success"


### PR DESCRIPTION
It slipped through in #217 because we were only checking for a successful compilation rather than executing tests.