### PR TITLE
Add status_mut() function to Response

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@ We contributors to Pavex:
 * Harry Barber (@hlbarber)
 * Jan Ehrhardt (@jehrhardt)
 * Lukas Slanius (@bosukas)
+* Ben Wishovich (@benwis)

--- a/libs/pavex/src/response/response_.rs
+++ b/libs/pavex/src/response/response_.rs
@@ -130,7 +130,6 @@ impl Response {
     /// *status = StatusCode::NOT_FOUND;
     ///
     /// assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    ///
     /// ```
     pub fn status_mut(&mut self) -> &mut StatusCode {
         self.inner.status_mut()

--- a/libs/pavex/src/response/response_.rs
+++ b/libs/pavex/src/response/response_.rs
@@ -119,7 +119,7 @@ impl Response {
     /// use pavex::response::Response;
     /// use pavex::http::header::CONTENT_TYPE;
     ///
-    /// let mut response = Response::ok();    ///
+    /// let mut response = Response::ok();
     ///
     /// assert_eq!(response.status(), StatusCode::OK);
     ///

--- a/libs/pavex/src/response/response_.rs
+++ b/libs/pavex/src/response/response_.rs
@@ -118,24 +118,18 @@ impl Response {
     /// use pavex::http::StatusCode;
     /// use pavex::response::Response;
     /// use pavex::http::header::CONTENT_TYPE;
-    /// 
-    /// let mut response = Response::ok();
     ///
-    /// // We're doing this trick with the brackets to tell Rust to drop the reference
-    /// // since you can't hold an immutable and mutable ref at the same time
-    /// {
-    ///     assert!(response.status() == StatusCode::OK);
-    /// }
-    /// {
+    /// let mut response = Response::ok();    ///
+    ///
+    /// assert_eq!(response.status(), StatusCode::OK);
+    ///
     /// // Get a mutable reference to the status.
     /// let status = response.status_mut();
-    /// 
+    ///
     /// // Change the Status
     /// *status = StatusCode::NOT_FOUND;
-    /// }
     ///
-    /// 
-    /// assert!(response.status() == StatusCode::NOT_FOUND);
+    /// assert_eq!(response.status(), StatusCode::NOT_FOUND);
     ///
     /// ```
     pub fn status_mut(&mut self) -> &mut StatusCode {

--- a/libs/pavex/src/response/response_.rs
+++ b/libs/pavex/src/response/response_.rs
@@ -110,6 +110,38 @@ impl Response {
         self
     }
 
+    /// Get a mutable reference to the [`Response`] status.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pavex::http::StatusCode;
+    /// use pavex::response::Response;
+    /// use pavex::http::header::CONTENT_TYPE;
+    /// 
+    /// let mut response = Response::ok();
+    ///
+    /// // We're doing this trick with the brackets to tell Rust to drop the reference
+    /// // since you can't hold an immutable and mutable ref at the same time
+    /// {
+    ///     assert!(response.status() == StatusCode::OK);
+    /// }
+    /// {
+    /// // Get a mutable reference to the status.
+    /// let status = response.status_mut();
+    /// 
+    /// // Change the Status
+    /// *status = StatusCode::NOT_FOUND;
+    /// }
+    ///
+    /// 
+    /// assert!(response.status() == StatusCode::NOT_FOUND);
+    ///
+    /// ```
+    pub fn status_mut(&mut self) -> &mut StatusCode {
+        self.inner.status_mut()
+    }
+
     /// Change the HTTP version of the [`Response`].
     ///
     /// # Example


### PR DESCRIPTION
I'd like to use a Leptos trait that expects this to be available, and I couldn't think of a reason not to have it. Let me know if there are any issues