### PR TITLE
Use a consistent naming scheme for request handlers.

### DIFF
--- a/doc_examples/quickstart/02-new_submodule.snap
+++ b/doc_examples/quickstart/02-new_submodule.snap
@@ -1,4 +1,4 @@
 ```rust title="app/src/routes/mod.rs" hl_lines="1"
 pub mod greet;
-pub mod status;
+pub mod ping;
 ```

--- a/doc_examples/quickstart/02-register_new_route.snap
+++ b/doc_examples/quickstart/02-register_new_route.snap
@@ -1,7 +1,7 @@
 ```rust title="app/src/routes/mod.rs" hl_lines="4"
 // [...]
 pub fn register(bp: &mut Blueprint) {
-    bp.route(GET, "/api/ping", f!(self::status::ping));
-    bp.route(GET, "/api/greet/:name", f!(self::greet::greet)); // (1)!
+    bp.route(GET, "/api/ping", f!(self::ping::get));
+    bp.route(GET, "/api/greet/:name", f!(self::greet::get)); // (1)!
 }
 ```

--- a/doc_examples/quickstart/02-route_def.snap
+++ b/doc_examples/quickstart/02-route_def.snap
@@ -1,7 +1,7 @@
 ```rust title="app/src/routes/greet.rs"
 use pavex::response::Response;
 
-pub fn greet() -> Response {
+pub fn get() -> Response {
     todo!()
 }
 ```

--- a/doc_examples/quickstart/02.patch
+++ b/doc_examples/quickstart/02.patch
@@ -6,7 +6,7 @@ index 0000000..38ec1e3
 @@ -0,0 +1,5 @@
 +use pavex::response::Response;
 +
-+pub fn greet() -> Response {
++pub fn get() -> Response {
 +    todo!()
 +}
 diff --git a/app/src/routes/mod.rs b/app/src/routes/mod.rs
@@ -15,12 +15,12 @@ index 0472c7d..3c53d60 100644
 +++ b/app/src/routes/mod.rs
 @@ -1,3 +1,4 @@
 +pub mod greet;
- pub mod status;
+ pub mod ping;
 
  use pavex::blueprint::{router::GET, Blueprint};
 @@ -5,4 +5,5 @@ use pavex::f;
 
  pub fn register(bp: &mut Blueprint) {
-     bp.route(GET, "/api/ping", f!(self::status::ping));
-+    bp.route(GET, "/api/greet/:name", f!(self::greet::greet)); // (1)!
+     bp.route(GET, "/api/ping", f!(self::ping::get));
++    bp.route(GET, "/api/greet/:name", f!(self::greet::get)); // (1)!
  }

--- a/doc_examples/quickstart/03-route_def.snap
+++ b/doc_examples/quickstart/03-route_def.snap
@@ -7,7 +7,7 @@ pub struct GreetParams {
     pub name: String, /* (1)! */
 }
 
-pub fn greet(params: PathParams<GreetParams> /* (2)! */) -> Response {
+pub fn get(params: PathParams<GreetParams> /* (2)! */) -> Response {
     todo!()
 }
 ```

--- a/doc_examples/quickstart/03.patch
+++ b/doc_examples/quickstart/03.patch
@@ -6,12 +6,12 @@ index 38ec1e3..adfbbd5 100644
 +use pavex::request::path::PathParams;
  use pavex::response::Response;
  
--pub fn greet() -> Response {
+-pub fn get() -> Response {
 +#[PathParams]
 +pub struct GreetParams {
 +    pub name: String /* (1)! */
 +}
 +
-+pub fn greet(params: PathParams<GreetParams> /* (2)! */) -> Response {
++pub fn get(params: PathParams<GreetParams> /* (2)! */) -> Response {
      todo!()
  }

--- a/doc_examples/quickstart/04-route_def.snap
+++ b/doc_examples/quickstart/04-route_def.snap
@@ -7,7 +7,7 @@ pub struct GreetParams {
     pub name: String,
 }
 
-pub fn greet(params: PathParams<GreetParams>) -> Response {
+pub fn get(params: PathParams<GreetParams>) -> Response {
     let GreetParams { name }/* (1)! */ = params.0;
     Response::ok() // (2)!
         .set_typed_body(format!("Hello, {name}!")) // (3)!

--- a/doc_examples/quickstart/04.patch
+++ b/doc_examples/quickstart/04.patch
@@ -10,9 +10,9 @@ index e0be313..5080f53 100644
 +    pub name: String,
  }
 
--pub fn greet(params: PathParams<GreetParams> /* (2)! */) -> Response {
+-pub fn get(params: PathParams<GreetParams> /* (2)! */) -> Response {
 -    todo!()
-+pub fn greet(params: PathParams<GreetParams>) -> Response {
++pub fn get(params: PathParams<GreetParams>) -> Response {
 +    let GreetParams { name }/* (1)! */ = params.0;
 +    Response::ok() // (2)!
 +        .set_typed_body(format!("Hello, {name}!")) // (3)!

--- a/doc_examples/quickstart/05-bis.patch
+++ b/doc_examples/quickstart/05-bis.patch
@@ -5,9 +5,9 @@ index 042c06f..01a843c 100644
 @@ -6,5 +6,5 @@ use pavex::f;
 
  pub fn register(bp: &mut Blueprint) {
-     bp.route(GET, "/api/ping", f!(self::status::ping));
--    bp.route(GET, "/api/greet/:name", f!(self::greet::greet)); // (1)!
-+    bp.route(GET, "/api/greet/:name", f!(self::greet::greet));
+     bp.route(GET, "/api/ping", f!(self::ping::get));
+-    bp.route(GET, "/api/greet/:name", f!(self::greet::get)); // (1)!
++    bp.route(GET, "/api/greet/:name", f!(self::greet::get));
  }
 diff --git a/app/src/routes/greet.rs b/app/src/routes/greet.rs
 --- a/app/src/routes/greet.rs
@@ -16,8 +16,8 @@ diff --git a/app/src/routes/greet.rs b/app/src/routes/greet.rs
      pub name: String,
  }
  
--pub fn greet(params: PathParams<GreetParams>, user_agent: UserAgent /* (1)! */) -> Response {
-+pub fn greet(params: PathParams<GreetParams>, user_agent: UserAgent) -> Response {
+-pub fn get(params: PathParams<GreetParams>, user_agent: UserAgent /* (1)! */) -> Response {
++pub fn get(params: PathParams<GreetParams>, user_agent: UserAgent) -> Response {
      if let UserAgent::Unknown = user_agent {
          return Response::unauthorized()
              .set_typed_body("You must provide a `User-Agent` header");

--- a/doc_examples/quickstart/05-error.snap
+++ b/doc_examples/quickstart/05-error.snap
@@ -1,18 +1,18 @@
 [31m[1mERROR[0m[39m: 
-  [31m×[0m I can't invoke your request handler, `app::routes::greet::greet`, because it needs an instance
+  [31m×[0m I can't invoke your request handler, `app::routes::greet::get`, because it needs an instance
   [31m│[0m of `app::user_agent::UserAgent` as input, but I can't find a constructor for that type.
   [31m│[0m
   [31m│[0m     ╭─[[36;1;4mapp/src/routes/mod.rs[0m:8:1]
-  [31m│[0m  [2m 8[0m │     bp.route(GET, "/api/ping", f!(self::status::ping));
-  [31m│[0m  [2m 9[0m │     bp.route(GET, "/api/greet/:name", f!(self::greet::greet));
-  [31m│[0m     · [35;1m                                      ───────────┬──────────[0m
-  [31m│[0m     ·                                                  [35;1m╰── The request handler was registered here[0m
+  [31m│[0m  [2m 8[0m │     bp.route(GET, "/api/ping", f!(self::ping::get));
+  [31m│[0m  [2m 9[0m │     bp.route(GET, "/api/greet/:name", f!(self::greet::get));
+  [31m│[0m     · [35;1m                                      ──────────┬─────────[0m
+  [31m│[0m     ·                                                 [35;1m╰── The request handler was registered here[0m
   [31m│[0m  [2m10[0m │ }
   [31m│[0m     ╰────
   [31m│[0m     ╭─[[36;1;4mapp/src/routes/greet.rs[0m:10:1]
   [31m│[0m  [2m10[0m │ 
-  [31m│[0m  [2m11[0m │ pub fn greet(params: PathParams<GreetParams>, user_agent: UserAgent) -> Response {
-  [31m│[0m     · [35;1m                                              ──────────┬──────────[0m
+  [31m│[0m  [2m11[0m │ pub fn get(params: PathParams<GreetParams>, user_agent: UserAgent) -> Response {
+  [31m│[0m     · [35;1m                                            ──────────┬──────────[0m
   [31m│[0m     ·               [35;1mI don't know how to construct an instance of this input parameter[0m
   [31m│[0m  [2m12[0m │     if let UserAgent::Unknown = user_agent {
   [31m│[0m     ╰────

--- a/doc_examples/quickstart/05-inject.snap
+++ b/doc_examples/quickstart/05-inject.snap
@@ -2,7 +2,7 @@
 // [...]
 use crate::user_agent::UserAgent;
 // [...]
-pub fn greet(params: PathParams<GreetParams>, user_agent: UserAgent /* (1)! */) -> Response {
+pub fn get(params: PathParams<GreetParams>, user_agent: UserAgent /* (1)! */) -> Response {
     if let UserAgent::Unknown = user_agent {
         return Response::unauthorized().set_typed_body("You must provide a `User-Agent` header");
     }

--- a/doc_examples/quickstart/05.patch
+++ b/doc_examples/quickstart/05.patch
@@ -27,11 +27,11 @@ index 5080f53..721ca61 100644
      pub name: String,
  }
 
--pub fn greet(params: PathParams<GreetParams>) -> Response {
+-pub fn get(params: PathParams<GreetParams>) -> Response {
 -    let GreetParams { name }/* (1)! */ = params.0;
 -    Response::ok() // (2)!
 -        .set_typed_body(format!("Hello, {name}!")) // (3)!
-+pub fn greet(params: PathParams<GreetParams>, user_agent: UserAgent /* (1)! */) -> Response {
++pub fn get(params: PathParams<GreetParams>, user_agent: UserAgent /* (1)! */) -> Response {
 +    if let UserAgent::Unknown = user_agent {
 +        return Response::unauthorized().set_typed_body("You must provide a `User-Agent` header");
 +    }

--- a/doc_examples/quickstart/09-greet_test.snap
+++ b/doc_examples/quickstart/09-greet_test.snap
@@ -16,7 +16,7 @@ async fn greet_happy_path() {
         .await
         .expect("Failed to execute request.");
 
-    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.text().await.unwrap(), "Hello, Ursula!");
 }
 ```

--- a/doc_examples/quickstart/09-ping_test.snap
+++ b/doc_examples/quickstart/09-ping_test.snap
@@ -10,6 +10,6 @@ async fn ping_works() {
 
     let response = api.get_ping().await; //(3)!
 
-    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(response.status(), StatusCode::OK);
 }
 ```

--- a/doc_examples/quickstart/09.patch
+++ b/doc_examples/quickstart/09.patch
@@ -21,7 +21,7 @@ index 0000000..fb02807
 +        .await
 +        .expect("Failed to execute request.");
 +
-+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
++    assert_eq!(response.status(), StatusCode::OK);
 +    assert_eq!(response.text().await.unwrap(), "Hello, Ursula!");
 +}
 diff --git a/server/tests/integration/main.rs b/server/tests/integration/main.rs
@@ -51,5 +51,5 @@ index c79eb0e..bfd2726 100644
 -    let response = api.get_ping().await;
 +    let response = api.get_ping().await; //(3)!
  
-     assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+     assert_eq!(response.status(), StatusCode::OK);
  }

--- a/doc_examples/quickstart/10-greet_test.snap
+++ b/doc_examples/quickstart/10-greet_test.snap
@@ -13,7 +13,7 @@ async fn non_utf8_user_agent_is_rejected() {
         .await
         .expect("Failed to execute request.");
 
-    assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.text().await.unwrap(),
         "The `User-Agent` header value can only use ASCII printable characters."

--- a/doc_examples/quickstart/10.patch
+++ b/doc_examples/quickstart/10.patch
@@ -3,7 +3,7 @@ index fb02807..eeb2652 100644
 --- a/server/tests/integration/greet.rs
 +++ b/server/tests/integration/greet.rs
 @@ -18,3 +18,23 @@ async fn greet_happy_path() {
-     assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+     assert_eq!(response.status(), StatusCode::OK);
      assert_eq!(response.text().await.unwrap(), "Hello, Ursula!");
  }
 +
@@ -20,7 +20,7 @@ index fb02807..eeb2652 100644
 +        .await
 +        .expect("Failed to execute request.");
 +
-+    assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
++    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 +    assert_eq!(
 +        response.text().await.unwrap(),
 +        "The `User-Agent` header value can only use ASCII printable characters."

--- a/doc_examples/quickstart/demo-ping_handler.snap
+++ b/doc_examples/quickstart/demo-ping_handler.snap
@@ -1,9 +1,9 @@
-```rust title="app/src/routes/status.rs"
+```rust title="app/src/routes/ping.rs"
 use pavex::http::StatusCode;
 
 /// Respond with a `200 OK` status code to indicate that the server is alive
 /// and ready to accept new requests.
-pub fn ping() -> StatusCode {
+pub fn get() -> StatusCode {
     StatusCode::OK
 }
 ```

--- a/doc_examples/quickstart/demo-ping_test.snap
+++ b/doc_examples/quickstart/demo-ping_test.snap
@@ -8,6 +8,6 @@ async fn ping_works() {
 
     let response = api.get_ping().await;
 
-    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(response.status(), StatusCode::OK);
 }
 ```

--- a/doc_examples/quickstart/demo-route_registration.snap
+++ b/doc_examples/quickstart/demo-route_registration.snap
@@ -4,6 +4,6 @@ use pavex::blueprint::{router::GET, Blueprint};
 use pavex::f;
 
 pub fn register(bp: &mut Blueprint) {
-    bp.route(GET, "/api/ping", f!(self::status::ping));
+    bp.route(GET, "/api/ping", f!(self::ping::get));
 }
 ```

--- a/doc_examples/quickstart/tutorial.yml
+++ b/doc_examples/quickstart/tutorial.yml
@@ -10,7 +10,7 @@ snippets:
     ranges: [ "2.." ]
     hl_lines: [ 6 ]
   - name: "ping_handler"
-    source_path: "app/src/routes/status.rs"
+    source_path: "app/src/routes/ping.rs"
     ranges: [ ".." ]
   - name: "cargo_px_in_manifest"
     source_path: "server_sdk/Cargo.toml"

--- a/docs/getting_started/quickstart/dependency_injection.md
+++ b/docs/getting_started/quickstart/dependency_injection.md
@@ -1,6 +1,6 @@
 # Dependency injection
 
-You just added a new input parameter to your `greet` handler and, somehow, the framework was able to provide its value
+You just added a new input parameter to your request handler and, somehow, the framework was able to provide its value
 at runtime without you having to do anything.  
 How does that work?
 
@@ -39,7 +39,7 @@ Let's start by defining a new `UserAgent` type:
 
 ## Missing constructor
 
-What if you tried to inject `UserAgent` into your `greet` handler straight away? Would it work?  
+What if you tried to inject `UserAgent` into your request handler straight away? Would it work?  
 Let's find out!
 
 --8<-- "doc_examples/quickstart/05-inject.snap"
@@ -59,7 +59,7 @@ We strive to make them as helpful as possible. If you find them confusing, repor
 
 ## Add a new constructor
 
-To inject `UserAgent` into our `greet` handler, you need to define a constructor for it.  
+To inject `UserAgent` into your request handler, you need to define a constructor for it.  
 Constructors, just like request handlers, can take advantage of dependency injection: they can request input parameters
 that will be injected by the framework at runtime.  
 Since you need to look at headers, ask for [`RequestHead`][RequestHead] as input parameter: the incoming request data,

--- a/docs/getting_started/quickstart/routing.md
+++ b/docs/getting_started/quickstart/routing.md
@@ -12,7 +12,7 @@ It specifies:
 
 - The HTTP method (`GET`)
 - The path (`/api/ping`)
-- An [unambiguous path](../../guide/dependency_injection/cookbook.md) to the handler function (`self::status::ping`), wrapped in the [`f!`][f!] macro
+- An [unambiguous path](../../guide/dependency_injection/cookbook.md) to the handler function (`self::ping::get`), wrapped in the [`f!`][f!] macro
 
 ## Request handlers
 
@@ -39,7 +39,7 @@ Create a new module, `greet.rs`, in the `app/src/routes` folder:
 
 --8<-- "doc_examples/quickstart/02-route_def.snap"
 
-The body of the `greet` handler is stubbed out with `todo!()` for now, but we'll fix that soon enough.  
+The body of the `GET /api/greet/:name` handler is stubbed out with `todo!()` for now, but we'll fix that soon enough.  
 Let's register the new route with the [`Blueprint`][Blueprint] in the meantime:
 
 --8<-- "doc_examples/quickstart/02-register_new_route.snap"
@@ -50,7 +50,6 @@ Let's register the new route with the [`Blueprint`][Blueprint] in the meantime:
 
 To access the `name` route parameter from your new handler you must use the [`PathParams`][PathParams] extractor:
 
-
 --8<-- "doc_examples/quickstart/03-route_def.snap"
 
 1. The name of the field must match the name of the route parameter as it appears in the path we registered with
@@ -58,7 +57,7 @@ To access the `name` route parameter from your new handler you must use the [`Pa
 2. The [`PathParams`][PathParams] extractor is generic over the type of the path parameters.  
    In this case, we're using the `GreetParams` type we just defined.
 
-You can now return the expected response from the `greet` handler:
+You can now return the expected response from the handler:
 
 --8<-- "doc_examples/quickstart/04-route_def.snap"
 

--- a/libs/pavexc_cli/template/app/src/routes/mod.rs
+++ b/libs/pavexc_cli/template/app/src/routes/mod.rs
@@ -1,8 +1,8 @@
-pub mod status;
+pub mod ping;
 
 use pavex::blueprint::{router::GET, Blueprint};
 use pavex::f;
 
 pub fn register(bp: &mut Blueprint) {
-    bp.route(GET, "/api/ping", f!(self::status::ping));
+    bp.route(GET, "/api/ping", f!(self::ping::get));
 }

--- a/libs/pavexc_cli/template/app/src/routes/ping.rs
+++ b/libs/pavexc_cli/template/app/src/routes/ping.rs
@@ -2,6 +2,6 @@ use pavex::http::StatusCode;
 
 /// Respond with a `200 OK` status code to indicate that the server is alive
 /// and ready to accept new requests.
-pub fn ping() -> StatusCode {
+pub fn get() -> StatusCode {
     StatusCode::OK
 }

--- a/libs/pavexc_cli/template/server/Cargo.toml.liquid
+++ b/libs/pavexc_cli/template/server/Cargo.toml.liquid
@@ -23,4 +23,4 @@ tracing-panic = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "registry", "smallvec", "std", "tracing-log"] }
 
 [dev-dependencies]
-reqwest = "0.11"
+reqwest = "0.12"

--- a/libs/pavexc_cli/template/server/tests/integration/ping.rs
+++ b/libs/pavexc_cli/template/server/tests/integration/ping.rs
@@ -7,5 +7,5 @@ async fn ping_works() {
 
     let response = api.get_ping().await;
 
-    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(response.status(), StatusCode::OK);
 }


### PR DESCRIPTION
Misc: update `reqwest` to `0.12`.