### PR TITLE
Cookies integration

### DIFF
--- a/examples/realworld/Cargo.lock
+++ b/examples/realworld/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "app"
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ba4cac0a46bc1d2912652a751c47f2a9f3a7fe89bcae2275d418f5270402f9"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
@@ -164,26 +164,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-write-file"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
-dependencies = [
- "nix",
- "rand",
-]
-
-[[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -232,9 +222,9 @@ checksum = "7e0d60973d9320722cb1206f412740e162a33b8547ea8d6be75d7cff237c7a85"
 
 [[package]]
 name = "biscotti"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3eece11455d5bc07597a9e96995eb119eee01c9083080dfab7e158ba12437c"
+checksum = "9c00e96f8e5da56dcc794d3e2a78f360b606716244277c77ebe161786c1733d2"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -246,7 +236,6 @@ dependencies = [
  "serde",
  "sha2",
  "subtle",
- "thiserror",
  "time",
 ]
 
@@ -258,9 +247,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 dependencies = [
  "serde",
 ]
@@ -285,15 +274,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -303,9 +292,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cargo_px_env"
@@ -315,9 +304,9 @@ checksum = "8b459425e7bfec0783df9538ecc749961f076cc793a09e91f1d082ee0012c925"
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -327,14 +316,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -349,13 +338,12 @@ dependencies = [
 
 [[package]]
 name = "coarsetime"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a"
+checksum = "13b3839cf01bb7960114be3ccf2340f541b6d0c81f8690b007b2b39f750f7e5d"
 dependencies = [
  "libc",
- "once_cell",
- "wasi",
+ "wasix",
  "wasm-bindgen",
 ]
 
@@ -471,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "pem-rfc7468 0.7.0",
@@ -514,7 +502,7 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.8",
+ "der 0.7.9",
  "digest",
  "elliptic-curve",
  "rfc6979",
@@ -524,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-compact"
-version = "2.0.6"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a667e6426df16c2ac478efa4a439d0e674cba769c5556e8cf221739251640c8c"
+checksum = "e9b3460f44bea8cd47f45a0c70892f1eff856d97cd55358b2f73f663789f6190"
 dependencies = [
  "ct-codecs",
  "getrandom",
@@ -606,9 +594,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "ff"
@@ -622,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "figment"
-version = "0.10.14"
+version = "0.10.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
+checksum = "7270677e7067213e04f323b55084586195f18308cd7546cfac9f873344ccceb6"
 dependencies = [
  "atomic 0.6.0",
  "pear",
@@ -742,7 +730,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -827,35 +815,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
 dependencies = [
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 1.0.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -893,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -956,35 +925,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.11",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -994,19 +941,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.0.0",
+ "http",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1024,30 +971,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.24",
- "http 0.2.11",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
@@ -1055,9 +978,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.2",
- "http 1.0.0",
- "http-body 1.0.0",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1069,15 +992,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1087,13 +1013,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
- "hyper 1.2.0",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1131,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1172,15 +1102,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1227,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -1289,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "matchers"
@@ -1314,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mime"
@@ -1341,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1366,17 +1296,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -1425,19 +1344,18 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1491,7 +1409,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1508,7 +1426,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1519,9 +1437,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -1602,10 +1520,10 @@ dependencies = [
  "bytes",
  "fs-err",
  "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper",
  "hyper-util",
  "indexmap",
  "mime",
@@ -1655,7 +1573,7 @@ version = "0.1.23"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1681,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "pear"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccca0f6c17acc81df8e242ed473ec144cbf5c98037e69aa6d144780aad103c8"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
 dependencies = [
  "inlinable_string",
  "pear_codegen",
@@ -1692,14 +1610,14 @@ dependencies = [
 
 [[package]]
 name = "pear_codegen"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e22670e8eb757cff11d6c199ca7b987f352f0346e0be4dd23869ec72cb53c77"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1746,10 +1664,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.13"
+name = "pin-project"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.57",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1775,7 +1713,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.8",
+ "der 0.7.9",
  "pkcs8 0.10.2",
  "spki 0.7.3",
 ]
@@ -1796,7 +1734,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.8",
+ "der 0.7.9",
  "spki 0.7.3",
 ]
 
@@ -1841,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1856,7 +1794,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
  "version_check",
  "yansi",
 ]
@@ -1911,14 +1849,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1932,13 +1870,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1949,26 +1887,28 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
  "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
- "http 0.2.11",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2040,7 +1980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "serde",
  "serde_derive",
 ]
@@ -2094,11 +2034,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2173,7 +2113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.8",
+ "der 0.7.9",
  "generic-array",
  "pkcs8 0.10.2",
  "subtle",
@@ -2192,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -2205,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2224,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "serde-aux"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86348501c129f3ad50c2f4635a01971f76974cd8a3f335988a0f1581c082765"
+checksum = "0d2e8bfba469d06512e11e3311d4d051a4a387a5b42d010404fecf3200321c95"
 dependencies = [
  "chrono",
  "serde",
@@ -2241,14 +2181,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "serde_html_form"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e1066e1cfa6692a722cf40386a2caec36da5ddc4a2c16df592f0f609677e8c"
+checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
 dependencies = [
  "form_urlencoded",
  "indexmap",
@@ -2259,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2270,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
@@ -2292,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2330,8 +2270,8 @@ version = "0.1.0"
 dependencies = [
  "app",
  "biscotti",
- "http 1.0.0",
- "hyper 1.2.0",
+ "http",
+ "hyper",
  "jsonwebtoken",
  "pavex",
  "pavex_matchit",
@@ -2424,18 +2364,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2470,7 +2410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.8",
+ "der 0.7.9",
 ]
 
 [[package]]
@@ -2486,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba03c279da73694ef99763320dea58b51095dfe87d001b1d4b5fe78ba8763cf"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2499,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
  "ahash",
  "atoi",
@@ -2509,7 +2449,6 @@ dependencies = [
  "bytes",
  "crc",
  "crossbeam-queue",
- "dotenvy",
  "either",
  "event-listener",
  "futures-channel",
@@ -2544,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89961c00dc4d7dffb7aee214964b065072bff69e36ddb9e2c107541f75e4f2a5"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2557,11 +2496,10 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bd4519486723648186a08785143599760f7cc81c52334a55d6a83ea1e20841"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
- "atomic-write-file",
  "dotenvy",
  "either",
  "heck",
@@ -2584,13 +2522,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "byteorder",
  "bytes",
  "crc",
@@ -2628,13 +2566,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -2655,7 +2593,6 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "sha1",
  "sha2",
  "smallvec",
  "sqlx-core",
@@ -2669,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
  "flume",
@@ -2722,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2760,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2772,22 +2709,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2848,9 +2785,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2873,7 +2810,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2888,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2910,6 +2847,28 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -2937,7 +2896,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3082,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -3117,9 +3076,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "atomic 0.5.3",
  "getrandom",
@@ -3160,10 +3119,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.91"
+name = "wasite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasix"
+version = "0.12.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
+dependencies = [
+ "wasi",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3171,24 +3145,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3198,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3208,28 +3182,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3243,9 +3217,13 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
 
 [[package]]
 name = "winapi"
@@ -3275,7 +3253,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3293,7 +3271,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3313,17 +3291,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.3",
- "windows_aarch64_msvc 0.52.3",
- "windows_i686_gnu 0.52.3",
- "windows_i686_msvc 0.52.3",
- "windows_x86_64_gnu 0.52.3",
- "windows_x86_64_gnullvm 0.52.3",
- "windows_x86_64_msvc 0.52.3",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -3334,9 +3312,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3346,9 +3324,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3358,9 +3336,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3370,9 +3348,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3382,9 +3360,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3394,9 +3372,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3406,9 +3384,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winreg"
@@ -3422,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "1.0.0-rc.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
@@ -3443,7 +3421,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.57",
 ]
 
 [[package]]

--- a/examples/realworld/Cargo.lock
+++ b/examples/realworld/Cargo.lock
@@ -18,6 +18,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +229,26 @@ name = "binstring"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e0d60973d9320722cb1206f412740e162a33b8547ea8d6be75d7cff237c7a85"
+
+[[package]]
+name = "biscotti"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac260b0392bba9873665d07367cb71f0298352e7fc2ed154ad4af57c47476a94"
+dependencies = [
+ "aes-gcm-siv",
+ "anyhow",
+ "base64 0.22.0",
+ "hkdf",
+ "hmac",
+ "percent-encoding",
+ "rand",
+ "serde",
+ "sha2",
+ "subtle",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "bitflags"
@@ -273,6 +335,16 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-targets 0.52.3",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -367,6 +439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -375,6 +448,15 @@ name = "ct-codecs"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "der"
@@ -1065,6 +1147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,9 +1595,10 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pavex"
-version = "0.1.21"
+version = "0.1.23"
 dependencies = [
  "anyhow",
+ "biscotti",
  "bytes",
  "fs-err",
  "futures-util",
@@ -1527,6 +1625,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
  "ubyte",
@@ -1535,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.21"
+version = "0.1.23"
 dependencies = [
  "pavex_reflection",
  "serde",
@@ -1543,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.21"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "pavex",
@@ -1552,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.21"
+version = "0.1.23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1567,14 +1666,14 @@ checksum = "77b9753b03381fd8856966146c4d626d9a8507901c1bcdfbc41df03deea551fc"
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.21"
+version = "0.1.23"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "pavex_tracing"
-version = "0.1.21"
+version = "0.1.23"
 dependencies = [
  "pavex",
  "tracing",
@@ -1638,7 +1737,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "persist_if_changed"
-version = "0.1.21"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -1706,6 +1805,18 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "powerfmt"
@@ -2957,6 +3068,16 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/examples/realworld/Cargo.lock
+++ b/examples/realworld/Cargo.lock
@@ -232,9 +232,9 @@ checksum = "7e0d60973d9320722cb1206f412740e162a33b8547ea8d6be75d7cff237c7a85"
 
 [[package]]
 name = "biscotti"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac260b0392bba9873665d07367cb71f0298352e7fc2ed154ad4af57c47476a94"
+checksum = "7d3eece11455d5bc07597a9e96995eb119eee01c9083080dfab7e158ba12437c"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -2329,6 +2329,7 @@ name = "server_sdk"
 version = "0.1.0"
 dependencies = [
  "app",
+ "biscotti",
  "http 1.0.0",
  "hyper 1.2.0",
  "jsonwebtoken",

--- a/examples/realworld/app/src/blueprint.rs
+++ b/examples/realworld/app/src/blueprint.rs
@@ -4,6 +4,7 @@ use crate::routes::profiles::profiles_bp;
 use crate::routes::users::users_bp;
 use crate::telemetry;
 use pavex::blueprint::{router::GET, Blueprint};
+use pavex::cookie::CookieKit;
 use pavex::f;
 use pavex::kit::ApiKit;
 
@@ -14,6 +15,7 @@ pub fn blueprint() -> Blueprint {
     ApiKit::new().register(&mut bp);
     telemetry::register(&mut bp);
     ApplicationConfig::register(&mut bp);
+    CookieKit::new().register(&mut bp);
 
     bp.nest_at("/articles", articles_bp());
     bp.nest_at("/profiles", profiles_bp());

--- a/examples/realworld/app/src/configuration.rs
+++ b/examples/realworld/app/src/configuration.rs
@@ -1,6 +1,6 @@
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use pavex::blueprint::Blueprint;
-use pavex::f;
+use pavex::{cookie, f};
 use secrecy::{ExposeSecret, Secret};
 use serde_aux::field_attributes::deserialize_number_from_string;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
@@ -11,6 +11,7 @@ use sqlx::postgres::{PgConnectOptions, PgSslMode};
 pub struct ApplicationConfig {
     pub database: DatabaseConfig,
     pub auth: AuthConfig,
+    pub cookie: cookie::config::Config,
 }
 
 impl ApplicationConfig {
@@ -22,9 +23,14 @@ impl ApplicationConfig {
         &self.auth
     }
 
+    pub fn cookie_config(&self) -> cookie::config::Config {
+        self.cookie.clone()
+    }
+
     pub fn register(bp: &mut Blueprint) {
         bp.singleton(f!(self::ApplicationConfig::database_config));
         bp.singleton(f!(self::ApplicationConfig::auth_config));
+        bp.singleton(f!(self::ApplicationConfig::cookie_config));
         bp.singleton(f!(self::DatabaseConfig::get_pool));
         bp.singleton(f!(self::AuthConfig::decoding_key));
     }

--- a/examples/realworld/app/src/configuration.rs
+++ b/examples/realworld/app/src/configuration.rs
@@ -1,6 +1,7 @@
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use pavex::blueprint::Blueprint;
-use pavex::{cookie, f};
+use pavex::cookie::ProcessorConfig;
+use pavex::f;
 use secrecy::{ExposeSecret, Secret};
 use serde_aux::field_attributes::deserialize_number_from_string;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
@@ -11,7 +12,7 @@ use sqlx::postgres::{PgConnectOptions, PgSslMode};
 pub struct ApplicationConfig {
     pub database: DatabaseConfig,
     pub auth: AuthConfig,
-    pub cookie: cookie::config::Config,
+    pub cookie: ProcessorConfig,
 }
 
 impl ApplicationConfig {
@@ -23,7 +24,7 @@ impl ApplicationConfig {
         &self.auth
     }
 
-    pub fn cookie_config(&self) -> cookie::config::Config {
+    pub fn cookie_config(&self) -> ProcessorConfig {
         self.cookie.clone()
     }
 

--- a/examples/realworld/server/Cargo.toml
+++ b/examples/realworld/server/Cargo.toml
@@ -16,7 +16,7 @@ app = { path = "../app" }
 
 # Configuration
 figment = { version = "0.10", features = ["env", "yaml"] }
-serde = { version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 
 # Telemetry
 tracing = "0.1"
@@ -25,7 +25,7 @@ tracing-bunyan-formatter = "0.3"
 pavex_tracing = "0.1"
 
 [dev-dependencies]
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 jwt-simple = "0.11"
 secrecy = "0.8"
 serde_json = "1"

--- a/examples/realworld/server_sdk/Cargo.toml
+++ b/examples/realworld/server_sdk/Cargo.toml
@@ -14,12 +14,13 @@ verifier_args = ["--check"]
 
 [dependencies]
 app = { version = "0.1.0", path = "../app", package = "app" }
+biscotti = { version = "0.2.2", package = "biscotti" }
 http = { version = "1.0.0", package = "http" }
 hyper = { version = "1.2.0", package = "hyper" }
 jsonwebtoken = { version = "8.3.0", package = "jsonwebtoken" }
-pavex = { version = "0.1.21", path = "../../../libs/pavex", package = "pavex" }
+pavex = { version = "0.1.23", path = "../../../libs/pavex", package = "pavex" }
 pavex_matchit = { version = "0.7.4", package = "pavex_matchit" }
-pavex_tracing = { version = "0.1.21", path = "../../../libs/pavex_tracing", package = "pavex_tracing" }
+pavex_tracing = { version = "0.1.23", path = "../../../libs/pavex_tracing", package = "pavex_tracing" }
 sqlx_core = { version = "0.7.3", package = "sqlx-core" }
 sqlx_postgres = { version = "0.7.3", package = "sqlx-postgres" }
 thiserror = { version = "1.0.57", package = "thiserror" }

--- a/examples/realworld/server_sdk/Cargo.toml
+++ b/examples/realworld/server_sdk/Cargo.toml
@@ -14,13 +14,13 @@ verifier_args = ["--check"]
 
 [dependencies]
 app = { version = "0.1.0", path = "../app", package = "app" }
-biscotti = { version = "0.2.2", package = "biscotti" }
-http = { version = "1.0.0", package = "http" }
+biscotti = { version = "0.3.2", package = "biscotti" }
+http = { version = "1.1.0", package = "http" }
 hyper = { version = "1.2.0", package = "hyper" }
 jsonwebtoken = { version = "8.3.0", package = "jsonwebtoken" }
 pavex = { version = "0.1.23", path = "../../../libs/pavex", package = "pavex" }
 pavex_matchit = { version = "0.7.4", package = "pavex_matchit" }
 pavex_tracing = { version = "0.1.23", path = "../../../libs/pavex_tracing", package = "pavex_tracing" }
-sqlx_core = { version = "0.7.3", package = "sqlx-core" }
-sqlx_postgres = { version = "0.7.3", package = "sqlx-postgres" }
-thiserror = { version = "1.0.57", package = "thiserror" }
+sqlx_core = { version = "0.7.4", package = "sqlx-core" }
+sqlx_postgres = { version = "0.7.4", package = "sqlx-postgres" }
+thiserror = { version = "1.0.58", package = "thiserror" }

--- a/examples/realworld/server_sdk/src/lib.rs
+++ b/examples/realworld/server_sdk/src/lib.rs
@@ -7,8 +7,9 @@ struct ServerState {
     application_state: ApplicationState,
 }
 pub struct ApplicationState {
-    s0: sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
-    s1: jsonwebtoken::EncodingKey,
+    s0: biscotti::Processor,
+    s1: sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+    s2: jsonwebtoken::EncodingKey,
 }
 #[derive(Debug, thiserror::Error)]
 pub enum ApplicationStateError {
@@ -42,11 +43,16 @@ pub async fn build_application_state(
             };
         }
     };
-    let v7 = crate::ApplicationState {
-        s0: v6,
-        s1: v3,
+    let v7 = app::configuration::ApplicationConfig::cookie_config(v0);
+    let v8 = <pavex::cookie::Processor as std::convert::From<
+        pavex::cookie::config::Config,
+    >>::from(v7);
+    let v9 = crate::ApplicationState {
+        s0: v8,
+        s1: v6,
+        s2: v3,
     };
-    core::result::Result::Ok(v7)
+    core::result::Result::Ok(v9)
 }
 pub fn run(
     server_builder: pavex::server::Server,
@@ -94,6 +100,7 @@ async fn route_request(
                 "*",
             );
             return route_2::entrypoint(
+                    &server_state.application_state.s0,
                     &request_head,
                     matched_route_template,
                     &allowed_methods,
@@ -113,7 +120,12 @@ async fn route_request(
             );
             match &request_head.method {
                 &pavex::http::Method::GET => {
-                    route_0::entrypoint(matched_route_template, &request_head).await
+                    route_0::entrypoint(
+                            &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
+                        )
+                        .await
                 }
                 _ => {
                     let allowed_methods: pavex::router::AllowedMethods = pavex::router::MethodAllowList::from_iter([
@@ -121,6 +133,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -135,11 +148,17 @@ async fn route_request(
             );
             match &request_head.method {
                 &pavex::http::Method::GET => {
-                    route_10::entrypoint(matched_route_template, &request_head).await
+                    route_10::entrypoint(
+                            &server_state.application_state.s0,
+                            matched_route_template,
+                            &request_head,
+                        )
+                        .await
                 }
                 &pavex::http::Method::POST => {
                     route_11::entrypoint(
                             request_body,
+                            &server_state.application_state.s0,
                             matched_route_template,
                             &request_head,
                         )
@@ -152,6 +171,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -168,16 +188,18 @@ async fn route_request(
                 &pavex::http::Method::GET => {
                     route_13::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
                 &pavex::http::Method::DELETE => {
                     route_14::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
@@ -185,6 +207,7 @@ async fn route_request(
                     route_15::entrypoint(
                             request_body,
                             url_params,
+                            &server_state.application_state.s0,
                             matched_route_template,
                             &request_head,
                         )
@@ -198,6 +221,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -214,8 +238,9 @@ async fn route_request(
                 &pavex::http::Method::GET => {
                     route_18::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
@@ -223,6 +248,7 @@ async fn route_request(
                     route_19::entrypoint(
                             request_body,
                             url_params,
+                            &server_state.application_state.s0,
                             matched_route_template,
                             &request_head,
                         )
@@ -235,6 +261,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -251,8 +278,9 @@ async fn route_request(
                 &pavex::http::Method::DELETE => {
                     route_20::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
@@ -262,6 +290,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -278,16 +307,18 @@ async fn route_request(
                 &pavex::http::Method::DELETE => {
                     route_16::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
                 &pavex::http::Method::POST => {
                     route_17::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
@@ -298,6 +329,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -312,7 +344,12 @@ async fn route_request(
             );
             match &request_head.method {
                 &pavex::http::Method::GET => {
-                    route_12::entrypoint(matched_route_template, &request_head).await
+                    route_12::entrypoint(
+                            &server_state.application_state.s0,
+                            matched_route_template,
+                            &request_head,
+                        )
+                        .await
                 }
                 _ => {
                     let allowed_methods: pavex::router::AllowedMethods = pavex::router::MethodAllowList::from_iter([
@@ -320,6 +357,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -336,8 +374,9 @@ async fn route_request(
                 &pavex::http::Method::GET => {
                     route_7::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
@@ -347,6 +386,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -363,16 +403,18 @@ async fn route_request(
                 &pavex::http::Method::POST => {
                     route_8::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
                 &pavex::http::Method::DELETE => {
                     route_9::entrypoint(
                             url_params,
-                            matched_route_template,
                             &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
                         )
                         .await
                 }
@@ -383,6 +425,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -397,7 +440,12 @@ async fn route_request(
             );
             match &request_head.method {
                 &pavex::http::Method::GET => {
-                    route_1::entrypoint(matched_route_template, &request_head).await
+                    route_1::entrypoint(
+                            &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
+                        )
+                        .await
                 }
                 _ => {
                     let allowed_methods: pavex::router::AllowedMethods = pavex::router::MethodAllowList::from_iter([
@@ -405,6 +453,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -419,11 +468,17 @@ async fn route_request(
             );
             match &request_head.method {
                 &pavex::http::Method::GET => {
-                    route_5::entrypoint(matched_route_template, &request_head).await
+                    route_5::entrypoint(
+                            &request_head,
+                            matched_route_template,
+                            &server_state.application_state.s0,
+                        )
+                        .await
                 }
                 &pavex::http::Method::PUT => {
                     route_6::entrypoint(
                             request_body,
+                            &server_state.application_state.s0,
                             matched_route_template,
                             &request_head,
                         )
@@ -436,6 +491,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -451,11 +507,12 @@ async fn route_request(
             match &request_head.method {
                 &pavex::http::Method::POST => {
                     route_3::entrypoint(
-                            &server_state.application_state.s1,
-                            &server_state.application_state.s0,
-                            request_body,
-                            matched_route_template,
                             &request_head,
+                            &server_state.application_state.s1,
+                            request_body,
+                            &server_state.application_state.s0,
+                            matched_route_template,
+                            &server_state.application_state.s2,
                         )
                         .await
                 }
@@ -465,6 +522,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -480,11 +538,12 @@ async fn route_request(
             match &request_head.method {
                 &pavex::http::Method::POST => {
                     route_4::entrypoint(
-                            &server_state.application_state.s1,
-                            &server_state.application_state.s0,
-                            request_body,
-                            matched_route_template,
                             &request_head,
+                            &server_state.application_state.s1,
+                            request_body,
+                            &server_state.application_state.s0,
+                            matched_route_template,
+                            &server_state.application_state.s2,
                         )
                         .await
                 }
@@ -494,6 +553,7 @@ async fn route_request(
                         ])
                         .into();
                     route_2::entrypoint(
+                            &server_state.application_state.s0,
                             &request_head,
                             matched_route_template,
                             &allowed_methods,
@@ -506,175 +566,127 @@ async fn route_request(
     }
 }
 pub mod route_0 {
-    pub async fn entrypoint<'a>(
-        s_0: pavex::request::path::MatchedPathPattern,
-        s_1: &'a pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1).await;
-        response
-    }
-    async fn stage_1<'a>(s_0: &'a pavex_tracing::RootSpan) -> pavex::response::Response {
-        let response = handler().await;
-        let response = post_processing_0(response, s_0).await;
-        response
-    }
-    pub async fn wrapping_0(
-        v0: pavex::request::path::MatchedPathPattern,
-        v1: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v2 = pavex::telemetry::ServerRequestId::generate();
-        let v3 = app::telemetry::root_span(v1, v0, v2);
-        let v4 = crate::route_0::Next0 {
-            s_0: &v3,
-            next: stage_1,
-        };
-        let v5 = pavex::middleware::Next::new(v4);
-        let v6 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v3);
-        let v7 = pavex_tracing::logger(v6, v5).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v7)
-    }
-    pub async fn handler() -> pavex::response::Response {
-        let v0 = app::routes::status::ping();
-        <http::StatusCode as pavex::response::IntoResponse>::into_response(v0)
-    }
-    pub async fn post_processing_0(
-        v0: pavex::response::Response,
-        v1: &pavex_tracing::RootSpan,
-    ) -> pavex::response::Response {
-        let v2 = app::telemetry::response_logger(v0, v1).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
-    }
-    pub struct Next0<'a, T>
-    where
-        T: std::future::Future<Output = pavex::response::Response>,
-    {
-        s_0: &'a pavex_tracing::RootSpan,
-        next: fn(&'a pavex_tracing::RootSpan) -> T,
-    }
-    impl<'a, T> std::future::IntoFuture for Next0<'a, T>
-    where
-        T: std::future::Future<Output = pavex::response::Response>,
-    {
-        type Output = pavex::response::Response;
-        type IntoFuture = T;
-        fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0)
-        }
-    }
-}
-pub mod route_1 {
-    pub async fn entrypoint<'a>(
-        s_0: pavex::request::path::MatchedPathPattern,
-        s_1: &'a pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1).await;
-        response
-    }
-    async fn stage_1<'a>(s_0: &'a pavex_tracing::RootSpan) -> pavex::response::Response {
-        let response = handler().await;
-        let response = post_processing_0(response, s_0).await;
-        response
-    }
-    pub async fn wrapping_0(
-        v0: pavex::request::path::MatchedPathPattern,
-        v1: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v2 = pavex::telemetry::ServerRequestId::generate();
-        let v3 = app::telemetry::root_span(v1, v0, v2);
-        let v4 = crate::route_1::Next0 {
-            s_0: &v3,
-            next: stage_1,
-        };
-        let v5 = pavex::middleware::Next::new(v4);
-        let v6 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v3);
-        let v7 = pavex_tracing::logger(v6, v5).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v7)
-    }
-    pub async fn handler() -> pavex::response::Response {
-        let v0 = app::routes::tags::get_tags();
-        <http::StatusCode as pavex::response::IntoResponse>::into_response(v0)
-    }
-    pub async fn post_processing_0(
-        v0: pavex::response::Response,
-        v1: &pavex_tracing::RootSpan,
-    ) -> pavex::response::Response {
-        let v2 = app::telemetry::response_logger(v0, v1).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
-    }
-    pub struct Next0<'a, T>
-    where
-        T: std::future::Future<Output = pavex::response::Response>,
-    {
-        s_0: &'a pavex_tracing::RootSpan,
-        next: fn(&'a pavex_tracing::RootSpan) -> T,
-    }
-    impl<'a, T> std::future::IntoFuture for Next0<'a, T>
-    where
-        T: std::future::Future<Output = pavex::response::Response>,
-    {
-        type Output = pavex::response::Response;
-        type IntoFuture = T;
-        fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0)
-        }
-    }
-}
-pub mod route_2 {
     pub async fn entrypoint<'a, 'b>(
         s_0: &'a pavex::request::RequestHead,
         s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'b pavex::router::AllowedMethods,
+        s_2: &'b biscotti::Processor,
     ) -> pavex::response::Response {
         let response = wrapping_0(s_0, s_1, s_2).await;
         response
     }
     async fn stage_1<'a, 'b>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: &'b pavex::router::AllowedMethods,
+        s_0: &'a biscotti::Processor,
+        s_1: pavex::request::path::MatchedPathPattern,
+        s_2: &'b pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_2, s_1, s_0).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b>(
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: &'b biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler().await;
+        let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_1).await;
+        response
+    }
+    async fn wrapping_0(
         v0: &pavex::request::RequestHead,
         v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::router::AllowedMethods,
+        v2: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v3 = crate::route_0::Next0 {
+            s_0: v2,
+            s_1: v1,
+            s_2: v0,
+            next: stage_1,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        let v5 = pavex::middleware::wrap_noop(v4).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v5)
+    }
+    async fn wrapping_1(
+        v0: &pavex::request::RequestHead,
+        v1: pavex::request::path::MatchedPathPattern,
+        v2: &biscotti::Processor,
     ) -> pavex::response::Response {
         let v3 = pavex::telemetry::ServerRequestId::generate();
         let v4 = app::telemetry::root_span(v0, v1, v3);
-        let v5 = crate::route_2::Next0 {
+        let v5 = crate::route_0::Next1 {
             s_0: &v4,
             s_1: v2,
-            next: stage_1,
+            next: stage_2,
         };
         let v6 = pavex::middleware::Next::new(v5);
         let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
         let v8 = pavex_tracing::logger(v7, v6).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
     }
-    pub async fn handler(
-        v0: &pavex::router::AllowedMethods,
-    ) -> pavex::response::Response {
-        let v1 = pavex::router::default_fallback(v0).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v1)
+    async fn handler() -> pavex::response::Response {
+        let v0 = app::routes::status::ping();
+        <http::StatusCode as pavex::response::IntoResponse>::into_response(v0)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a biscotti::Processor,
+        s_1: pavex::request::path::MatchedPathPattern,
+        s_2: &'b pavex::request::RequestHead,
+        next: fn(
+            &'a biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'b pavex::request::RequestHead,
+        ) -> T,
+    }
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
+        }
+    }
+    struct Next1<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         s_0: &'a pavex_tracing::RootSpan,
-        s_1: &'b pavex::router::AllowedMethods,
-        next: fn(&'a pavex_tracing::RootSpan, &'b pavex::router::AllowedMethods) -> T,
+        s_1: &'b biscotti::Processor,
+        next: fn(&'a pavex_tracing::RootSpan, &'b biscotti::Processor) -> T,
     }
-    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+    impl<'a, 'b, T> std::future::IntoFuture for Next1<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
@@ -685,51 +697,366 @@ pub mod route_2 {
         }
     }
 }
-pub mod route_3 {
+pub mod route_1 {
+    pub async fn entrypoint<'a, 'b>(
+        s_0: &'a pavex::request::RequestHead,
+        s_1: pavex::request::path::MatchedPathPattern,
+        s_2: &'b biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = wrapping_0(s_0, s_1, s_2).await;
+        response
+    }
+    async fn stage_1<'a, 'b>(
+        s_0: &'a biscotti::Processor,
+        s_1: pavex::request::path::MatchedPathPattern,
+        s_2: &'b pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let response = wrapping_1(s_2, s_1, s_0).await;
+        response
+    }
+    async fn stage_2<'a, 'b>(
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: &'b biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler().await;
+        let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_1).await;
+        response
+    }
+    async fn wrapping_0(
+        v0: &pavex::request::RequestHead,
+        v1: pavex::request::path::MatchedPathPattern,
+        v2: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v3 = crate::route_1::Next0 {
+            s_0: v2,
+            s_1: v1,
+            s_2: v0,
+            next: stage_1,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        let v5 = pavex::middleware::wrap_noop(v4).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v5)
+    }
+    async fn wrapping_1(
+        v0: &pavex::request::RequestHead,
+        v1: pavex::request::path::MatchedPathPattern,
+        v2: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v3 = pavex::telemetry::ServerRequestId::generate();
+        let v4 = app::telemetry::root_span(v0, v1, v3);
+        let v5 = crate::route_1::Next1 {
+            s_0: &v4,
+            s_1: v2,
+            next: stage_2,
+        };
+        let v6 = pavex::middleware::Next::new(v5);
+        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
+        let v8 = pavex_tracing::logger(v7, v6).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+    }
+    async fn handler() -> pavex::response::Response {
+        let v0 = app::routes::tags::get_tags();
+        <http::StatusCode as pavex::response::IntoResponse>::into_response(v0)
+    }
+    async fn post_processing_0(
+        v0: pavex::response::Response,
+        v1: &pavex_tracing::RootSpan,
+    ) -> pavex::response::Response {
+        let v2 = app::telemetry::response_logger(v0, v1).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
+    }
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a biscotti::Processor,
+        s_1: pavex::request::path::MatchedPathPattern,
+        s_2: &'b pavex::request::RequestHead,
+        next: fn(
+            &'a biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'b pavex::request::RequestHead,
+        ) -> T,
+    }
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
+        }
+    }
+    struct Next1<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: &'b biscotti::Processor,
+        next: fn(&'a pavex_tracing::RootSpan, &'b biscotti::Processor) -> T,
+    }
+    impl<'a, 'b, T> std::future::IntoFuture for Next1<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1)
+        }
+    }
+}
+pub mod route_2 {
     pub async fn entrypoint<'a, 'b, 'c>(
-        s_0: &'a jsonwebtoken::EncodingKey,
+        s_0: &'a biscotti::Processor,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'c pavex::router::AllowedMethods,
+    ) -> pavex::response::Response {
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
+        response
+    }
+    async fn stage_1<'a, 'b, 'c>(
+        s_0: &'a pavex::router::AllowedMethods,
+        s_1: &'b biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'c pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let response = wrapping_1(s_1, s_3, s_2, s_0).await;
+        response
+    }
+    async fn stage_2<'a, 'b, 'c>(
+        s_0: &'a pavex::router::AllowedMethods,
+        s_1: &'b pavex_tracing::RootSpan,
+        s_2: &'c biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
+        v0: &biscotti::Processor,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &pavex::router::AllowedMethods,
+    ) -> pavex::response::Response {
+        let v4 = crate::route_2::Next0 {
+            s_0: v3,
+            s_1: v0,
+            s_2: v2,
+            s_3: v1,
+            next: stage_1,
+        };
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
+    }
+    async fn wrapping_1(
+        v0: &biscotti::Processor,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &pavex::router::AllowedMethods,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_2::Next1 {
+            s_0: v3,
+            s_1: &v5,
+            s_2: v0,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(v0: &pavex::router::AllowedMethods) -> pavex::response::Response {
+        let v1 = pavex::router::default_fallback(v0).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v1)
+    }
+    async fn post_processing_0(
+        v0: pavex::response::Response,
+        v1: &pavex_tracing::RootSpan,
+    ) -> pavex::response::Response {
+        let v2 = app::telemetry::response_logger(v0, v1).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
+    }
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex::router::AllowedMethods,
+        s_1: &'b biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'c pavex::request::RequestHead,
+        next: fn(
+            &'a pavex::router::AllowedMethods,
+            &'b biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'c pavex::request::RequestHead,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex::router::AllowedMethods,
+        s_1: &'b pavex_tracing::RootSpan,
+        s_2: &'c biscotti::Processor,
+        next: fn(
+            &'a pavex::router::AllowedMethods,
+            &'b pavex_tracing::RootSpan,
+            &'c biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
+        }
+    }
+}
+pub mod route_3 {
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
+        s_0: &'a pavex::request::RequestHead,
         s_1: &'b sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         s_2: pavex::request::body::RawIncomingBody,
-        s_3: pavex::request::path::MatchedPathPattern,
-        s_4: &'c pavex::request::RequestHead,
+        s_3: &'c biscotti::Processor,
+        s_4: pavex::request::path::MatchedPathPattern,
+        s_5: &'d jsonwebtoken::EncodingKey,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2, s_3, s_4).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3, s_4, s_5).await;
         response
     }
     async fn stage_1<'a, 'b, 'c, 'd>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: &'b jsonwebtoken::EncodingKey,
-        s_2: &'c pavex::request::RequestHead,
-        s_3: pavex::request::body::RawIncomingBody,
-        s_4: &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_0: &'a jsonwebtoken::EncodingKey,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: pavex::request::body::RawIncomingBody,
+        s_3: &'c sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_4: &'d biscotti::Processor,
+        s_5: pavex::request::path::MatchedPathPattern,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_2, s_0, s_3, s_4).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_4, s_5, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd, 'e>(
+        s_0: &'a jsonwebtoken::EncodingKey,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: &'c pavex_tracing::RootSpan,
+        s_3: pavex::request::body::RawIncomingBody,
+        s_4: &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_5: &'e biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1, s_2, s_3, s_4).await;
+        let response = post_processing_0(response, s_2).await;
+        let response = post_processing_1(response, s_5).await;
+        response
+    }
+    async fn wrapping_0(
+        v0: &pavex::request::RequestHead,
+        v1: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        v2: pavex::request::body::RawIncomingBody,
+        v3: &biscotti::Processor,
+        v4: pavex::request::path::MatchedPathPattern,
+        v5: &jsonwebtoken::EncodingKey,
+    ) -> pavex::response::Response {
+        let v6 = crate::route_3::Next0 {
+            s_0: v5,
+            s_1: v0,
+            s_2: v2,
+            s_3: v1,
+            s_4: v3,
+            s_5: v4,
+            next: stage_1,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = pavex::middleware::wrap_noop(v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+    }
+    async fn wrapping_1(
         v0: &'_ jsonwebtoken::EncodingKey,
         v1: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         v2: pavex::request::body::RawIncomingBody,
-        v3: pavex::request::path::MatchedPathPattern,
-        v4: &pavex::request::RequestHead,
+        v3: &biscotti::Processor,
+        v4: pavex::request::path::MatchedPathPattern,
+        v5: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v5 = pavex::telemetry::ServerRequestId::generate();
-        let v6 = app::telemetry::root_span(v4, v3, v5);
-        let v7 = crate::route_3::Next0 {
-            s_0: &v6,
-            s_1: v0,
-            s_2: v4,
+        let v6 = pavex::telemetry::ServerRequestId::generate();
+        let v7 = app::telemetry::root_span(v5, v4, v6);
+        let v8 = crate::route_3::Next1 {
+            s_0: v0,
+            s_1: v5,
+            s_2: &v7,
             s_3: v2,
             s_4: v1,
-            next: stage_1,
+            s_5: v3,
+            next: stage_2,
         };
-        let v8 = pavex::middleware::Next::new(v7);
-        let v9 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v6);
-        let v10 = pavex_tracing::logger(v9, v8).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v10)
+        let v9 = pavex::middleware::Next::new(v8);
+        let v10 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v7);
+        let v11 = pavex_tracing::logger(v10, v9).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v11)
     }
-    pub async fn handler(
+    async fn handler(
         v0: &jsonwebtoken::EncodingKey,
         v1: &pavex::request::RequestHead,
         v2: &pavex_tracing::RootSpan,
@@ -785,28 +1112,51 @@ pub mod route_3 {
         };
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v11)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, 'd, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: &'b jsonwebtoken::EncodingKey,
-        s_2: &'c pavex::request::RequestHead,
-        s_3: pavex::request::body::RawIncomingBody,
-        s_4: &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_0: &'a jsonwebtoken::EncodingKey,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: pavex::request::body::RawIncomingBody,
+        s_3: &'c sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_4: &'d biscotti::Processor,
+        s_5: pavex::request::path::MatchedPathPattern,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            &'b jsonwebtoken::EncodingKey,
-            &'c pavex::request::RequestHead,
+            &'a jsonwebtoken::EncodingKey,
+            &'b pavex::request::RequestHead,
             pavex::request::body::RawIncomingBody,
-            &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+            &'c sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+            &'d biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
         ) -> T,
     }
     impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
@@ -816,55 +1166,121 @@ pub mod route_3 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4, self.s_5)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, 'e, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a jsonwebtoken::EncodingKey,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: &'c pavex_tracing::RootSpan,
+        s_3: pavex::request::body::RawIncomingBody,
+        s_4: &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_5: &'e biscotti::Processor,
+        next: fn(
+            &'a jsonwebtoken::EncodingKey,
+            &'b pavex::request::RequestHead,
+            &'c pavex_tracing::RootSpan,
+            pavex::request::body::RawIncomingBody,
+            &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+            &'e biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, 'e, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, 'e, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4, self.s_5)
         }
     }
 }
 pub mod route_4 {
-    pub async fn entrypoint<'a, 'b, 'c>(
-        s_0: &'a jsonwebtoken::EncodingKey,
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
+        s_0: &'a pavex::request::RequestHead,
         s_1: &'b sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         s_2: pavex::request::body::RawIncomingBody,
-        s_3: pavex::request::path::MatchedPathPattern,
-        s_4: &'c pavex::request::RequestHead,
+        s_3: &'c biscotti::Processor,
+        s_4: pavex::request::path::MatchedPathPattern,
+        s_5: &'d jsonwebtoken::EncodingKey,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2, s_3, s_4).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3, s_4, s_5).await;
         response
     }
     async fn stage_1<'a, 'b, 'c, 'd>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: &'b jsonwebtoken::EncodingKey,
-        s_2: &'c pavex::request::RequestHead,
-        s_3: pavex::request::body::RawIncomingBody,
-        s_4: &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_0: &'a jsonwebtoken::EncodingKey,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: pavex::request::body::RawIncomingBody,
+        s_3: &'c sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_4: &'d biscotti::Processor,
+        s_5: pavex::request::path::MatchedPathPattern,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_2, s_0, s_3, s_4).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_4, s_5, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd, 'e>(
+        s_0: &'a jsonwebtoken::EncodingKey,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: &'c pavex_tracing::RootSpan,
+        s_3: pavex::request::body::RawIncomingBody,
+        s_4: &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_5: &'e biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1, s_2, s_3, s_4).await;
+        let response = post_processing_0(response, s_2).await;
+        let response = post_processing_1(response, s_5).await;
+        response
+    }
+    async fn wrapping_0(
+        v0: &pavex::request::RequestHead,
+        v1: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        v2: pavex::request::body::RawIncomingBody,
+        v3: &biscotti::Processor,
+        v4: pavex::request::path::MatchedPathPattern,
+        v5: &jsonwebtoken::EncodingKey,
+    ) -> pavex::response::Response {
+        let v6 = crate::route_4::Next0 {
+            s_0: v5,
+            s_1: v0,
+            s_2: v2,
+            s_3: v1,
+            s_4: v3,
+            s_5: v4,
+            next: stage_1,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = pavex::middleware::wrap_noop(v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+    }
+    async fn wrapping_1(
         v0: &'_ jsonwebtoken::EncodingKey,
         v1: &sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
         v2: pavex::request::body::RawIncomingBody,
-        v3: pavex::request::path::MatchedPathPattern,
-        v4: &pavex::request::RequestHead,
+        v3: &biscotti::Processor,
+        v4: pavex::request::path::MatchedPathPattern,
+        v5: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v5 = pavex::telemetry::ServerRequestId::generate();
-        let v6 = app::telemetry::root_span(v4, v3, v5);
-        let v7 = crate::route_4::Next0 {
-            s_0: &v6,
-            s_1: v0,
-            s_2: v4,
+        let v6 = pavex::telemetry::ServerRequestId::generate();
+        let v7 = app::telemetry::root_span(v5, v4, v6);
+        let v8 = crate::route_4::Next1 {
+            s_0: v0,
+            s_1: v5,
+            s_2: &v7,
             s_3: v2,
             s_4: v1,
-            next: stage_1,
+            s_5: v3,
+            next: stage_2,
         };
-        let v8 = pavex::middleware::Next::new(v7);
-        let v9 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v6);
-        let v10 = pavex_tracing::logger(v9, v8).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v10)
+        let v9 = pavex::middleware::Next::new(v8);
+        let v10 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v7);
+        let v11 = pavex_tracing::logger(v10, v9).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v11)
     }
-    pub async fn handler(
+    async fn handler(
         v0: &jsonwebtoken::EncodingKey,
         v1: &pavex::request::RequestHead,
         v2: &pavex_tracing::RootSpan,
@@ -920,28 +1336,51 @@ pub mod route_4 {
         };
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v11)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, 'd, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: &'b jsonwebtoken::EncodingKey,
-        s_2: &'c pavex::request::RequestHead,
-        s_3: pavex::request::body::RawIncomingBody,
-        s_4: &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_0: &'a jsonwebtoken::EncodingKey,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: pavex::request::body::RawIncomingBody,
+        s_3: &'c sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_4: &'d biscotti::Processor,
+        s_5: pavex::request::path::MatchedPathPattern,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            &'b jsonwebtoken::EncodingKey,
-            &'c pavex::request::RequestHead,
+            &'a jsonwebtoken::EncodingKey,
+            &'b pavex::request::RequestHead,
             pavex::request::body::RawIncomingBody,
-            &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+            &'c sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+            &'d biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
         ) -> T,
     }
     impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
@@ -951,104 +1390,239 @@ pub mod route_4 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4, self.s_5)
         }
     }
-}
-pub mod route_5 {
-    pub async fn entrypoint<'a>(
-        s_0: pavex::request::path::MatchedPathPattern,
-        s_1: &'a pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1).await;
-        response
-    }
-    async fn stage_1<'a>(s_0: &'a pavex_tracing::RootSpan) -> pavex::response::Response {
-        let response = handler().await;
-        let response = post_processing_0(response, s_0).await;
-        response
-    }
-    pub async fn wrapping_0(
-        v0: pavex::request::path::MatchedPathPattern,
-        v1: &pavex::request::RequestHead,
-    ) -> pavex::response::Response {
-        let v2 = pavex::telemetry::ServerRequestId::generate();
-        let v3 = app::telemetry::root_span(v1, v0, v2);
-        let v4 = crate::route_5::Next0 {
-            s_0: &v3,
-            next: stage_1,
-        };
-        let v5 = pavex::middleware::Next::new(v4);
-        let v6 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v3);
-        let v7 = pavex_tracing::logger(v6, v5).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v7)
-    }
-    pub async fn handler() -> pavex::response::Response {
-        let v0 = app::routes::users::get_user();
-        <http::StatusCode as pavex::response::IntoResponse>::into_response(v0)
-    }
-    pub async fn post_processing_0(
-        v0: pavex::response::Response,
-        v1: &pavex_tracing::RootSpan,
-    ) -> pavex::response::Response {
-        let v2 = app::telemetry::response_logger(v0, v1).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
-    }
-    pub struct Next0<'a, T>
+    struct Next1<'a, 'b, 'c, 'd, 'e, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        next: fn(&'a pavex_tracing::RootSpan) -> T,
+        s_0: &'a jsonwebtoken::EncodingKey,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: &'c pavex_tracing::RootSpan,
+        s_3: pavex::request::body::RawIncomingBody,
+        s_4: &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+        s_5: &'e biscotti::Processor,
+        next: fn(
+            &'a jsonwebtoken::EncodingKey,
+            &'b pavex::request::RequestHead,
+            &'c pavex_tracing::RootSpan,
+            pavex::request::body::RawIncomingBody,
+            &'d sqlx_core::driver_prelude::pool::Pool<sqlx_postgres::Postgres>,
+            &'e biscotti::Processor,
+        ) -> T,
     }
-    impl<'a, T> std::future::IntoFuture for Next0<'a, T>
+    impl<'a, 'b, 'c, 'd, 'e, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, 'e, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4, self.s_5)
         }
     }
 }
-pub mod route_6 {
-    pub async fn entrypoint<'a>(
-        s_0: pavex::request::body::RawIncomingBody,
+pub mod route_5 {
+    pub async fn entrypoint<'a, 'b>(
+        s_0: &'a pavex::request::RequestHead,
         s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'a pavex::request::RequestHead,
+        s_2: &'b biscotti::Processor,
     ) -> pavex::response::Response {
         let response = wrapping_0(s_0, s_1, s_2).await;
         response
     }
     async fn stage_1<'a, 'b>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::body::RawIncomingBody,
+        s_0: &'a biscotti::Processor,
+        s_1: pavex::request::path::MatchedPathPattern,
         s_2: &'b pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_0, s_1, s_2).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_2, s_1, s_0).await;
         response
     }
-    pub async fn wrapping_0(
-        v0: pavex::request::body::RawIncomingBody,
+    async fn stage_2<'a, 'b>(
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: &'b biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler().await;
+        let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_1).await;
+        response
+    }
+    async fn wrapping_0(
+        v0: &pavex::request::RequestHead,
         v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v2: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v3 = crate::route_5::Next0 {
+            s_0: v2,
+            s_1: v1,
+            s_2: v0,
+            next: stage_1,
+        };
+        let v4 = pavex::middleware::Next::new(v3);
+        let v5 = pavex::middleware::wrap_noop(v4).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v5)
+    }
+    async fn wrapping_1(
+        v0: &pavex::request::RequestHead,
+        v1: pavex::request::path::MatchedPathPattern,
+        v2: &biscotti::Processor,
     ) -> pavex::response::Response {
         let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_6::Next0 {
+        let v4 = app::telemetry::root_span(v0, v1, v3);
+        let v5 = crate::route_5::Next1 {
             s_0: &v4,
-            s_1: v0,
-            s_2: v2,
-            next: stage_1,
+            s_1: v2,
+            next: stage_2,
         };
         let v6 = pavex::middleware::Next::new(v5);
         let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
         let v8 = pavex_tracing::logger(v7, v6).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
     }
-    pub async fn handler(
+    async fn handler() -> pavex::response::Response {
+        let v0 = app::routes::users::get_user();
+        <http::StatusCode as pavex::response::IntoResponse>::into_response(v0)
+    }
+    async fn post_processing_0(
+        v0: pavex::response::Response,
+        v1: &pavex_tracing::RootSpan,
+    ) -> pavex::response::Response {
+        let v2 = app::telemetry::response_logger(v0, v1).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
+    }
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a biscotti::Processor,
+        s_1: pavex::request::path::MatchedPathPattern,
+        s_2: &'b pavex::request::RequestHead,
+        next: fn(
+            &'a biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'b pavex::request::RequestHead,
+        ) -> T,
+    }
+    impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
+        }
+    }
+    struct Next1<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: &'b biscotti::Processor,
+        next: fn(&'a pavex_tracing::RootSpan, &'b biscotti::Processor) -> T,
+    }
+    impl<'a, 'b, T> std::future::IntoFuture for Next1<'a, 'b, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1)
+        }
+    }
+}
+pub mod route_6 {
+    pub async fn entrypoint<'a, 'b>(
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: &'a biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'b pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
+        response
+    }
+    async fn stage_1<'a, 'b>(
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: &'a pavex::request::RequestHead,
+        s_2: &'b biscotti::Processor,
+        s_3: pavex::request::path::MatchedPathPattern,
+    ) -> pavex::response::Response {
+        let response = wrapping_1(s_0, s_2, s_3, s_1).await;
+        response
+    }
+    async fn stage_2<'a, 'b, 'c>(
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: pavex::request::body::RawIncomingBody,
+        s_2: &'b pavex::request::RequestHead,
+        s_3: &'c biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1, s_2).await;
+        let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_3).await;
+        response
+    }
+    async fn wrapping_0(
+        v0: pavex::request::body::RawIncomingBody,
+        v1: &biscotti::Processor,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v4 = crate::route_6::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v1,
+            s_3: v2,
+            next: stage_1,
+        };
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
+    }
+    async fn wrapping_1(
+        v0: pavex::request::body::RawIncomingBody,
+        v1: &biscotti::Processor,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v3, v2, v4);
+        let v6 = crate::route_6::Next1 {
+            s_0: &v5,
+            s_1: v0,
+            s_2: v3,
+            s_3: v1,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: &pavex_tracing::RootSpan,
         v1: pavex::request::body::RawIncomingBody,
         v2: &pavex::request::RequestHead,
@@ -1089,24 +1663,47 @@ pub mod route_6 {
         let v8 = app::routes::users::update_user(v7);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v8)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::body::RawIncomingBody,
-        s_2: &'b pavex::request::RequestHead,
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: &'a pavex::request::RequestHead,
+        s_2: &'b biscotti::Processor,
+        s_3: pavex::request::path::MatchedPathPattern,
         next: fn(
-            &'a pavex_tracing::RootSpan,
             pavex::request::body::RawIncomingBody,
-            &'b pavex::request::RequestHead,
+            &'a pavex::request::RequestHead,
+            &'b biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
         ) -> T,
     }
     impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
@@ -1116,45 +1713,101 @@ pub mod route_6 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1, self.s_2)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: pavex::request::body::RawIncomingBody,
+        s_2: &'b pavex::request::RequestHead,
+        s_3: &'c biscotti::Processor,
+        next: fn(
+            &'a pavex_tracing::RootSpan,
+            pavex::request::body::RawIncomingBody,
+            &'b pavex::request::RequestHead,
+            &'c biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
         }
     }
 }
 pub mod route_7 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_7::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_7::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_7::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -1177,70 +1830,149 @@ pub mod route_7 {
         let v4 = app::routes::profiles::get_profile(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_8 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_8::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_8::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_8::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -1263,70 +1995,149 @@ pub mod route_8 {
         let v4 = app::routes::profiles::follow_profile(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_9 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_9::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_9::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_9::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -1349,68 +2160,144 @@ pub mod route_9 {
         let v4 = app::routes::profiles::unfollow_profile(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_10 {
-    pub async fn entrypoint<'a>(
-        s_0: pavex::request::path::MatchedPathPattern,
-        s_1: &'a pavex::request::RequestHead,
+    pub async fn entrypoint<'a, 'b>(
+        s_0: &'a biscotti::Processor,
+        s_1: pavex::request::path::MatchedPathPattern,
+        s_2: &'b pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1).await;
+        let response = wrapping_0(s_0, s_1, s_2).await;
         response
     }
     async fn stage_1<'a, 'b>(
+        s_0: &'a pavex::request::RequestHead,
+        s_1: &'b biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+    ) -> pavex::response::Response {
+        let response = wrapping_1(s_1, s_2, s_0).await;
+        response
+    }
+    async fn stage_2<'a, 'b, 'c>(
         s_0: &'a pavex_tracing::RootSpan,
         s_1: &'b pavex::request::RequestHead,
+        s_2: &'c biscotti::Processor,
     ) -> pavex::response::Response {
         let response = handler(s_0, s_1).await;
         let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_2).await;
         response
     }
-    pub async fn wrapping_0(
-        v0: pavex::request::path::MatchedPathPattern,
-        v1: &pavex::request::RequestHead,
+    async fn wrapping_0(
+        v0: &biscotti::Processor,
+        v1: pavex::request::path::MatchedPathPattern,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = pavex::telemetry::ServerRequestId::generate();
-        let v3 = app::telemetry::root_span(v1, v0, v2);
-        let v4 = crate::route_10::Next0 {
-            s_0: &v3,
-            s_1: v1,
+        let v3 = crate::route_10::Next0 {
+            s_0: v2,
+            s_1: v0,
+            s_2: v1,
             next: stage_1,
         };
-        let v5 = pavex::middleware::Next::new(v4);
-        let v6 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v3);
-        let v7 = pavex_tracing::logger(v6, v5).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v7)
+        let v4 = pavex::middleware::Next::new(v3);
+        let v5 = pavex::middleware::wrap_noop(v4).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v5)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: &biscotti::Processor,
+        v1: pavex::request::path::MatchedPathPattern,
+        v2: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v3 = pavex::telemetry::ServerRequestId::generate();
+        let v4 = app::telemetry::root_span(v2, v1, v3);
+        let v5 = crate::route_10::Next1 {
+            s_0: &v4,
+            s_1: v2,
+            s_2: v0,
+            next: stage_2,
+        };
+        let v6 = pavex::middleware::Next::new(v5);
+        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
+        let v8 = pavex_tracing::logger(v7, v6).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+    }
+    async fn handler(
         v0: &pavex_tracing::RootSpan,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
@@ -1433,20 +2320,46 @@ pub mod route_10 {
         let v4 = app::routes::articles::list_articles(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: &'b pavex::request::RequestHead,
-        next: fn(&'a pavex_tracing::RootSpan, &'b pavex::request::RequestHead) -> T,
+        s_0: &'a pavex::request::RequestHead,
+        s_1: &'b biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        next: fn(
+            &'a pavex::request::RequestHead,
+            &'b biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+        ) -> T,
     }
     impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
@@ -1455,47 +2368,101 @@ pub mod route_10 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2)
+        }
+    }
+    struct Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: &'c biscotti::Processor,
+        next: fn(
+            &'a pavex_tracing::RootSpan,
+            &'b pavex::request::RequestHead,
+            &'c biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_11 {
-    pub async fn entrypoint<'a>(
+    pub async fn entrypoint<'a, 'b>(
         s_0: pavex::request::body::RawIncomingBody,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'a pavex::request::RequestHead,
+        s_1: &'a biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'b pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
     async fn stage_1<'a, 'b>(
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: &'a pavex::request::RequestHead,
+        s_2: &'b biscotti::Processor,
+        s_3: pavex::request::path::MatchedPathPattern,
+    ) -> pavex::response::Response {
+        let response = wrapping_1(s_0, s_2, s_3, s_1).await;
+        response
+    }
+    async fn stage_2<'a, 'b, 'c>(
         s_0: &'a pavex_tracing::RootSpan,
         s_1: pavex::request::body::RawIncomingBody,
         s_2: &'b pavex::request::RequestHead,
+        s_3: &'c biscotti::Processor,
     ) -> pavex::response::Response {
         let response = handler(s_0, s_1, s_2).await;
         let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_3).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn wrapping_0(
         v0: pavex::request::body::RawIncomingBody,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &biscotti::Processor,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_11::Next0 {
-            s_0: &v4,
-            s_1: v0,
-            s_2: v2,
+        let v4 = crate::route_11::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v1,
+            s_3: v2,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::body::RawIncomingBody,
+        v1: &biscotti::Processor,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v3, v2, v4);
+        let v6 = crate::route_11::Next1 {
+            s_0: &v5,
+            s_1: v0,
+            s_2: v3,
+            s_3: v1,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: &pavex_tracing::RootSpan,
         v1: pavex::request::body::RawIncomingBody,
         v2: &pavex::request::RequestHead,
@@ -1536,24 +2503,47 @@ pub mod route_11 {
         let v8 = app::routes::articles::publish_article(v7);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v8)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::body::RawIncomingBody,
-        s_2: &'b pavex::request::RequestHead,
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: &'a pavex::request::RequestHead,
+        s_2: &'b biscotti::Processor,
+        s_3: pavex::request::path::MatchedPathPattern,
         next: fn(
-            &'a pavex_tracing::RootSpan,
             pavex::request::body::RawIncomingBody,
-            &'b pavex::request::RequestHead,
+            &'a pavex::request::RequestHead,
+            &'b biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
         ) -> T,
     }
     impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
@@ -1563,43 +2553,96 @@ pub mod route_11 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1, self.s_2)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: pavex::request::body::RawIncomingBody,
+        s_2: &'b pavex::request::RequestHead,
+        s_3: &'c biscotti::Processor,
+        next: fn(
+            &'a pavex_tracing::RootSpan,
+            pavex::request::body::RawIncomingBody,
+            &'b pavex::request::RequestHead,
+            &'c biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
         }
     }
 }
 pub mod route_12 {
-    pub async fn entrypoint<'a>(
-        s_0: pavex::request::path::MatchedPathPattern,
-        s_1: &'a pavex::request::RequestHead,
+    pub async fn entrypoint<'a, 'b>(
+        s_0: &'a biscotti::Processor,
+        s_1: pavex::request::path::MatchedPathPattern,
+        s_2: &'b pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1).await;
+        let response = wrapping_0(s_0, s_1, s_2).await;
         response
     }
     async fn stage_1<'a, 'b>(
+        s_0: &'a pavex::request::RequestHead,
+        s_1: &'b biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+    ) -> pavex::response::Response {
+        let response = wrapping_1(s_1, s_2, s_0).await;
+        response
+    }
+    async fn stage_2<'a, 'b, 'c>(
         s_0: &'a pavex_tracing::RootSpan,
         s_1: &'b pavex::request::RequestHead,
+        s_2: &'c biscotti::Processor,
     ) -> pavex::response::Response {
         let response = handler(s_0, s_1).await;
         let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_2).await;
         response
     }
-    pub async fn wrapping_0(
-        v0: pavex::request::path::MatchedPathPattern,
-        v1: &pavex::request::RequestHead,
+    async fn wrapping_0(
+        v0: &biscotti::Processor,
+        v1: pavex::request::path::MatchedPathPattern,
+        v2: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v2 = pavex::telemetry::ServerRequestId::generate();
-        let v3 = app::telemetry::root_span(v1, v0, v2);
-        let v4 = crate::route_12::Next0 {
-            s_0: &v3,
-            s_1: v1,
+        let v3 = crate::route_12::Next0 {
+            s_0: v2,
+            s_1: v0,
+            s_2: v1,
             next: stage_1,
         };
-        let v5 = pavex::middleware::Next::new(v4);
-        let v6 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v3);
-        let v7 = pavex_tracing::logger(v6, v5).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v7)
+        let v4 = pavex::middleware::Next::new(v3);
+        let v5 = pavex::middleware::wrap_noop(v4).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v5)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: &biscotti::Processor,
+        v1: pavex::request::path::MatchedPathPattern,
+        v2: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v3 = pavex::telemetry::ServerRequestId::generate();
+        let v4 = app::telemetry::root_span(v2, v1, v3);
+        let v5 = crate::route_12::Next1 {
+            s_0: &v4,
+            s_1: v2,
+            s_2: v0,
+            next: stage_2,
+        };
+        let v6 = pavex::middleware::Next::new(v5);
+        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
+        let v8 = pavex_tracing::logger(v7, v6).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+    }
+    async fn handler(
         v0: &pavex_tracing::RootSpan,
         v1: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
@@ -1622,20 +2665,46 @@ pub mod route_12 {
         let v4 = app::routes::articles::get_feed(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: &'b pavex::request::RequestHead,
-        next: fn(&'a pavex_tracing::RootSpan, &'b pavex::request::RequestHead) -> T,
+        s_0: &'a pavex::request::RequestHead,
+        s_1: &'b biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        next: fn(
+            &'a pavex::request::RequestHead,
+            &'b biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+        ) -> T,
     }
     impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
@@ -1644,45 +2713,99 @@ pub mod route_12 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2)
+        }
+    }
+    struct Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: &'b pavex::request::RequestHead,
+        s_2: &'c biscotti::Processor,
+        next: fn(
+            &'a pavex_tracing::RootSpan,
+            &'b pavex::request::RequestHead,
+            &'c biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next1<'a, 'b, 'c, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_13 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_13::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_13::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_13::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -1705,70 +2828,149 @@ pub mod route_13 {
         let v4 = app::routes::articles::get_article(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_14 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_14::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_14::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_14::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -1791,76 +2993,158 @@ pub mod route_14 {
         let v4 = app::routes::articles::delete_article(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_15 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::body::RawIncomingBody,
         s_1: pavex::request::path::RawPathParams<'a, 'b>,
-        s_2: pavex::request::path::MatchedPathPattern,
-        s_3: &'c pavex::request::RequestHead,
+        s_2: &'c biscotti::Processor,
+        s_3: pavex::request::path::MatchedPathPattern,
+        s_4: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3, s_4).await;
         response
     }
     async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: pavex::request::path::RawPathParams<'a, 'b>,
+        s_2: &'c pavex::request::RequestHead,
+        s_3: &'d biscotti::Processor,
+        s_4: pavex::request::path::MatchedPathPattern,
+    ) -> pavex::response::Response {
+        let response = wrapping_1(s_0, s_1, s_3, s_4, s_2).await;
+        response
+    }
+    async fn stage_2<'a, 'b, 'c, 'd, 'e>(
         s_0: &'a pavex_tracing::RootSpan,
         s_1: pavex::request::body::RawIncomingBody,
         s_2: pavex::request::path::RawPathParams<'b, 'c>,
         s_3: &'d pavex::request::RequestHead,
+        s_4: &'e biscotti::Processor,
     ) -> pavex::response::Response {
         let response = handler(s_0, s_1, s_2, s_3).await;
         let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_4).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn wrapping_0(
         v0: pavex::request::body::RawIncomingBody,
         v1: pavex::request::path::RawPathParams<'_, '_>,
-        v2: pavex::request::path::MatchedPathPattern,
-        v3: &pavex::request::RequestHead,
+        v2: &biscotti::Processor,
+        v3: pavex::request::path::MatchedPathPattern,
+        v4: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v4 = pavex::telemetry::ServerRequestId::generate();
-        let v5 = app::telemetry::root_span(v3, v2, v4);
-        let v6 = crate::route_15::Next0 {
-            s_0: &v5,
-            s_1: v0,
-            s_2: v1,
-            s_3: v3,
+        let v5 = crate::route_15::Next0 {
+            s_0: v0,
+            s_1: v1,
+            s_2: v4,
+            s_3: v2,
+            s_4: v3,
             next: stage_1,
         };
-        let v7 = pavex::middleware::Next::new(v6);
-        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
-        let v9 = pavex_tracing::logger(v8, v7).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+        let v6 = pavex::middleware::Next::new(v5);
+        let v7 = pavex::middleware::wrap_noop(v6).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v7)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::body::RawIncomingBody,
+        v1: pavex::request::path::RawPathParams<'_, '_>,
+        v2: &biscotti::Processor,
+        v3: pavex::request::path::MatchedPathPattern,
+        v4: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v5 = pavex::telemetry::ServerRequestId::generate();
+        let v6 = app::telemetry::root_span(v4, v3, v5);
+        let v7 = crate::route_15::Next1 {
+            s_0: &v6,
+            s_1: v0,
+            s_2: v1,
+            s_3: v4,
+            s_4: v2,
+            next: stage_2,
+        };
+        let v8 = pavex::middleware::Next::new(v7);
+        let v9 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v6);
+        let v10 = pavex_tracing::logger(v9, v8).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v10)
+    }
+    async fn handler(
         v0: &pavex_tracing::RootSpan,
         v1: pavex::request::body::RawIncomingBody,
         v2: pavex::request::path::RawPathParams<'_, '_>,
@@ -1918,26 +3202,49 @@ pub mod route_15 {
         let v11 = app::routes::articles::update_article(v10, v8);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v11)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, 'd, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::body::RawIncomingBody,
-        s_2: pavex::request::path::RawPathParams<'b, 'c>,
-        s_3: &'d pavex::request::RequestHead,
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: pavex::request::path::RawPathParams<'a, 'b>,
+        s_2: &'c pavex::request::RequestHead,
+        s_3: &'d biscotti::Processor,
+        s_4: pavex::request::path::MatchedPathPattern,
         next: fn(
-            &'a pavex_tracing::RootSpan,
             pavex::request::body::RawIncomingBody,
-            pavex::request::path::RawPathParams<'b, 'c>,
-            &'d pavex::request::RequestHead,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex::request::RequestHead,
+            &'d biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
         ) -> T,
     }
     impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
@@ -1947,45 +3254,103 @@ pub mod route_15 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, 'e, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: pavex::request::body::RawIncomingBody,
+        s_2: pavex::request::path::RawPathParams<'b, 'c>,
+        s_3: &'d pavex::request::RequestHead,
+        s_4: &'e biscotti::Processor,
+        next: fn(
+            &'a pavex_tracing::RootSpan,
+            pavex::request::body::RawIncomingBody,
+            pavex::request::path::RawPathParams<'b, 'c>,
+            &'d pavex::request::RequestHead,
+            &'e biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, 'e, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, 'e, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4)
         }
     }
 }
 pub mod route_16 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_16::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_16::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_16::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -2008,70 +3373,149 @@ pub mod route_16 {
         let v4 = app::routes::articles::unfavorite_article(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_17 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_17::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_17::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_17::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -2094,70 +3538,149 @@ pub mod route_17 {
         let v4 = app::routes::articles::favorite_article(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_18 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_18::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_18::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_18::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -2180,76 +3703,158 @@ pub mod route_18 {
         let v4 = app::routes::articles::list_comments(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }
 pub mod route_19 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::body::RawIncomingBody,
         s_1: pavex::request::path::RawPathParams<'a, 'b>,
-        s_2: pavex::request::path::MatchedPathPattern,
-        s_3: &'c pavex::request::RequestHead,
+        s_2: &'c biscotti::Processor,
+        s_3: pavex::request::path::MatchedPathPattern,
+        s_4: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3, s_4).await;
         response
     }
     async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: pavex::request::path::RawPathParams<'a, 'b>,
+        s_2: &'c pavex::request::RequestHead,
+        s_3: &'d biscotti::Processor,
+        s_4: pavex::request::path::MatchedPathPattern,
+    ) -> pavex::response::Response {
+        let response = wrapping_1(s_0, s_1, s_3, s_4, s_2).await;
+        response
+    }
+    async fn stage_2<'a, 'b, 'c, 'd, 'e>(
         s_0: &'a pavex_tracing::RootSpan,
         s_1: pavex::request::body::RawIncomingBody,
         s_2: pavex::request::path::RawPathParams<'b, 'c>,
         s_3: &'d pavex::request::RequestHead,
+        s_4: &'e biscotti::Processor,
     ) -> pavex::response::Response {
         let response = handler(s_0, s_1, s_2, s_3).await;
         let response = post_processing_0(response, s_0).await;
+        let response = post_processing_1(response, s_4).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn wrapping_0(
         v0: pavex::request::body::RawIncomingBody,
         v1: pavex::request::path::RawPathParams<'_, '_>,
-        v2: pavex::request::path::MatchedPathPattern,
-        v3: &pavex::request::RequestHead,
+        v2: &biscotti::Processor,
+        v3: pavex::request::path::MatchedPathPattern,
+        v4: &pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let v4 = pavex::telemetry::ServerRequestId::generate();
-        let v5 = app::telemetry::root_span(v3, v2, v4);
-        let v6 = crate::route_19::Next0 {
-            s_0: &v5,
-            s_1: v0,
-            s_2: v1,
-            s_3: v3,
+        let v5 = crate::route_19::Next0 {
+            s_0: v0,
+            s_1: v1,
+            s_2: v4,
+            s_3: v2,
+            s_4: v3,
             next: stage_1,
         };
-        let v7 = pavex::middleware::Next::new(v6);
-        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
-        let v9 = pavex_tracing::logger(v8, v7).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+        let v6 = pavex::middleware::Next::new(v5);
+        let v7 = pavex::middleware::wrap_noop(v6).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v7)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::body::RawIncomingBody,
+        v1: pavex::request::path::RawPathParams<'_, '_>,
+        v2: &biscotti::Processor,
+        v3: pavex::request::path::MatchedPathPattern,
+        v4: &pavex::request::RequestHead,
+    ) -> pavex::response::Response {
+        let v5 = pavex::telemetry::ServerRequestId::generate();
+        let v6 = app::telemetry::root_span(v4, v3, v5);
+        let v7 = crate::route_19::Next1 {
+            s_0: &v6,
+            s_1: v0,
+            s_2: v1,
+            s_3: v4,
+            s_4: v2,
+            next: stage_2,
+        };
+        let v8 = pavex::middleware::Next::new(v7);
+        let v9 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v6);
+        let v10 = pavex_tracing::logger(v9, v8).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v10)
+    }
+    async fn handler(
         v0: &pavex_tracing::RootSpan,
         v1: pavex::request::body::RawIncomingBody,
         v2: pavex::request::path::RawPathParams<'_, '_>,
@@ -2307,26 +3912,49 @@ pub mod route_19 {
         let v11 = app::routes::articles::publish_comment(v10, v8);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v11)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, 'd, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::body::RawIncomingBody,
-        s_2: pavex::request::path::RawPathParams<'b, 'c>,
-        s_3: &'d pavex::request::RequestHead,
+        s_0: pavex::request::body::RawIncomingBody,
+        s_1: pavex::request::path::RawPathParams<'a, 'b>,
+        s_2: &'c pavex::request::RequestHead,
+        s_3: &'d biscotti::Processor,
+        s_4: pavex::request::path::MatchedPathPattern,
         next: fn(
-            &'a pavex_tracing::RootSpan,
             pavex::request::body::RawIncomingBody,
-            pavex::request::path::RawPathParams<'b, 'c>,
-            &'d pavex::request::RequestHead,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex::request::RequestHead,
+            &'d biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
         ) -> T,
     }
     impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
@@ -2336,45 +3964,103 @@ pub mod route_19 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, 'e, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: &'a pavex_tracing::RootSpan,
+        s_1: pavex::request::body::RawIncomingBody,
+        s_2: pavex::request::path::RawPathParams<'b, 'c>,
+        s_3: &'d pavex::request::RequestHead,
+        s_4: &'e biscotti::Processor,
+        next: fn(
+            &'a pavex_tracing::RootSpan,
+            pavex::request::body::RawIncomingBody,
+            pavex::request::path::RawPathParams<'b, 'c>,
+            &'d pavex::request::RequestHead,
+            &'e biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, 'e, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, 'e, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3, self.s_4)
         }
     }
 }
 pub mod route_20 {
-    pub async fn entrypoint<'a, 'b, 'c>(
+    pub async fn entrypoint<'a, 'b, 'c, 'd>(
         s_0: pavex::request::path::RawPathParams<'a, 'b>,
-        s_1: pavex::request::path::MatchedPathPattern,
-        s_2: &'c pavex::request::RequestHead,
+        s_1: &'c pavex::request::RequestHead,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d biscotti::Processor,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
-    async fn stage_1<'a, 'b, 'c>(
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+    async fn stage_1<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
     ) -> pavex::response::Response {
-        let response = handler(s_1, s_0).await;
-        let response = post_processing_0(response, s_0).await;
+        let response = wrapping_1(s_0, s_3, s_2, s_1).await;
         response
     }
-    pub async fn wrapping_0(
+    async fn stage_2<'a, 'b, 'c, 'd>(
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+    ) -> pavex::response::Response {
+        let response = handler(s_0, s_1).await;
+        let response = post_processing_0(response, s_1).await;
+        let response = post_processing_1(response, s_2).await;
+        response
+    }
+    async fn wrapping_0(
         v0: pavex::request::path::RawPathParams<'_, '_>,
-        v1: pavex::request::path::MatchedPathPattern,
-        v2: &pavex::request::RequestHead,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v3 = pavex::telemetry::ServerRequestId::generate();
-        let v4 = app::telemetry::root_span(v2, v1, v3);
-        let v5 = crate::route_20::Next0 {
-            s_0: &v4,
-            s_1: v0,
+        let v4 = crate::route_20::Next0 {
+            s_0: v0,
+            s_1: v3,
+            s_2: v2,
+            s_3: v1,
             next: stage_1,
         };
-        let v6 = pavex::middleware::Next::new(v5);
-        let v7 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v4);
-        let v8 = pavex_tracing::logger(v7, v6).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v8)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
-    pub async fn handler(
+    async fn wrapping_1(
+        v0: pavex::request::path::RawPathParams<'_, '_>,
+        v1: &pavex::request::RequestHead,
+        v2: pavex::request::path::MatchedPathPattern,
+        v3: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v4 = pavex::telemetry::ServerRequestId::generate();
+        let v5 = app::telemetry::root_span(v1, v2, v4);
+        let v6 = crate::route_20::Next1 {
+            s_0: v0,
+            s_1: &v5,
+            s_2: v3,
+            next: stage_2,
+        };
+        let v7 = pavex::middleware::Next::new(v6);
+        let v8 = <pavex_tracing::RootSpan as core::clone::Clone>::clone(&v5);
+        let v9 = pavex_tracing::logger(v8, v7).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v9)
+    }
+    async fn handler(
         v0: pavex::request::path::RawPathParams<'_, '_>,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
@@ -2397,32 +4083,80 @@ pub mod route_20 {
         let v4 = app::routes::articles::delete_comment(v3);
         <http::StatusCode as pavex::response::IntoResponse>::into_response(v4)
     }
-    pub async fn post_processing_0(
+    async fn post_processing_0(
         v0: pavex::response::Response,
         v1: &pavex_tracing::RootSpan,
     ) -> pavex::response::Response {
         let v2 = app::telemetry::response_logger(v0, v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    pub struct Next0<'a, 'b, 'c, T>
+    async fn post_processing_1(
+        v0: pavex::response::Response,
+        v1: &biscotti::Processor,
+    ) -> pavex::response::Response {
+        let v2 = biscotti::ResponseCookies::new_static();
+        let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
+        let v4 = match v3 {
+            Ok(ok) => ok,
+            Err(v4) => {
+                return {
+                    let v5 = pavex::cookie::errors::InjectResponseCookiesError::into_response(
+                        &v4,
+                    );
+                    <pavex::response::Response as pavex::response::IntoResponse>::into_response(
+                        v5,
+                    )
+                };
+            }
+        };
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
+    }
+    struct Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
-        s_0: &'a pavex_tracing::RootSpan,
-        s_1: pavex::request::path::RawPathParams<'b, 'c>,
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c biscotti::Processor,
+        s_2: pavex::request::path::MatchedPathPattern,
+        s_3: &'d pavex::request::RequestHead,
         next: fn(
-            &'a pavex_tracing::RootSpan,
-            pavex::request::path::RawPathParams<'b, 'c>,
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c biscotti::Processor,
+            pavex::request::path::MatchedPathPattern,
+            &'d pavex::request::RequestHead,
         ) -> T,
     }
-    impl<'a, 'b, 'c, T> std::future::IntoFuture for Next0<'a, 'b, 'c, T>
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next0<'a, 'b, 'c, 'd, T>
     where
         T: std::future::Future<Output = pavex::response::Response>,
     {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
+        }
+    }
+    struct Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        s_0: pavex::request::path::RawPathParams<'a, 'b>,
+        s_1: &'c pavex_tracing::RootSpan,
+        s_2: &'d biscotti::Processor,
+        next: fn(
+            pavex::request::path::RawPathParams<'a, 'b>,
+            &'c pavex_tracing::RootSpan,
+            &'d biscotti::Processor,
+        ) -> T,
+    }
+    impl<'a, 'b, 'c, 'd, T> std::future::IntoFuture for Next1<'a, 'b, 'c, 'd, T>
+    where
+        T: std::future::Future<Output = pavex::response::Response>,
+    {
+        type Output = pavex::response::Response;
+        type IntoFuture = T;
+        fn into_future(self) -> Self::IntoFuture {
+            (self.next)(self.s_0, self.s_1, self.s_2)
         }
     }
 }

--- a/examples/realworld/server_sdk/src/lib.rs
+++ b/examples/realworld/server_sdk/src/lib.rs
@@ -45,7 +45,7 @@ pub async fn build_application_state(
     };
     let v7 = app::configuration::ApplicationConfig::cookie_config(v0);
     let v8 = <pavex::cookie::Processor as std::convert::From<
-        pavex::cookie::config::Config,
+        pavex::cookie::ProcessorConfig,
     >>::from(v7);
     let v9 = crate::ApplicationState {
         s0: v8,
@@ -638,7 +638,7 @@ pub mod route_0 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -770,7 +770,7 @@ pub mod route_1 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -909,7 +909,7 @@ pub mod route_2 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -1123,7 +1123,7 @@ pub mod route_3 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -1347,7 +1347,7 @@ pub mod route_4 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -1496,7 +1496,7 @@ pub mod route_5 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -1674,7 +1674,7 @@ pub mod route_6 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -1841,7 +1841,7 @@ pub mod route_7 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -2006,7 +2006,7 @@ pub mod route_8 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -2171,7 +2171,7 @@ pub mod route_9 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -2331,7 +2331,7 @@ pub mod route_10 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -2514,7 +2514,7 @@ pub mod route_11 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -2676,7 +2676,7 @@ pub mod route_12 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -2839,7 +2839,7 @@ pub mod route_13 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -3004,7 +3004,7 @@ pub mod route_14 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -3213,7 +3213,7 @@ pub mod route_15 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -3384,7 +3384,7 @@ pub mod route_16 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -3549,7 +3549,7 @@ pub mod route_17 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -3714,7 +3714,7 @@ pub mod route_18 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -3923,7 +3923,7 @@ pub mod route_19 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,
@@ -4094,7 +4094,7 @@ pub mod route_20 {
         v0: pavex::response::Response,
         v1: &biscotti::Processor,
     ) -> pavex::response::Response {
-        let v2 = biscotti::ResponseCookies::new_static();
+        let v2 = pavex::cookie::ResponseCookies::new();
         let v3 = pavex::cookie::inject_response_cookies(v0, v2, v1);
         let v4 = match v3 {
             Ok(ok) => ok,

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,21 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -188,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +247,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "biscotti"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac260b0392bba9873665d07367cb71f0298352e7fc2ed154ad4af57c47476a94"
+dependencies = [
+ "aes-gcm-siv",
+ "anyhow",
+ "base64 0.22.0",
+ "hkdf",
+ "hmac",
+ "percent-encoding",
+ "rand",
+ "serde",
+ "sha2",
+ "subtle",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -585,7 +636,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -610,6 +671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1023,6 +1085,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1654,6 +1725,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1899,7 @@ name = "pavex"
 version = "0.1.23"
 dependencies = [
  "anyhow",
+ "biscotti",
  "bytes",
  "fs-err",
  "futures-util",
@@ -1852,6 +1930,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
  "ubyte",
@@ -2195,6 +2274,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,7 +2496,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e333b1eb9fe677f6893a9efcb0d277a2d3edd83f358a236b657c32301dc6e5f6"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2462,7 +2553,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.5.0",
  "serde",
  "serde_derive",
@@ -2540,7 +2631,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -3372,6 +3463,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,7 +3484,7 @@ version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "flate2",
  "log",
  "once_cell",

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "aligned"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a21b9440a626c7fc8573a9e3d3a06b75c7c97754c2949bc7857b90353ca655"
+checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
 dependencies = [
  "as-slice",
 ]
@@ -178,9 +178,9 @@ checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
@@ -251,21 +251,21 @@ dependencies = [
 
 [[package]]
 name = "biscotti"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac260b0392bba9873665d07367cb71f0298352e7fc2ed154ad4af57c47476a94"
+checksum = "a5a57956e5d7a91adc693ef7ca9b93380a520b970d03095c39bec553b982e792"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
  "base64 0.22.0",
  "hkdf",
  "hmac",
+ "log",
  "percent-encoding",
  "rand",
  "serde",
  "sha2",
  "subtle",
- "thiserror",
  "time",
 ]
 
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -977,7 +977,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1287,15 +1287,14 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.36.1"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e"
+checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
 dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
  "similar",
- "yaml-rust",
 ]
 
 [[package]]
@@ -1339,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
@@ -1530,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "miette"
@@ -1764,9 +1763,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -2182,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2193,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2203,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2216,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
 dependencies = [
  "once_cell",
  "pest",
@@ -2257,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2305,9 +2304,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2439,7 +2438,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2459,7 +2458,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2470,9 +2469,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "remove_dir_all"
@@ -2492,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e333b1eb9fe677f6893a9efcb0d277a2d3edd83f358a236b657c32301dc6e5f6"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2613,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring",
@@ -2636,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -2718,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -2731,9 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2781,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "serde_html_form"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50437e6a58912eecc08865e35ea2e8d365fbb2db0debb1c8bb43bf1faf055f25"
+checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
 dependencies = [
  "form_urlencoded",
  "indexmap",
@@ -2794,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2877,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "slab"
@@ -2978,9 +2977,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3183,9 +3182,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3389,9 +3388,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa6f84ec205ebf87fb7a0abdbcd1467fa5af0e86878eb6d888b78ecbb10b6d5"
+checksum = "8ad7eb6319ebadebca3dacf1f85a93bc54b73dd81b9036795f73de7ddfe27d5a"
 dependencies = [
  "glob",
  "once_cell",
@@ -4028,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.10+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -251,16 +251,15 @@ dependencies = [
 
 [[package]]
 name = "biscotti"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a57956e5d7a91adc693ef7ca9b93380a520b970d03095c39bec553b982e792"
+checksum = "67407395981dac7f26e8a043947941348cf77bfeb8e040fed1dd04adf3b7f507"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
  "base64 0.22.0",
  "hkdf",
  "hmac",
- "log",
  "percent-encoding",
  "rand",
  "serde",

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -10,10 +10,12 @@ license.workspace = true
 readme = "README.md"
 
 [features]
-default = ["server", "server_request_id"]
+default = ["server", "server_request_id", "time", "cookie"]
 
 server = ["dep:hyper", "dep:hyper-util", "dep:socket2"]
+cookie = ["dep:biscotti", "time"]
 server_request_id = ["dep:uuid"]
+time = ["dep:time"]
 
 [dependencies]
 bytes = "1"
@@ -50,8 +52,14 @@ indexmap = { version = "2", features = ["serde"] }
 fs-err = "2.7.0"
 ron = "0.8"
 
+# Cookies
+biscotti = { version = "0.2.1", optional = true }
+
 # Server request id
 uuid = { version = "1", features = ["v7"], optional = true }
+
+# Time facilities
+time = { version = "0.3", features = ["serde"], optional = true }
 
 tokio = { version = "1.32", features = ["net", "sync", "rt", "time"] }
 hyper = { version = "1", features = ["full"], optional = true }

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -53,7 +53,7 @@ fs-err = "2.7.0"
 ron = "0.8"
 
 # Cookies
-biscotti = { version = "0.2.1", optional = true }
+biscotti = { version = "0.3", optional = true }
 
 # Server request id
 uuid = { version = "1", features = ["v7"], optional = true }

--- a/libs/pavex/src/cookie/components.rs
+++ b/libs/pavex/src/cookie/components.rs
@@ -1,0 +1,52 @@
+use crate::cookie::errors::{ExtractRequestCookiesError, InjectResponseCookiesError};
+use crate::cookie::ResponseCookies;
+use crate::error::UnexpectedError;
+use crate::request::RequestHead;
+use crate::response::Response;
+use biscotti::{Processor, RequestCookies};
+use http::header::{COOKIE, SET_COOKIE};
+use http::HeaderValue;
+
+/// Parse cookies out of the incoming request.
+///
+/// It's the default constructor for [`RequestCookies`].
+pub fn extract_request_cookies<'request, 'b>(
+    request_head: &'request RequestHead,
+    processor: &'b Processor,
+) -> Result<RequestCookies<'request>, ExtractRequestCookiesError> {
+    let mut cookies = RequestCookies::new();
+    for header in request_head.headers.get_all(COOKIE).into_iter() {
+        let header = header
+            .to_str()
+            .map_err(|e| ExtractRequestCookiesError::InvalidHeaderValue(e))?;
+        cookies.extend_from_header(header, processor).map_err(|e| {
+            use biscotti::errors::ParseError::*;
+            match e {
+                MissingPair(e) => ExtractRequestCookiesError::MissingPair(e),
+                EmptyName(e) => ExtractRequestCookiesError::EmptyName(e),
+                Crypto(e) => ExtractRequestCookiesError::Crypto(e),
+                Decoding(e) => ExtractRequestCookiesError::Decoding(e),
+                _ => ExtractRequestCookiesError::Unexpected(UnexpectedError::new(e)),
+            }
+        })?;
+    }
+    Ok(cookies)
+}
+
+/// Attach cookies to the outgoing response.
+///
+/// It consumes [`ResponseCookies`] by value since no response cookies should be
+/// added after the execution of this middleware.
+pub fn inject_response_cookies(
+    mut response: Response,
+    response_cookies: ResponseCookies,
+    processor: &Processor,
+) -> Result<Response, InjectResponseCookiesError> {
+    for value in response_cookies.header_values(processor) {
+        let value = HeaderValue::from_str(&value).map_err(|_| InjectResponseCookiesError {
+            invalid_header_value: value,
+        })?;
+        response = response.append_header(SET_COOKIE, value);
+    }
+    Ok(response)
+}

--- a/libs/pavex/src/cookie/errors.rs
+++ b/libs/pavex/src/cookie/errors.rs
@@ -1,0 +1,52 @@
+//! Errors that can occur when working with cookies.
+use crate::response::Response;
+pub use biscotti::errors::*;
+use http::header::ToStrError;
+
+#[derive(Debug, thiserror::Error)]
+/// The error type returned by [`extract_request_cookies`](super::extract_request_cookies).
+pub enum ExtractRequestCookiesError {
+    #[error("Some characters in the `Cookie` header aren't printable ASCII characters.")]
+    InvalidHeaderValue(#[from] ToStrError),
+    #[error("Failed to parse request cookies out of the `Cookie` header.")]
+    ParseError(#[from] ParseError),
+}
+
+impl ExtractRequestCookiesError {
+    /// Convert an [`ExtractRequestCookiesError`] into an HTTP response.
+    ///
+    /// It returns a `400 Bad Request` to the caller.
+    /// The body provides details on what exactly went wrong.
+    pub fn into_response(&self) -> Response {
+        use std::fmt::Write as _;
+
+        let mut body = self.to_string();
+        match self {
+            ExtractRequestCookiesError::InvalidHeaderValue(_) => {}
+            ExtractRequestCookiesError::ParseError(e) => {
+                let _ = write!(&mut body, "\n{e}");
+            }
+        }
+        Response::bad_request().set_typed_body(body)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+#[error("Some characters in the `Set-Cookie` header value are not printable ASCII characters.")]
+/// The error type returned by [`inject_response_cookies`](super::inject_response_cookies).
+pub struct InjectResponseCookiesError {
+    /// The invalid header value.
+    pub invalid_header_value: String,
+}
+
+impl InjectResponseCookiesError {
+    /// Convert an [`InjectResponseCookiesError`] into an HTTP response.
+    ///
+    /// It returns a `500 Internal Server Error` to the caller,
+    /// since failure is likely due to misconfiguration or
+    /// mismanagement on the server side.
+    pub fn into_response(&self) -> Response {
+        Response::internal_server_error()
+    }
+}

--- a/libs/pavex/src/cookie/kit.rs
+++ b/libs/pavex/src/cookie/kit.rs
@@ -1,0 +1,103 @@
+use crate::blueprint::Blueprint;
+use crate::blueprint::constructor::{Constructor, Lifecycle};
+use crate::blueprint::middleware::PostProcessingMiddleware;
+use crate::f;
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+/// A collection of components required to work with request and response cookies.
+///
+/// # Guide
+///
+/// Check out the ["Kits"](https://pavex.dev/docs/guide/dependency_injection/core_concepts/kits)
+/// section of Pavex's guide for a thorough introduction to kits and how to
+/// customize them.
+///
+/// # Example
+///
+/// ```rust
+/// use pavex::blueprint::Blueprint;
+/// use pavex::cookie::CookieKit;
+///
+/// let mut bp = Blueprint::new();
+/// let kit = CookieKit::new().register(&mut bp);
+/// ```
+pub struct CookieKit {
+    /// The constructor for [`RequestCookies`].
+    ///
+    /// By default, it uses [`extract_request_cookies`].
+    /// The error is handled by [`ExtractRequestCookiesError::into_response`].
+    ///
+    /// [`ExtractRequestCookiesError::into_response`]: super::errors::ExtractRequestCookiesError::into_response
+    /// [`extract_request_cookies`]: super::extract_request_cookies
+    /// [`RequestCookies`]: super::RequestCookies
+    pub request_cookies: Option<Constructor>,
+    /// The constructor for [`ResponseCookies`].
+    ///
+    /// By default, it uses [`ResponseCookies::new`].
+    ///
+    /// [`ResponseCookies::new`]: super::ResponseCookies::new
+    /// [`ResponseCookies`]: super::ResponseCookies
+    pub response_cookies: Option<Constructor>,
+    /// The constructor for [`Processor`].
+    ///
+    /// By default, it uses [`Processor::from`]
+    ///
+    /// [`Processor`]: super::Processor
+    /// [`Processor::from`]: super::Processor::from
+    pub processor: Option<Constructor>,
+    /// A post-processing middleware to inject response cookies into the outgoing response
+    /// via the `Set-Cookie` header.
+    ///
+    /// By default, it's set to [`inject_response_cookies`].
+    /// The error is handled by [`InjectResponseCookiesError::into_response`].
+    ///
+    /// [`InjectResponseCookiesError::into_response`]: super::errors::InjectResponseCookiesError::into_response
+    /// [`inject_response_cookies`]: super::inject_response_cookies
+    pub response_cookie_injector: Option<PostProcessingMiddleware>,
+}
+
+impl CookieKit {
+    /// Create a new [`CookieKit`] with all the bundled constructors and middlewares.
+    pub fn new() -> Self {
+        let request_cookies = Constructor::new(f!(super::extract_request_cookies), Lifecycle::RequestScoped)
+            .error_handler(f!(super::errors::ExtractRequestCookiesError::into_response));
+        let response_cookies = Constructor::new(f!(super::ResponseCookies::new), Lifecycle::RequestScoped);
+        let response_cookie_injector = PostProcessingMiddleware::new(f!(super::inject_response_cookies))
+            .error_handler(f!(super::errors::InjectResponseCookiesError::into_response));
+        let processor = Constructor::new(
+            f!(<super::Processor as std::convert::From<super::config::Config>>::from),
+            Lifecycle::Singleton,
+        );
+        Self {
+            request_cookies: Some(request_cookies),
+            response_cookies: Some(response_cookies),
+            response_cookie_injector: Some(response_cookie_injector),
+            processor: Some(processor),
+        }
+    }
+
+    /// Register all the bundled constructors and middlewares with a [`Blueprint`].
+    ///
+    /// If a component is set to `None` it will not be registered.
+    pub fn register(self, bp: &mut Blueprint) -> RegisteredCookieKit {
+        if let Some(request_cookies) = self.request_cookies {
+            request_cookies.register(bp);
+        }
+        if let Some(response_cookies) = self.response_cookies {
+            response_cookies.register(bp);
+        }
+        if let Some(response_cookie_injector) = self.response_cookie_injector {
+            response_cookie_injector.register(bp);
+        }
+        if let Some(processor) = self.processor {
+            processor.register(bp);
+        }
+        RegisteredCookieKit {}
+    }
+}
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+/// The type returned by [`CookieKit::register`].
+pub struct RegisteredCookieKit {}

--- a/libs/pavex/src/cookie/kit.rs
+++ b/libs/pavex/src/cookie/kit.rs
@@ -34,9 +34,9 @@ pub struct CookieKit {
     pub request_cookies: Option<Constructor>,
     /// The constructor for [`ResponseCookies`].
     ///
-    /// By default, it uses [`ResponseCookies::new`].
+    /// By default, it uses [`ResponseCookies::new_static`].
     ///
-    /// [`ResponseCookies::new`]: super::ResponseCookies::new
+    /// [`ResponseCookies::new_static`]: super::ResponseCookies::new_static
     /// [`ResponseCookies`]: super::ResponseCookies
     pub response_cookies: Option<Constructor>,
     /// The constructor for [`Processor`].
@@ -62,7 +62,7 @@ impl CookieKit {
     pub fn new() -> Self {
         let request_cookies = Constructor::new(f!(super::extract_request_cookies), Lifecycle::RequestScoped)
             .error_handler(f!(super::errors::ExtractRequestCookiesError::into_response));
-        let response_cookies = Constructor::new(f!(super::ResponseCookies::new), Lifecycle::RequestScoped);
+        let response_cookies = Constructor::new(f!(biscotti::ResponseCookies::new_static), Lifecycle::RequestScoped);
         let response_cookie_injector = PostProcessingMiddleware::new(f!(super::inject_response_cookies))
             .error_handler(f!(super::errors::InjectResponseCookiesError::into_response));
         let processor = Constructor::new(

--- a/libs/pavex/src/cookie/mod.rs
+++ b/libs/pavex/src/cookie/mod.rs
@@ -1,36 +1,49 @@
 //! Everything you need to work with HTTP cookies.
 //!
 //! Most types and functions are re-exports of the
-//! [`biscotti@0.2`](https://docs.rs/biscotti/0.2) crate.
-use crate::cookie::errors::InjectResponseCookiesError;
+//! [`biscotti@0.3`](https://docs.rs/biscotti/0.3) crate.
+use crate::cookie::errors::{ExtractRequestCookiesError, InjectResponseCookiesError};
 use crate::request::RequestHead;
 use crate::response::Response;
-// Everything from `biscotti`, except the `time` module
+// Everything from `biscotti`, except the `time` module and `ResponseCookies`.
 pub use biscotti::{
     config, request, Expiration, Key, Processor, RemovalCookie, RequestCookie, RequestCookies,
-    ResponseCookie, ResponseCookieId, ResponseCookies, SameSite,
+    ResponseCookie, ResponseCookieId, SameSite,
 };
+pub mod errors;
+pub mod response;
 use http::header::{COOKIE, SET_COOKIE};
 use http::HeaderValue;
 
 mod kit;
+mod response_cookies;
+use crate::error::UnexpectedError;
 pub use kit::CookieKit;
+pub use response_cookies::ResponseCookies;
 
 /// Parse cookies out of the incoming request.
 ///
 /// It's the default constructor for [`RequestCookies`].
-pub fn extract_request_cookies<'a, 'b>(
-    request_head: &'a RequestHead,
+pub fn extract_request_cookies<'request, 'b>(
+    request_head: &'request RequestHead,
     processor: &'b Processor,
-) -> Result<RequestCookies<'a>, errors::ExtractRequestCookiesError> {
-    // TODO: Avoid allocation once `biscotti`'s API allows it.
-    let cookie_headers = request_head
-        .headers
-        .get_all(COOKIE)
-        .into_iter()
-        .map(|h| h.to_str())
-        .collect::<Result<Vec<_>, _>>()?;
-    let cookies = RequestCookies::parse_headers(cookie_headers.into_iter(), processor)?;
+) -> Result<RequestCookies<'request>, ExtractRequestCookiesError> {
+    let mut cookies = RequestCookies::new();
+    for header in request_head.headers.get_all(COOKIE).into_iter() {
+        let header = header
+            .to_str()
+            .map_err(|e| ExtractRequestCookiesError::InvalidHeaderValue(e))?;
+        cookies.extend_from_header(header, processor).map_err(|e| {
+            use biscotti::errors::ParseError::*;
+            match e {
+                MissingPair(e) => ExtractRequestCookiesError::MissingPair(e),
+                EmptyName(e) => ExtractRequestCookiesError::EmptyName(e),
+                Crypto(e) => ExtractRequestCookiesError::Crypto(e),
+                Decoding(e) => ExtractRequestCookiesError::Decoding(e),
+                _ => ExtractRequestCookiesError::Unexpected(UnexpectedError::new(e)),
+            }
+        })?;
+    }
     Ok(cookies)
 }
 
@@ -44,14 +57,10 @@ pub fn inject_response_cookies(
     processor: &Processor,
 ) -> Result<Response, InjectResponseCookiesError> {
     for value in response_cookies.header_values(processor) {
-        let value = HeaderValue::from_str(&value)
-            .map_err(|_| InjectResponseCookiesError {
-                invalid_header_value: value
-            })?;
+        let value = HeaderValue::from_str(&value).map_err(|_| InjectResponseCookiesError {
+            invalid_header_value: value,
+        })?;
         response = response.append_header(SET_COOKIE, value);
     }
     Ok(response)
 }
-
-pub mod errors;
-

--- a/libs/pavex/src/cookie/mod.rs
+++ b/libs/pavex/src/cookie/mod.rs
@@ -8,8 +8,8 @@
 // - the `errors` module, which is augmented with additional error types in the `errors` module
 // - the `response` module, which is replaced with a wrapped version in the `response` module
 pub use biscotti::{
-    config, request, Expiration, Key, Processor, RemovalCookie, RequestCookie, RequestCookies,
-    ResponseCookie, ResponseCookieId, SameSite,
+    config, request, Expiration, Key, Processor, ProcessorConfig, RemovalCookie, RequestCookie,
+    RequestCookies, ResponseCookie, ResponseCookieId, SameSite,
 };
 pub mod errors;
 pub mod response;

--- a/libs/pavex/src/cookie/mod.rs
+++ b/libs/pavex/src/cookie/mod.rs
@@ -2,65 +2,23 @@
 //!
 //! Most types and functions are re-exports of the
 //! [`biscotti@0.3`](https://docs.rs/biscotti/0.3) crate.
-use crate::cookie::errors::{ExtractRequestCookiesError, InjectResponseCookiesError};
-use crate::request::RequestHead;
-use crate::response::Response;
-// Everything from `biscotti`, except the `time` module and `ResponseCookies`.
+// Everything from `biscotti`, except:
+// - the `time` module, which is re-exported as a top-level module in Pavex itself
+// - `ResponseCookies`, which is customized in the `response_cookies` module
+// - the `errors` module, which is augmented with additional error types in the `errors` module
+// - the `response` module, which is replaced with a wrapped version in the `response` module
 pub use biscotti::{
     config, request, Expiration, Key, Processor, RemovalCookie, RequestCookie, RequestCookies,
     ResponseCookie, ResponseCookieId, SameSite,
 };
 pub mod errors;
 pub mod response;
-use http::header::{COOKIE, SET_COOKIE};
-use http::HeaderValue;
+
+mod components;
+pub use components::{extract_request_cookies, inject_response_cookies};
 
 mod kit;
-mod response_cookies;
-use crate::error::UnexpectedError;
 pub use kit::CookieKit;
+
+mod response_cookies;
 pub use response_cookies::ResponseCookies;
-
-/// Parse cookies out of the incoming request.
-///
-/// It's the default constructor for [`RequestCookies`].
-pub fn extract_request_cookies<'request, 'b>(
-    request_head: &'request RequestHead,
-    processor: &'b Processor,
-) -> Result<RequestCookies<'request>, ExtractRequestCookiesError> {
-    let mut cookies = RequestCookies::new();
-    for header in request_head.headers.get_all(COOKIE).into_iter() {
-        let header = header
-            .to_str()
-            .map_err(|e| ExtractRequestCookiesError::InvalidHeaderValue(e))?;
-        cookies.extend_from_header(header, processor).map_err(|e| {
-            use biscotti::errors::ParseError::*;
-            match e {
-                MissingPair(e) => ExtractRequestCookiesError::MissingPair(e),
-                EmptyName(e) => ExtractRequestCookiesError::EmptyName(e),
-                Crypto(e) => ExtractRequestCookiesError::Crypto(e),
-                Decoding(e) => ExtractRequestCookiesError::Decoding(e),
-                _ => ExtractRequestCookiesError::Unexpected(UnexpectedError::new(e)),
-            }
-        })?;
-    }
-    Ok(cookies)
-}
-
-/// Attach cookies to the outgoing response.
-///
-/// It consumes [`ResponseCookies`] by value since no response cookies should be
-/// added after the execution of this middleware.
-pub fn inject_response_cookies(
-    mut response: Response,
-    response_cookies: ResponseCookies,
-    processor: &Processor,
-) -> Result<Response, InjectResponseCookiesError> {
-    for value in response_cookies.header_values(processor) {
-        let value = HeaderValue::from_str(&value).map_err(|_| InjectResponseCookiesError {
-            invalid_header_value: value,
-        })?;
-        response = response.append_header(SET_COOKIE, value);
-    }
-    Ok(response)
-}

--- a/libs/pavex/src/cookie/mod.rs
+++ b/libs/pavex/src/cookie/mod.rs
@@ -1,0 +1,57 @@
+//! Everything you need to work with HTTP cookies.
+//!
+//! Most types and functions are re-exports of the
+//! [`biscotti@0.2`](https://docs.rs/biscotti/0.2) crate.
+use crate::cookie::errors::InjectResponseCookiesError;
+use crate::request::RequestHead;
+use crate::response::Response;
+// Everything from `biscotti`, except the `time` module
+pub use biscotti::{
+    config, request, Expiration, Key, Processor, RemovalCookie, RequestCookie, RequestCookies,
+    ResponseCookie, ResponseCookieId, ResponseCookies, SameSite,
+};
+use http::header::{COOKIE, SET_COOKIE};
+use http::HeaderValue;
+
+mod kit;
+pub use kit::CookieKit;
+
+/// Parse cookies out of the incoming request.
+///
+/// It's the default constructor for [`RequestCookies`].
+pub fn extract_request_cookies<'a, 'b>(
+    request_head: &'a RequestHead,
+    processor: &'b Processor,
+) -> Result<RequestCookies<'a>, errors::ExtractRequestCookiesError> {
+    // TODO: Avoid allocation once `biscotti`'s API allows it.
+    let cookie_headers = request_head
+        .headers
+        .get_all(COOKIE)
+        .into_iter()
+        .map(|h| h.to_str())
+        .collect::<Result<Vec<_>, _>>()?;
+    let cookies = RequestCookies::parse_headers(cookie_headers.into_iter(), processor)?;
+    Ok(cookies)
+}
+
+/// Attach cookies to the outgoing response.
+///
+/// It consumes [`ResponseCookies`] by value since no response cookies should be
+/// added after the execution of this middleware.
+pub fn inject_response_cookies(
+    mut response: Response,
+    response_cookies: ResponseCookies,
+    processor: &Processor,
+) -> Result<Response, InjectResponseCookiesError> {
+    for value in response_cookies.header_values(processor) {
+        let value = HeaderValue::from_str(&value)
+            .map_err(|_| InjectResponseCookiesError {
+                invalid_header_value: value
+            })?;
+        response = response.append_header(SET_COOKIE, value);
+    }
+    Ok(response)
+}
+
+pub mod errors;
+

--- a/libs/pavex/src/cookie/response.rs
+++ b/libs/pavex/src/cookie/response.rs
@@ -1,0 +1,19 @@
+//! Low-level types related to [`ResponseCookies`].
+//!
+//! [`ResponseCookies`]: super::ResponseCookies
+use super::ResponseCookie;
+
+/// Iterator over all the cookies in a [`ResponseCookies`].
+///
+/// [`ResponseCookies`]: super::ResponseCookies
+pub struct ResponseCookiesIter<'map> {
+    pub(crate) cookies: biscotti::response::ResponseCookiesIter<'map, 'static>,
+}
+
+impl<'map> Iterator for ResponseCookiesIter<'map> {
+    type Item = &'map ResponseCookie<'static>;
+
+    fn next(&mut self) -> Option<&'map ResponseCookie<'static>> {
+        self.cookies.next()
+    }
+}

--- a/libs/pavex/src/cookie/response_cookies.rs
+++ b/libs/pavex/src/cookie/response_cookies.rs
@@ -51,7 +51,7 @@ use crate::cookie::response::ResponseCookiesIter;
 /// Cookies can be retrieved with [`ResponseCookies::get()`].
 /// Check the method's documentation for more information.
 ///
-/// [`RemovalCookie`]: crate::RemovalCookie
+/// [`RemovalCookie`]: super::RemovalCookie
 #[derive(Default, Debug, Clone)]
 pub struct ResponseCookies(biscotti::ResponseCookies<'static>);
 
@@ -192,7 +192,7 @@ impl ResponseCookies {
     /// assert_eq!(set.iter().count(), 0);
     /// ```
     ///
-    /// [`RemovalCookie`]: crate::RemovalCookie
+    /// [`RemovalCookie`]: super::RemovalCookie
     pub fn discard<'map, 'key, Key>(&'map mut self, id: Key)
     where
         Key: Into<ResponseCookieId<'key>>,

--- a/libs/pavex/src/cookie/response_cookies.rs
+++ b/libs/pavex/src/cookie/response_cookies.rs
@@ -1,0 +1,277 @@
+use super::{Processor, ResponseCookie, ResponseCookieId};
+use crate::cookie::response::ResponseCookiesIter;
+
+/// A collection of [`ResponseCookie`]s to be attached to an HTTP response
+/// using the `Set-Cookie` header.
+///
+/// # Adding a cookie
+///
+/// A set's life begins via [`ResponseCookies::new()`] and calls to
+/// [`ResponseCookies::insert()`]:
+///
+/// ```rust
+/// use pavex::cookie::{ResponseCookie, ResponseCookies};
+///
+/// let mut set = ResponseCookies::new();
+/// set.insert(("name", "value"));
+/// set.insert(("second", "another"));
+/// set.insert(ResponseCookie::new("third", "again").set_path("/"));
+/// ```
+///
+/// # Removing a cookie
+///
+/// If you want to tell the client to remove a cookie, you need to
+/// insert a [`RemovalCookie`] into the set.
+/// Note that any `T: Into<ResponseCookie>` can be passed into
+/// these methods.
+///
+/// ```rust
+/// use pavex::cookie::{ResponseCookie, ResponseCookies, RemovalCookie, ResponseCookieId};
+///
+/// let mut set = ResponseCookies::new();
+/// let removal = RemovalCookie::new("name").set_path("/");
+/// // This will tell the client to remove the cookie with name "name"
+/// // and path "/".
+/// set.insert(removal);
+///
+/// // If you insert a cookie with the same name and path, it will replace
+/// // the removal cookie.
+/// let cookie = ResponseCookie::new("name", "value").set_path("/");
+/// set.insert(cookie);
+///
+/// let retrieved = set.get(ResponseCookieId::new("name").set_path("/")).unwrap();
+/// assert_eq!(retrieved.value(), "value");
+/// ```
+///
+/// If you want to remove a cookie from the set without telling the client to remove it,
+/// you can use [`ResponseCookies::discard()`].
+///
+/// # Retrieving a cookie
+///
+/// Cookies can be retrieved with [`ResponseCookies::get()`].
+/// Check the method's documentation for more information.
+///
+/// [`RemovalCookie`]: crate::RemovalCookie
+#[derive(Default, Debug, Clone)]
+pub struct ResponseCookies(biscotti::ResponseCookies<'static>);
+
+impl ResponseCookies {
+    /// Creates an empty cookie set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pavex::cookie::ResponseCookies;
+    ///
+    /// let set = ResponseCookies::new();
+    /// assert_eq!(set.iter().count(), 0);
+    /// ```
+    pub fn new() -> ResponseCookies {
+        ResponseCookies::default()
+    }
+
+    /// Returns a reference to the [`ResponseCookie`] inside this set with the specified `id`.
+    ///
+    /// # Via id
+    ///
+    /// ```rust
+    /// use pavex::cookie::{ResponseCookies, ResponseCookie, ResponseCookieId};
+    ///
+    /// let mut set = ResponseCookies::new();
+    /// assert!(set.get("name").is_none());
+    ///
+    /// let cookie = ResponseCookie::new("name", "value").set_path("/");
+    /// set.insert(cookie);
+    ///
+    /// // By specifying just the name, the domain and path are assumed to be None.
+    /// let id = ResponseCookieId::new("name");
+    /// // `name` has a path of `/`, so it doesn't match the empty path.
+    /// assert!(set.get(id).is_none());
+    ///
+    /// let id = ResponseCookieId::new("name").set_path("/");
+    /// // You need to specify a matching path to get the cookie we inserted above.
+    /// assert_eq!(set.get(id).map(|c| c.value()), Some("value"));
+    /// ```
+    ///
+    /// # Via name
+    ///
+    /// ```rust
+    /// use pavex::cookie::{ResponseCookies, ResponseCookie, ResponseCookieId};
+    ///
+    /// let mut set = ResponseCookies::new();
+    /// assert!(set.get("name").is_none());
+    ///
+    /// let cookie = ResponseCookie::new("name", "value");
+    /// set.insert(cookie);
+    ///
+    /// // By specifying just the name, the domain and path are assumed to be None.
+    /// assert_eq!(set.get("name").map(|c| c.value()), Some("value"));
+    /// ```
+    pub fn get<'map, 'key, Key>(&'map self, id: Key) -> Option<&'map ResponseCookie<'static>>
+    where
+        Key: Into<ResponseCookieId<'key>>,
+    {
+        self.0.get(id)
+    }
+
+    /// Inserts `cookie` into this set.
+    /// If a cookie with the same [`ResponseCookieId`] already
+    /// exists, it is replaced with `cookie` and the old cookie is returned.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pavex::cookie::{ResponseCookies, ResponseCookie, ResponseCookieId};
+    ///
+    /// let mut set = ResponseCookies::new();
+    /// set.insert(("name", "value"));
+    /// set.insert(("second", "two"));
+    /// // Replaces the "second" cookie with a new one.
+    /// assert!(set.insert(("second", "three")).is_some());
+    ///
+    /// assert_eq!(set.get("name").map(|c| c.value()), Some("value"));
+    /// assert_eq!(set.get("second").map(|c| c.value()), Some("three"));
+    /// assert_eq!(set.iter().count(), 2);
+    ///
+    /// // If we insert another cookie with name "second", but different domain and path,
+    /// // it won't replace the existing one.
+    /// let cookie = ResponseCookie::new("second", "four").set_domain("rust-lang.org");
+    /// set.insert(cookie);
+    ///
+    /// assert_eq!(set.get("second").map(|c| c.value()), Some("three"));
+    /// let id = ResponseCookieId::new("second").set_domain("rust-lang.org");
+    /// assert_eq!(set.get(id).map(|c| c.value()), Some("four"));
+    /// assert_eq!(set.iter().count(), 3);
+    /// ```
+    pub fn insert<C>(&mut self, cookie: C) -> Option<ResponseCookie<'static>>
+    where
+        C: Into<ResponseCookie<'static>>,
+    {
+        self.0.insert(cookie)
+    }
+
+    /// Discard `cookie` from this set.
+    ///
+    /// **`discard` does not instruct the client to remove the cookie**.
+    /// You need to insert a [`RemovalCookie`] into [`ResponseCookies`] to do that.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pavex::cookie::{ResponseCookies, ResponseCookie};
+    ///
+    /// let mut set = ResponseCookies::new();
+    /// set.insert(("second", "two"));
+    /// set.discard("second");
+    ///
+    /// assert!(set.get("second").is_none());
+    /// assert_eq!(set.iter().count(), 0);
+    /// ```
+    ///
+    /// # Example with path and domain
+    ///
+    /// A cookie is identified by its name, domain, and path.
+    /// If you want to discard a cookie with a non-empty domain and/or path, you need to specify them.
+    ///
+    /// ```rust
+    /// use pavex::cookie::{ResponseCookies, ResponseCookie, ResponseCookieId};
+    ///
+    /// let mut set = ResponseCookies::new();
+    /// let cookie = ResponseCookie::new("name", "value").set_domain("rust-lang.org").set_path("/");
+    /// let id = cookie.id();
+    /// set.insert((cookie));
+    ///
+    /// // This won't discard the cookie because the path and the domain don't match.
+    /// set.discard("second");
+    /// assert_eq!(set.iter().count(), 1);
+    /// assert!(set.get(id).is_some());
+    ///
+    /// // This will discard the cookie because the name, the path and the domain match.
+    /// let id = ResponseCookieId::new("name").set_domain("rust-lang.org").set_path("/");
+    /// set.discard(id);
+    /// assert_eq!(set.iter().count(), 0);
+    /// ```
+    ///
+    /// [`RemovalCookie`]: crate::RemovalCookie
+    pub fn discard<'map, 'key, Key>(&'map mut self, id: Key)
+    where
+        Key: Into<ResponseCookieId<'key>>,
+    {
+        self.0.discard(id)
+    }
+
+    /// Returns an iterator over all the cookies present in this set.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pavex::cookie::{ResponseCookies, ResponseCookie};
+    ///
+    /// let mut set = ResponseCookies::new();
+    ///
+    /// set.insert(("name", "value"));
+    /// set.insert(("second", "two"));
+    /// set.insert(("new", "third"));
+    /// set.insert(("another", "fourth"));
+    /// set.insert(("yac", "fifth"));
+    ///
+    /// set.discard("name");
+    /// set.discard("another");
+    ///
+    /// // There are three cookies in the set: "second", "new", and "yac".
+    /// # assert_eq!(set.iter().count(), 3);
+    /// for cookie in set.iter() {
+    ///     match cookie.name() {
+    ///         "second" => assert_eq!(cookie.value(), "two"),
+    ///         "new" => assert_eq!(cookie.value(), "third"),
+    ///         "yac" => assert_eq!(cookie.value(), "fifth"),
+    ///         _ => unreachable!("there are only three cookies in the set")
+    ///     }
+    /// }
+    /// ```
+    pub fn iter(&self) -> ResponseCookiesIter {
+        ResponseCookiesIter {
+            cookies: self.0.iter(),
+        }
+    }
+
+    /// Returns the values that should be sent to the client as `Set-Cookie` headers.
+    pub fn header_values<'a>(self, processor: &'a Processor) -> impl Iterator<Item = String> + 'a {
+        self.0.header_values(processor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ResponseCookies;
+
+    #[test]
+    #[allow(deprecated)]
+    fn simple() {
+        let mut c = ResponseCookies::new();
+
+        c.insert(("test", ""));
+        c.insert(("test2", ""));
+        c.discard("test");
+
+        assert!(c.get("test").is_none());
+        assert!(c.get("test2").is_some());
+
+        c.insert(("test3", ""));
+        c.discard("test2");
+        c.discard("test3");
+
+        assert!(c.get("test").is_none());
+        assert!(c.get("test2").is_none());
+        assert!(c.get("test3").is_none());
+    }
+
+    #[test]
+    fn set_is_send() {
+        fn is_send<T: Send>(_: T) -> bool {
+            true
+        }
+
+        assert!(is_send(ResponseCookies::new()))
+    }
+}

--- a/libs/pavex/src/error/error_.rs
+++ b/libs/pavex/src/error/error_.rs
@@ -1,4 +1,3 @@
-//! The error type used by Pavex for runtime failures.
 // Most of this module is a direct copy (with, from time to time,
 // minor modifications) of the corresponding `error` module in
 // `axum-core`.
@@ -31,7 +30,7 @@
 use std::fmt;
 
 /// Pavex's error type: an opaque wrapper around the concrete error type
-/// return by your components (e.g. request handlers, constructors, etc.).  
+/// return by your components (e.g. request handlers, constructors, etc.).
 /// It is used as an input parameter by
 /// [error observers](https://pavex.dev/docs/guide/errors/error_observers/) and
 /// [universal error handlers](https://pavex.dev/docs/guide/errors/error_handlers/#universal).
@@ -52,8 +51,8 @@ pub struct Error {
 impl Error {
     /// Create a new [`Error`] from a boxable error.
     pub fn new<E>(error: E) -> Self
-    where
-        E: Into<Box<dyn std::error::Error + Send + Sync>>,
+        where
+            E: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
         Self {
             inner: error.into(),

--- a/libs/pavex/src/error/mod.rs
+++ b/libs/pavex/src/error/mod.rs
@@ -1,0 +1,96 @@
+//! Error handling utilities.
+pub(crate) mod error_;
+
+/// When things went wrong, but you don't know why.
+///
+/// `UnexpectedError` is designed for failure scenarios
+/// that the application wasn't explicitly prepared to handle.
+/// It works, in particular, as the "catch-all" variant in
+/// an error enum.
+///
+/// # Example
+///
+/// ```rust
+/// use pavex::error::UnexpectedError;
+/// use pavex::response::Response;
+/// # #[derive(Debug)] struct AuthorizationError;
+/// # #[derive(Debug)] struct DatabaseError;
+/// # impl std::fmt::Display for AuthorizationError {
+/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+/// #         write!(f, "Authorization error")
+/// #     }
+/// # }
+/// # impl std::fmt::Display for DatabaseError {
+/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+/// #         write!(f, "Database error")
+/// #     }
+/// # }
+/// # impl std::error::Error for AuthorizationError {}
+/// # impl std::error::Error for DatabaseError {}
+///
+/// #[derive(Debug, thiserror::Error)]
+/// pub enum HandlerError {
+///     // One variant for each kind of known issue
+///     // that might occur in the request handler.
+///     #[error(transparent)]
+///     Authorization(#[from] AuthorizationError),
+///     #[error(transparent)]
+///     Database(#[from] DatabaseError),
+///     // [...]
+///     // Followed by the catch-all variant.
+///     #[error(transparent)]
+///     Unexpected(#[from] UnexpectedError),
+/// }
+///
+/// pub async fn request_handler() -> Result<Response, HandlerError> {
+///     // [...]
+/// # todo!()
+/// }
+/// ```
+///
+/// # Error message
+///
+/// The error message is always the same when using `UnexpectedError`:
+/// "An unexpected error occurred".
+/// This is intentional, as we don't want to leak any sensitive information
+/// or implementation details to the client.
+/// The full error details are still available when walking the source error chain and
+/// will be captured in your logs if you have a suitable error observer in place.
+#[derive(Debug)]
+pub struct UnexpectedError {
+    inner: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl UnexpectedError {
+    /// Create a new [`UnexpectedError`] from a boxable error.
+    pub fn new<E>(error: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        Self {
+            inner: error.into(),
+        }
+    }
+
+    /// Convert [`UnexpectedError`] back into the underlying boxed error.
+    pub fn into_inner(self) -> Box<dyn std::error::Error + Send + Sync> {
+        self.inner
+    }
+
+    /// Return a reference to the underlying boxed error.
+    pub fn inner_ref(&self) -> &(dyn std::error::Error + Send + Sync) {
+        &*self.inner
+    }
+}
+
+impl std::fmt::Display for UnexpectedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "An unexpected error occurred")
+    }
+}
+
+impl std::error::Error for UnexpectedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&*self.inner)
+    }
+}

--- a/libs/pavex/src/lib.rs
+++ b/libs/pavex/src/lib.rs
@@ -13,6 +13,8 @@
 pub use error::Error;
 
 pub mod blueprint;
+#[cfg(feature = "cookie")]
+pub mod cookie;
 mod error;
 pub mod http;
 pub mod kit;
@@ -25,3 +27,9 @@ pub mod serialization;
 pub mod server;
 pub mod telemetry;
 pub mod unit;
+pub mod time {
+    //! Utilities to work with dates, timestamps and datetimes.
+    //!
+    //! It's a re-export of the [`time@0.3`](https://docs.rs/time/0.3) crate.
+    pub use time::*;
+}

--- a/libs/pavex/src/lib.rs
+++ b/libs/pavex/src/lib.rs
@@ -9,13 +9,12 @@
 //! [quickstart tutorial](https://pavex.dev/docs/getting_started/quickstart/)
 //! to get you up and running with the framework in no time.
 
-// Re-export the dependencies that we use in the generated application code.
-pub use error::Error;
+pub use error::error_::Error;
 
 pub mod blueprint;
 #[cfg(feature = "cookie")]
 pub mod cookie;
-mod error;
+pub mod error;
 pub mod http;
 pub mod kit;
 pub mod middleware;


### PR DESCRIPTION
We re-export `biscotti` as our cookie API, with one key difference: we don't re-export `ResponseCookies` as is.
We instead expose our own `ResponseCookies` type that wraps around `biscotti`'s one, constraining its generic lifetime to be `'static` since that's what the vast majority of applications will need.

The integration is not yet ready for prime time—we need a section in the guide. But that'll come in a follow-up PR.

Other changes:

- Pavex gained a top-level `error` module, where I added an `UnexpectedError` type. Almost any application defines one as a "catch-all" error variant, therefore it looked like a win to make it first-party since we need it anyway for our own error enums.