### PR TITLE
Use Unix path separator in Cargo.toml manifests when specifying path dependencies

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2097,7 +2097,6 @@ dependencies = [
  "miette",
  "num_cpus",
  "once_cell",
- "pathdiff",
  "pavex",
  "pavex_bp_schema",
  "pavex_matchit",
@@ -2109,6 +2108,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "rayon",
+ "relative-path",
  "rusqlite",
  "rustdoc-types",
  "semver",
@@ -2479,6 +2479,12 @@ name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "remove_dir_all"

--- a/libs/pavexc/Cargo.toml
+++ b/libs/pavexc/Cargo.toml
@@ -38,7 +38,6 @@ miette = { version = "6.0.1" }
 guppy = "0.17"
 itertools = "0.12"
 cargo-manifest = "0.13.0"
-pathdiff = "0.2.1"
 elsa = "1.4.0"
 tracing = "0.1"
 fixedbitset = "0.4.2"
@@ -51,6 +50,7 @@ toml_edit = { version = "0.21", features = ["serde"] }
 semver = "1.0.17"
 persist_if_changed = { path = "../persist_if_changed", version = "0.1.33" }
 matchit = { version = "0.7", package = "pavex_matchit" }
+relative-path = "1.9"
 
 # Sqlite cache
 xdg-home = "1.0.0"

--- a/libs/pavexc/src/compiler/codegen.rs
+++ b/libs/pavexc/src/compiler/codegen.rs
@@ -634,10 +634,12 @@ where
             let metadata = package_graph.metadata(package_id).unwrap();
             let version = metadata.version();
             let mut dependency_details = DependencyDetail {
-                package: Some(name.to_string()),
                 version: Some(version.to_string()),
                 ..DependencyDetail::default()
             };
+            if needs_rename {
+                dependency_details.package = Some(name.to_string());
+            }
 
             let source = metadata.source();
             match source {


### PR DESCRIPTION
This ensures that paths will resolve on all platforms, Windows included.