### PR TITLE
Ensure ordering of error variants for ApplicationStateError

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2612,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",

--- a/libs/pavexc/src/compiler/analyses/call_graph/application_state.rs
+++ b/libs/pavexc/src/compiler/analyses/call_graph/application_state.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use ahash::{HashMap, HashMapExt, HashSet};
+use ahash::{HashMap, HashMapExt};
 use bimap::BiHashMap;
 use convert_case::{Case, Casing};
 use guppy::graph::PackageGraph;
@@ -122,7 +122,7 @@ pub(crate) fn application_state_call_graph(
 
     // Let's start by collecting the possible error types.
     let error_type2err_match_ids = {
-        let mut map = IndexMap::<_, HashSet<ComponentId>>::new();
+        let mut map = IndexMap::<_, BTreeSet<ComponentId>>::new();
         let mut output_node_indexes = call_graph
             .externals(Direction::Outgoing)
             .collect::<BTreeSet<_>>();
@@ -235,7 +235,7 @@ pub(crate) fn application_state_call_graph(
             computation_db,
         );
 
-        let mut error_variants = IndexMap::new();
+        let mut error_variants = BTreeMap::new();
         let mut collision_map = HashMap::<_, usize>::new();
         for (error_type, err_match_ids) in &error_type2err_match_ids {
             for err_match_id in err_match_ids {
@@ -357,7 +357,7 @@ pub(crate) fn application_state_call_graph(
     )?;
     Ok(ApplicationStateCallGraph {
         call_graph,
-        error_variants,
+        error_variants: error_variants.into_iter().collect(),
     })
 }
 


### PR DESCRIPTION
There was an iteration over a `HashSet` resulting in inconsistent ordering when multiple variants are present.