### PR TITLE
feat: Rework CLI introspections

### DIFF
--- a/libs/pavex_cli/src/command.rs
+++ b/libs/pavex_cli/src/command.rs
@@ -5,20 +5,55 @@ use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+const INTROSPECTION_HEADING: &str = "Introspection";
+
 #[derive(Parser)]
-#[clap(author, version = VERSION, about, long_about = None)]
+#[clap(
+    author,
+    version = VERSION, about,
+    long_about = None,
+    after_long_help = "Use `pavex -h` rather than `pavex --help` for a more concise summary of the available options."
+)]
 pub struct Cli {
-    /// Pavex will expose the full error chain when reporting diagnostics.
-    ///
-    /// It will also emit tracing output, both to stdout and to disk.
-    /// The file serialized on disk (`trace-[...].json`) can be opened in
-    /// Google Chrome by visiting chrome://tracing for further analysis.
-    #[clap(long, env = "PAVEX_DEBUG")]
-    pub debug: bool,
     #[clap(long, env = "PAVEX_COLOR", default_value_t = Color::Auto)]
+    /// Color settings for the CLI output: auto, always, never.
     pub color: Color,
     #[clap(subcommand)]
     pub command: Command,
+    #[clap(
+        long,
+        env = "PAVEX_DEBUG",
+        help = "Pavex will expose the full error chain when reporting diagnostics.",
+        long_help = "Pavex will expose the full error chain when reporting diagnostics.\nSet `PAVEX_DEBUG=1` to enable this option."
+    )]
+    pub debug: bool,
+    #[clap(
+        long,
+        env = "PAVEX_LOG",
+        help_heading = Some(INTROSPECTION_HEADING),
+        hide_short_help = true,
+        hide_env = true,
+        long_help = "Pavex will emit internal logs to the console.\nSet `PAVEX_LOG=true` to enable this option using an environment variable."
+    )]
+    pub log: bool,
+    #[clap(
+        long,
+        env = "PAVEX_LOG_FILTER",
+        help_heading = Some(INTROSPECTION_HEADING),
+        hide_short_help = true,
+        hide_env = true,
+        long_help = "Control which logs are emitted if `--log` or `--perf-profile` are enabled.\nIf no filter is specified, Pavex will default to `info,pavex=trace`."
+    )]
+    pub log_filter: Option<String>,
+    #[clap(
+        long,
+        env = "PAVEX_PERF_PROFILE",
+        help_heading = Some(INTROSPECTION_HEADING),
+        hide_short_help = true,
+        hide_env = true,
+        long_help = "Pavex will serialize to disk tracing information to profile command execution.\nThe file (`trace-[...].json`) can be opened using https://ui.perfetto.dev/ or in Google Chrome by visiting chrome://tracing.\nSet `PAVEX_PERF_PROFILE=true` to enable this option using an environment variable."
+    )]
+    pub perf_profile: bool,
 }
 
 // Same structure used by `cargo --version`.

--- a/libs/pavex_cli_client/src/client.rs
+++ b/libs/pavex_cli_client/src/client.rs
@@ -128,7 +128,7 @@ impl Client {
 
     /// Enable logging.
     ///
-    /// `pavexc` will emit internal log messages to the console.
+    /// `pavex` will emit internal log messages to the console.
     pub fn log(mut self) -> Self {
         self.log = true;
         self
@@ -136,7 +136,7 @@ impl Client {
 
     /// Disable logging.
     ///
-    /// `pavexc` will not emit internal log messages to the console.
+    /// `pavex` will not emit internal log messages to the console.
     /// This is the default behaviour.
     pub fn no_log(mut self) -> Self {
         self.log = false;
@@ -154,7 +154,7 @@ impl Client {
 
     /// Enable performance profiling.
     ///
-    /// `pavexc` will serialize to disk tracing information to profile command execution.
+    /// `pavex` will serialize to disk tracing information to profile command execution.
     pub fn perf_profile(mut self) -> Self {
         self.perf_profile = true;
         self
@@ -162,7 +162,7 @@ impl Client {
 
     /// Disable performance profiling.
     ///
-    /// `pavexc` will not serialize to disk tracing information to profile command execution.
+    /// `pavex` will not serialize to disk tracing information to profile command execution.
     /// This is the default behaviour.
     pub fn no_perf_profile(mut self) -> Self {
         self.perf_profile = false;

--- a/libs/pavex_cli_client/src/client.rs
+++ b/libs/pavex_cli_client/src/client.rs
@@ -12,6 +12,9 @@ pub struct Client {
     pavex_cli_path: Option<PathBuf>,
     color: Color,
     debug: bool,
+    log: bool,
+    log_filter: Option<String>,
+    perf_profile: bool,
 }
 
 impl Default for Client {
@@ -20,6 +23,9 @@ impl Default for Client {
             pavex_cli_path: None,
             color: Color::Auto,
             debug: false,
+            log: false,
+            log_filter: None,
+            perf_profile: false,
         }
     }
 }
@@ -48,6 +54,18 @@ impl Client {
 
         if self.debug {
             cmd.arg("--debug");
+        }
+
+        if self.log {
+            cmd.arg("--log");
+        }
+
+        if let Some(filter) = self.log_filter {
+            cmd.arg("--log-filter").arg(filter);
+        }
+
+        if self.perf_profile {
+            cmd.arg("--perf-profile");
         }
 
         cmd
@@ -106,5 +124,48 @@ impl Client {
     pub fn new_command(self, path: PathBuf) -> NewBuilder {
         let cmd = self.command();
         NewBuilder::new(cmd, path)
+    }
+
+    /// Enable logging.
+    ///
+    /// `pavexc` will emit internal log messages to the console.
+    pub fn log(mut self) -> Self {
+        self.log = true;
+        self
+    }
+
+    /// Disable logging.
+    ///
+    /// `pavexc` will not emit internal log messages to the console.
+    /// This is the default behaviour.
+    pub fn no_log(mut self) -> Self {
+        self.log = false;
+        self
+    }
+
+    /// Set the log filter.
+    ///
+    /// Control which logs are emitted if `--log` or `--perf-profile` are enabled.
+    /// If no filter is specified, Pavex will default to `info,pavex=trace`.
+    pub fn log_filter(mut self, filter: String) -> Self {
+        self.log_filter = Some(filter);
+        self
+    }
+
+    /// Enable performance profiling.
+    ///
+    /// `pavexc` will serialize to disk tracing information to profile command execution.
+    pub fn perf_profile(mut self) -> Self {
+        self.perf_profile = true;
+        self
+    }
+
+    /// Disable performance profiling.
+    ///
+    /// `pavexc` will not serialize to disk tracing information to profile command execution.
+    /// This is the default behaviour.
+    pub fn no_perf_profile(mut self) -> Self {
+        self.perf_profile = false;
+        self
     }
 }

--- a/libs/pavex_cli_client/src/commands/generate.rs
+++ b/libs/pavex_cli_client/src/commands/generate.rs
@@ -68,7 +68,7 @@ impl GenerateBuilder {
     ///
     /// This method can be useful if you need to customize the command before running it.  
     /// If that's not your usecase, consider using [`GenerateBuilder::execute`] instead.
-    pub fn command(mut self) -> Result<std::process::Command, BlueprintPersistenceError> {
+    pub fn command(mut self) -> Result<Command, BlueprintPersistenceError> {
         // TODO: Pass the blueprint via `stdin` instead of writing it to a file.
         let bp_path = self.output_directory.join("blueprint.ron");
         self.blueprint

--- a/libs/pavexc_cli/src/main.rs
+++ b/libs/pavexc_cli/src/main.rs
@@ -138,6 +138,13 @@ fn init_telemetry(
         });
     let base = tracing_subscriber::registry().with(filter_layer);
     let mut chrome_guard = None;
+    let trace_filename = format!(
+        "./trace-pavexc-{}.json",
+        std::time::SystemTime::UNIX_EPOCH
+            .elapsed()
+            .unwrap()
+            .as_millis()
+    );
 
     match console_logging {
         true => {
@@ -147,7 +154,10 @@ fn init_telemetry(
                 .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .with_timer(tracing_subscriber::fmt::time::uptime());
             if profiling {
-                let (chrome_layer, guard) = ChromeLayerBuilder::new().include_args(true).build();
+                let (chrome_layer, guard) = ChromeLayerBuilder::new()
+                    .file(trace_filename)
+                    .include_args(true)
+                    .build();
                 chrome_guard = Some(guard);
                 base.with(fmt_layer).with(chrome_layer).init();
             } else {
@@ -156,7 +166,10 @@ fn init_telemetry(
         }
         false => {
             if profiling {
-                let (chrome_layer, guard) = ChromeLayerBuilder::new().include_args(true).build();
+                let (chrome_layer, guard) = ChromeLayerBuilder::new()
+                    .file(trace_filename)
+                    .include_args(true)
+                    .build();
                 chrome_guard = Some(guard);
                 base.with(chrome_layer).init()
             }

--- a/libs/pavexc_cli/src/main.rs
+++ b/libs/pavexc_cli/src/main.rs
@@ -17,20 +17,49 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
+const INTROSPECTION_HEADING: &str = "Introspection";
+
 #[derive(Parser)]
 #[clap(author, version = VERSION, about, long_about = None)]
 struct Cli {
-    /// Pavex will expose the full error chain when reporting diagnostics.
-    ///
-    /// It will also emit tracing output, both to stdout and to disk.
-    /// The file serialized on disk (`trace-[...].json`) can be opened in
-    /// Google Chrome by visiting chrome://tracing for further analysis.
-    #[clap(long, env = "PAVEXC_DEBUG")]
-    debug: bool,
     #[clap(long, env = "PAVEXC_COLOR", default_value_t = Color::Auto)]
     color: Color,
     #[clap(subcommand)]
     command: Commands,
+    #[clap(
+        long,
+        env = "PAVEXC_DEBUG",
+        help = "Pavexc will expose the full error chain when reporting diagnostics.",
+        long_help = "Pavexc will expose the full error chain when reporting diagnostics.\nSet `PAVEXC_DEBUG=1` to enable this option."
+    )]
+    pub debug: bool,
+    #[clap(
+        long,
+        env = "PAVEXC_LOG",
+        help_heading = Some(INTROSPECTION_HEADING),
+        hide_short_help = true,
+        hide_env = true,
+        long_help = "Pavexc will emit internal logs to the console.\nSet `PAVEXC_LOG=true` to enable this option using an environment variable."
+    )]
+    pub log: bool,
+    #[clap(
+        long,
+        env = "PAVEXC_LOG_FILTER",
+        help_heading = Some(INTROSPECTION_HEADING),
+        hide_short_help = true,
+        hide_env = true,
+        long_help = "Control which logs are emitted if `--log` or `--perf-profile` are enabled.\nIf no filter is specified, Pavexc will default to `info,pavexc=trace`."
+    )]
+    pub log_filter: Option<String>,
+    #[clap(
+        long,
+        env = "PAVEXC_PERF_PROFILE",
+        help_heading = Some(INTROSPECTION_HEADING),
+        hide_short_help = true,
+        hide_env = true,
+        long_help = "Pavexc will serialize to disk tracing information to profile command execution.\nThe file (`trace-[...].json`) can be opened using https://ui.perfetto.dev/ or in Google Chrome by visiting chrome://tracing.\nSet `PAVEXC_PERF_PROFILE=true` to enable this option using an environment variable."
+    )]
+    pub perf_profile: bool,
 }
 
 // Same structure used by `cargo --version`.
@@ -97,23 +126,43 @@ enum Commands {
     },
 }
 
-fn init_telemetry() -> FlushGuard {
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_file(false)
-        .with_target(false)
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-        .with_timer(tracing_subscriber::fmt::time::uptime());
-    let (chrome_layer, guard) = ChromeLayerBuilder::new().include_args(true).build();
-    let filter_layer = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new("info,pavexc=trace"))
-        .unwrap();
+fn init_telemetry(
+    log_filter: Option<String>,
+    console_logging: bool,
+    profiling: bool,
+) -> Option<FlushGuard> {
+    let filter_layer = log_filter
+        .map(|f| EnvFilter::try_new(f).expect("Invalid log filter configuration"))
+        .unwrap_or_else(|| {
+            EnvFilter::try_new("info,pavexc=trace").expect("Invalid log filter configuration")
+        });
+    let base = tracing_subscriber::registry().with(filter_layer);
+    let mut chrome_guard = None;
 
-    tracing_subscriber::registry()
-        .with(filter_layer)
-        .with(fmt_layer)
-        .with(chrome_layer)
-        .init();
-    guard
+    match console_logging {
+        true => {
+            let fmt_layer = tracing_subscriber::fmt::layer()
+                .with_file(false)
+                .with_target(false)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                .with_timer(tracing_subscriber::fmt::time::uptime());
+            if profiling {
+                let (chrome_layer, guard) = ChromeLayerBuilder::new().include_args(true).build();
+                chrome_guard = Some(guard);
+                base.with(fmt_layer).with(chrome_layer).init();
+            } else {
+                base.with(fmt_layer).init();
+            }
+        }
+        false => {
+            if profiling {
+                let (chrome_layer, guard) = ChromeLayerBuilder::new().include_args(true).build();
+                chrome_guard = Some(guard);
+                base.with(chrome_layer).init()
+            }
+        }
+    }
+    chrome_guard
 }
 
 fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
@@ -147,11 +196,7 @@ fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
     .unwrap();
 
     better_panic::install();
-    let _guard = if cli.debug {
-        Some(init_telemetry())
-    } else {
-        None
-    };
+    let _guard = init_telemetry(cli.log_filter, cli.log, cli.perf_profile);
     match cli.command {
         Commands::Generate {
             blueprint,

--- a/libs/pavexc_cli_client/src/client.rs
+++ b/libs/pavexc_cli_client/src/client.rs
@@ -148,7 +148,7 @@ impl Client {
     /// Set the log filter.
     ///
     /// Control which logs are emitted if `--log` or `--perf-profile` are enabled.
-    /// If no filter is specified, Pavex will default to `info,pavex=trace`.
+    /// If no filter is specified, Pavex will default to `info,pavexc=trace`.
     pub fn log_filter(mut self, filter: String) -> Self {
         self.log_filter = Some(filter);
         self

--- a/libs/pavexc_cli_client/src/client.rs
+++ b/libs/pavexc_cli_client/src/client.rs
@@ -10,6 +10,9 @@ pub struct Client {
     pavexc_cli_path: Option<PathBuf>,
     color: Color,
     debug: bool,
+    log: bool,
+    log_filter: Option<String>,
+    perf_profile: bool,
 }
 
 impl Default for Client {
@@ -18,6 +21,9 @@ impl Default for Client {
             pavexc_cli_path: None,
             color: Color::Auto,
             debug: false,
+            log: false,
+            log_filter: None,
+            perf_profile: false,
         }
     }
 }
@@ -46,6 +52,18 @@ impl Client {
 
         if self.debug {
             cmd.arg("--debug");
+        }
+
+        if self.log {
+            cmd.arg("--log");
+        }
+
+        if let Some(filter) = self.log_filter {
+            cmd.arg("--log-filter").arg(filter);
+        }
+
+        if self.perf_profile {
+            cmd.arg("--perf-profile");
         }
 
         cmd
@@ -95,7 +113,7 @@ impl Client {
 
     /// Enable debug mode.
     ///
-    /// This will print additional debug information when running `pavexc` commands.
+    /// `pavexc` will expose the full error chain when reporting diagnostics.
     pub fn debug(mut self) -> Self {
         self.debug = true;
         self
@@ -103,10 +121,53 @@ impl Client {
 
     /// Disable debug mode.
     ///
-    /// `pavexc` will not print additional debug information when running commands.
+    /// `pavexc` will not expose the full error chain when reporting diagnostics.
     /// This is the default behaviour.
     pub fn no_debug(mut self) -> Self {
         self.debug = false;
+        self
+    }
+
+    /// Enable logging.
+    ///
+    /// `pavexc` will emit internal log messages to the console.
+    pub fn log(mut self) -> Self {
+        self.log = true;
+        self
+    }
+
+    /// Disable logging.
+    ///
+    /// `pavexc` will not emit internal log messages to the console.
+    /// This is the default behaviour.
+    pub fn no_log(mut self) -> Self {
+        self.log = false;
+        self
+    }
+
+    /// Set the log filter.
+    ///
+    /// Control which logs are emitted if `--log` or `--perf-profile` are enabled.
+    /// If no filter is specified, Pavex will default to `info,pavex=trace`.
+    pub fn log_filter(mut self, filter: String) -> Self {
+        self.log_filter = Some(filter);
+        self
+    }
+
+    /// Enable performance profiling.
+    ///
+    /// `pavexc` will serialize to disk tracing information to profile command execution.
+    pub fn perf_profile(mut self) -> Self {
+        self.perf_profile = true;
+        self
+    }
+
+    /// Disable performance profiling.
+    ///
+    /// `pavexc` will not serialize to disk tracing information to profile command execution.
+    /// This is the default behaviour.
+    pub fn no_perf_profile(mut self) -> Self {
+        self.perf_profile = false;
         self
     }
 }


### PR DESCRIPTION
`--debug` was a very overloaded CLI flag: it rendered the full diagnostic error chain, exported perf profiling info and enabled internal logging.
In most cases, that's undesirable:

- Users will _often_ reach for the full diagnostic error chain
- Maintainers, instead, will look for perf profiles and internal logging

To better accommodate these usage patterns, `--debug` will now be limited to diagnostic error chains.
We introduce `--perf-profile` to emit trace files, `--log` for internal logging and an explicit `--log-filter` to configure what gets logged.