### PR TITLE
feat: Server request id is now represented as a TypeId

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -151,6 +151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +1938,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "type-safe-id",
  "ubyte",
  "uuid",
  "workspace_hack",
@@ -3413,6 +3420,18 @@ dependencies = [
  "serde_json",
  "termcolor",
  "toml",
+]
+
+[[package]]
+name = "type-safe-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1211a53644c6a5ae26c45bdd520d1533b07dab50dc6af1a15063772f9061ad"
+dependencies = [
+ "arrayvec",
+ "rand",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "toml",
  "tracing",
  "walkdir",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -1933,6 +1934,7 @@ dependencies = [
  "tracing",
  "ubyte",
  "uuid",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -1941,6 +1943,7 @@ version = "0.1.32"
 dependencies = [
  "pavex_reflection",
  "serde",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -1982,6 +1985,7 @@ dependencies = [
  "ureq",
  "vergen",
  "windows-sys 0.52.0",
+ "workspace_hack",
  "xdg-home",
  "xz2",
  "zip",
@@ -1994,6 +1998,7 @@ dependencies = [
  "anyhow",
  "pavex",
  "thiserror",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -2006,6 +2011,7 @@ dependencies = [
  "serde",
  "syn",
  "trybuild",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -2026,6 +2032,7 @@ dependencies = [
  "terminal_size",
  "textwrap",
  "unicode-width",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -2033,6 +2040,7 @@ name = "pavex_reflection"
 version = "0.1.32"
 dependencies = [
  "serde",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -2060,6 +2068,7 @@ dependencies = [
  "toml",
  "tracing-subscriber",
  "walkdir",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -2068,6 +2077,7 @@ version = "0.1.32"
 dependencies = [
  "pavex",
  "tracing",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -2114,6 +2124,7 @@ dependencies = [
  "toml_edit 0.21.1",
  "tracing",
  "vergen",
+ "workspace_hack",
  "xdg-home",
 ]
 
@@ -2140,6 +2151,7 @@ dependencies = [
  "tracing-chrome",
  "tracing-subscriber",
  "vergen",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -2149,6 +2161,7 @@ dependencies = [
  "anyhow",
  "pavex",
  "thiserror",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -2177,6 +2190,7 @@ dependencies = [
  "fs-err",
  "sha2",
  "tracing",
+ "workspace_hack",
 ]
 
 [[package]]
@@ -3924,6 +3938,46 @@ dependencies = [
 [[package]]
 name = "workspace_hack"
 version = "0.1.0"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "bitflags 2.5.0",
+ "cc",
+ "clap",
+ "clap_builder",
+ "console",
+ "crossbeam-utils",
+ "crypto-common",
+ "deranged",
+ "digest",
+ "fixedbitset",
+ "getrandom",
+ "hashbrown 0.14.3",
+ "hmac",
+ "indexmap",
+ "log",
+ "memchr",
+ "miette",
+ "petgraph",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "subtle",
+ "syn",
+ "time",
+ "time-macros",
+ "tokio",
+ "toml",
+ "tracing-core",
+ "uuid",
+ "zeroize",
+]
 
 [[package]]
 name = "xattr"

--- a/libs/generate_from_path/Cargo.toml
+++ b/libs/generate_from_path/Cargo.toml
@@ -20,3 +20,4 @@ indicatif = "0.17.7"
 walkdir = "2.4.0"
 sanitize-filename = "0.5"
 regex = "1.10.2"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -57,6 +57,7 @@ biscotti = { version = "0.3", optional = true }
 
 # Server request id
 uuid = { version = "1", features = ["v7"], optional = true }
+type-safe-id = "0.2.1"
 
 # Time facilities
 time = { version = "0.3", features = ["serde"], optional = true }

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -66,6 +66,7 @@ hyper = { version = "1", features = ["full"], optional = true }
 hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto"], optional = true }
 socket2 = { version = "0.5.3", optional = true }
 smallvec = "1"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }

--- a/libs/pavex/src/telemetry/server_request_id.rs
+++ b/libs/pavex/src/telemetry/server_request_id.rs
@@ -3,9 +3,21 @@ use crate::blueprint::Blueprint;
 use crate::f;
 use crate::http::HeaderValue;
 use std::fmt::Formatter;
+use std::hash::{Hash, Hasher};
+use type_safe_id::{StaticType, TypeSafeId};
 use uuid::Uuid;
 
 /// A unique identifier generated for each incoming request.
+///
+/// It is a [TypeId](https://github.com/jetify-com/typeid).
+/// The prefix is always `sri`, followed by an underscore and UUIDv7 in base32 encoding.
+/// For example:
+///
+/// ```text
+///  sri_2x4y6z8a0b1c2d3e4f5g6h7j8k
+///  └─┘ └────────────────────────┘
+/// prefix    uuid suffix (base32)
+/// ```
 ///
 /// # Example
 ///
@@ -23,8 +35,21 @@ use uuid::Uuid;
 ///         )
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct ServerRequestId(Uuid);
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ServerRequestId(TypeSafeId<SriTag>);
+
+impl Hash for ServerRequestId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.uuid().hash(state)
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct SriTag;
+
+impl StaticType for SriTag {
+    const TYPE: &'static str = "sri";
+}
 
 impl ServerRequestId {
     /// The default constructor for [`ServerRequestId`].
@@ -32,25 +57,25 @@ impl ServerRequestId {
     /// It generates a new request id using a [UUID v7](https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04#name-uuid-version-7),
     /// with a random number and the current (UNIX) timestamp.
     pub fn generate() -> Self {
-        Self(Uuid::now_v7())
+        Self(TypeSafeId::from_uuid(Uuid::now_v7()))
     }
 
     /// Access the underlying UUID.
     pub fn inner(&self) -> Uuid {
-        self.0
+        self.0.uuid()
     }
 
     /// Return a [hyphenated representation](https://docs.rs/uuid/1.7.0/uuid/struct.Uuid.html#formatting)
     /// of [`ServerRequestId`] to be used as a [`HeaderValue`].
     pub fn header_value(&self) -> HeaderValue {
-        // The hyphenated representation of a UUID is always a valid header value.
-        format!("{self}").try_into().unwrap()
+        // It is always a valid header value.
+        self.0.to_string().try_into().unwrap()
     }
 }
 
 impl From<Uuid> for ServerRequestId {
     fn from(value: Uuid) -> Self {
-        Self(value)
+        Self(TypeSafeId::from_uuid(value))
     }
 }
 
@@ -71,5 +96,20 @@ impl ServerRequestId {
     /// The [default constructor](Self::generate) for [`ServerRequestId`].
     pub fn default_constructor() -> Constructor {
         Constructor::request_scoped(f!(super::ServerRequestId::generate))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_request_id() {
+        let request_id = ServerRequestId::generate();
+        let header_value = request_id.header_value();
+        let header_value = header_value.to_str().unwrap();
+        assert!(header_value.starts_with("sri_"));
+        // Prefix + `_` + UUID in base32 encoding
+        assert_eq!(header_value.len(), 3 + 1 + 26)
     }
 }

--- a/libs/pavex_bp_schema/Cargo.toml
+++ b/libs/pavex_bp_schema/Cargo.toml
@@ -10,3 +10,4 @@ license.workspace = true
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 pavex_reflection = { path = "../pavex_reflection", version = "=0.1.32" }
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -54,6 +54,7 @@ secrecy = { version = "0.8.0", features = ["serde"] }
 clap-stdin = "0.4.0"
 owo-colors = "4.0.0"
 anstyle = "1.0.6"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }
 
 [dev-dependencies]
 pavex_test_runner = { path = "../pavex_test_runner" }

--- a/libs/pavex_cli_client/Cargo.toml
+++ b/libs/pavex_cli_client/Cargo.toml
@@ -11,3 +11,4 @@ license.workspace = true
 anyhow = "1"
 pavex = { path = "../pavex", version = "0.1.32" }
 thiserror = "1.0.56"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/pavex_macros/Cargo.toml
+++ b/libs/pavex_macros/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/libs/pavex_miette/Cargo.toml
+++ b/libs/pavex_miette/Cargo.toml
@@ -16,3 +16,4 @@ supports-hyperlinks = { version = "3.0.0" }
 supports-color = { version = "3.0.0" }
 supports-unicode = { version = "3.0.0" }
 terminal_size = { version = "0.3" }
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/pavex_reflection/Cargo.toml
+++ b/libs/pavex_reflection/Cargo.toml
@@ -9,3 +9,4 @@ license.workspace = true
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/pavex_test_runner/Cargo.toml
+++ b/libs/pavex_test_runner/Cargo.toml
@@ -37,3 +37,4 @@ globwalk = "0.9.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 regex = "1.10.2"
 once_cell = "1.19.0"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/pavex_tracing/Cargo.toml
+++ b/libs/pavex_tracing/Cargo.toml
@@ -12,3 +12,4 @@ readme = "README.md"
 [dependencies]
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 pavex = { version = "0.1.32", path = "../pavex" }
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/pavexc/Cargo.toml
+++ b/libs/pavexc/Cargo.toml
@@ -60,3 +60,4 @@ r2d2 = "0.8"
 bincode = "1"
 rayon = "1.7"
 num_cpus = "1.15.0"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/pavexc_cli/Cargo.toml
+++ b/libs/pavexc_cli/Cargo.toml
@@ -31,6 +31,7 @@ ron = "0.8"
 generate_from_path = { path = "../generate_from_path", version = "0.1.32" }
 tempfile = "3.9.0"
 better-panic = "0.3.0"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }
 
 [build-dependencies]
 vergen = { workspace = true }

--- a/libs/pavexc_cli_client/Cargo.toml
+++ b/libs/pavexc_cli_client/Cargo.toml
@@ -11,3 +11,4 @@ license.workspace = true
 anyhow = "1"
 pavex = { path = "../pavex", version = "0.1.32" }
 thiserror = "1.0.56"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/persist_if_changed/Cargo.toml
+++ b/libs/persist_if_changed/Cargo.toml
@@ -12,3 +12,4 @@ tracing = "0.1"
 fs-err = "2.7"
 sha2 = "0.10"
 anyhow = "1"
+workspace_hack = { version = "0.1", path = "../workspace_hack" }

--- a/libs/workspace_hack/Cargo.toml
+++ b/libs/workspace_hack/Cargo.toml
@@ -14,8 +14,82 @@ publish = false
 # are managed by hakari.
 
 ### BEGIN HAKARI SECTION
+[dependencies]
+ahash = { version = "0.8" }
+aho-corasick = { version = "1" }
+bitflags = { version = "2", default-features = false, features = ["serde"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+console = { version = "0.15" }
+crossbeam-utils = { version = "0.8" }
+crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
+deranged = { version = "0.3", default-features = false, features = ["powerfmt", "serde", "std"] }
+digest = { version = "0.10", features = ["mac", "std"] }
+fixedbitset = { version = "0.4" }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
+hashbrown = { version = "0.14", features = ["raw"] }
+hmac = { version = "0.12", default-features = false, features = ["reset"] }
+indexmap = { version = "2", features = ["serde"] }
+log = { version = "0.4", default-features = false, features = ["std"] }
+memchr = { version = "2" }
+miette = { version = "6", features = ["fancy"] }
+petgraph = { version = "0.6", default-features = false, features = ["graphmap", "stable_graph"] }
+proc-macro2 = { version = "1", features = ["span-locations"] }
+quote = { version = "1" }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa", "perf", "unicode"] }
+regex-syntax = { version = "0.8" }
+serde = { version = "1", features = ["alloc", "derive"] }
+serde_json = { version = "1", features = ["unbounded_depth"] }
+sha2 = { version = "0.10" }
+smallvec = { version = "1", default-features = false, features = ["const_new"] }
+subtle = { version = "2" }
+syn = { version = "2", features = ["extra-traits", "full", "visit", "visit-mut"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing", "serde"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
+toml = { version = "0.8", features = ["preserve_order"] }
+tracing-core = { version = "0.1" }
+uuid = { version = "1", features = ["fast-rng", "v4", "v7"] }
+zeroize = { version = "1" }
 
-# Disabled by running `cargo hakari disable`.
-# To re-enable, run:
-#     cargo hakari generate
+[build-dependencies]
+ahash = { version = "0.8" }
+aho-corasick = { version = "1" }
+bitflags = { version = "2", default-features = false, features = ["serde"] }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+console = { version = "0.15" }
+crossbeam-utils = { version = "0.8" }
+crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
+deranged = { version = "0.3", default-features = false, features = ["powerfmt", "serde", "std"] }
+digest = { version = "0.10", features = ["mac", "std"] }
+fixedbitset = { version = "0.4" }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
+hashbrown = { version = "0.14", features = ["raw"] }
+hmac = { version = "0.12", default-features = false, features = ["reset"] }
+indexmap = { version = "2", features = ["serde"] }
+log = { version = "0.4", default-features = false, features = ["std"] }
+memchr = { version = "2" }
+miette = { version = "6", features = ["fancy"] }
+petgraph = { version = "0.6", default-features = false, features = ["graphmap", "stable_graph"] }
+proc-macro2 = { version = "1", features = ["span-locations"] }
+quote = { version = "1" }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa", "perf", "unicode"] }
+regex-syntax = { version = "0.8" }
+serde = { version = "1", features = ["alloc", "derive"] }
+serde_json = { version = "1", features = ["unbounded_depth"] }
+sha2 = { version = "0.10" }
+smallvec = { version = "1", default-features = false, features = ["const_new"] }
+subtle = { version = "2" }
+syn = { version = "2", features = ["extra-traits", "full", "visit", "visit-mut"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing", "serde"] }
+time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing", "serde"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
+toml = { version = "0.8", features = ["preserve_order"] }
+tracing-core = { version = "0.1" }
+uuid = { version = "1", features = ["fast-rng", "v4", "v7"] }
+zeroize = { version = "1" }
+
 ### END HAKARI SECTION


### PR DESCRIPTION
A TypeId lets us keep all the desirable properties of a UUIDv7 (k-sortable, globally unique), with the addition of type safety (i.e. you can recognise at a glance, thanks to the prefix, if you're looking at the id for a certain resource type).
We use `sri` as prefix for the server request id.