### PR TITLE
fix: std's collections can be used as prebuilt types

### DIFF
--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/components_can_fail/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/components_can_fail/expectations/app.rs
@@ -151,7 +151,9 @@ pub mod route_0 {
         };
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v5)
     }
-    async fn pre_processing_0() -> pavex::middleware::Processing {
+    async fn pre_processing_0() -> pavex::middleware::Processing<
+        pavex::response::Response,
+    > {
         let v0 = app::fallible_pre();
         let v1 = match v0 {
             Ok(ok) => ok,
@@ -329,7 +331,9 @@ pub mod route_1 {
         };
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
     }
-    async fn pre_processing_0() -> pavex::middleware::Processing {
+    async fn pre_processing_0() -> pavex::middleware::Processing<
+        pavex::response::Response,
+    > {
         let v0 = app::fallible_pre();
         let v1 = match v0 {
             Ok(ok) => ok,

--- a/libs/pavex_cli/tests/ui_tests/blueprint/common/components_can_fail/expectations/diagnostics.dot
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/common/components_can_fail/expectations/diagnostics.dot
@@ -37,12 +37,12 @@ digraph "GET /home - 1" {
 }
 
 digraph "GET /home - 2" {
-    0 [ label = "app::fallible_pre() -> core::prelude::rust_2015::Result<pavex::middleware::Processing, app::PreError>"]
-    1 [ label = "core::prelude::rust_2015::Result<pavex::middleware::Processing, app::PreError> -> pavex::middleware::Processing"]
-    2 [ label = "core::prelude::rust_2015::Result<pavex::middleware::Processing, app::PreError> -> app::PreError"]
+    0 [ label = "app::fallible_pre() -> core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, app::PreError>"]
+    1 [ label = "core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, app::PreError> -> pavex::middleware::Processing<pavex::response::Response>"]
+    2 [ label = "core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, app::PreError> -> app::PreError"]
     3 [ label = "app::pre_error(&app::PreError) -> pavex::response::Response"]
     4 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
-    5 [ label = "pavex::middleware::Processing::EarlyReturn(pavex::response::Response) -> pavex::middleware::Processing<T>"]
+    5 [ label = "pavex::middleware::Processing::EarlyReturn(pavex::response::Response) -> pavex::middleware::Processing<pavex::response::Response>"]
     6 [ label = "`match`"]
     6 -> 1 [ ]
     6 -> 2 [ ]
@@ -161,12 +161,12 @@ digraph "* /home - 1" {
 }
 
 digraph "* /home - 2" {
-    0 [ label = "app::fallible_pre() -> core::prelude::rust_2015::Result<pavex::middleware::Processing, app::PreError>"]
-    1 [ label = "core::prelude::rust_2015::Result<pavex::middleware::Processing, app::PreError> -> pavex::middleware::Processing"]
-    2 [ label = "core::prelude::rust_2015::Result<pavex::middleware::Processing, app::PreError> -> app::PreError"]
+    0 [ label = "app::fallible_pre() -> core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, app::PreError>"]
+    1 [ label = "core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, app::PreError> -> pavex::middleware::Processing<pavex::response::Response>"]
+    2 [ label = "core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, app::PreError> -> app::PreError"]
     3 [ label = "app::pre_error(&app::PreError) -> pavex::response::Response"]
     4 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
-    5 [ label = "pavex::middleware::Processing::EarlyReturn(pavex::response::Response) -> pavex::middleware::Processing<T>"]
+    5 [ label = "pavex::middleware::Processing::EarlyReturn(pavex::response::Response) -> pavex::middleware::Processing<pavex::response::Response>"]
     6 [ label = "`match`"]
     6 -> 1 [ ]
     6 -> 2 [ ]

--- a/libs/pavex_cli/tests/ui_tests/blueprint/pre_processing_middlewares/pre_process_without_wrapping/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/pre_processing_middlewares/pre_process_without_wrapping/expectations/app.rs
@@ -86,7 +86,9 @@ pub mod route_0 {
         let v2 = pavex::middleware::wrap_noop(v1).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    async fn pre_processing_0() -> pavex::middleware::Processing {
+    async fn pre_processing_0() -> pavex::middleware::Processing<
+        pavex::response::Response,
+    > {
         app::pre()
     }
     async fn handler() -> pavex::response::Response {
@@ -137,7 +139,9 @@ pub mod route_1 {
         let v3 = pavex::middleware::wrap_noop(v2).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v3)
     }
-    async fn pre_processing_0() -> pavex::middleware::Processing {
+    async fn pre_processing_0() -> pavex::middleware::Processing<
+        pavex::response::Response,
+    > {
         app::pre()
     }
     async fn handler(v0: &pavex::router::AllowedMethods) -> pavex::response::Response {

--- a/libs/pavex_cli/tests/ui_tests/blueprint/pre_processing_middlewares/pre_process_without_wrapping/expectations/diagnostics.dot
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/pre_processing_middlewares/pre_process_without_wrapping/expectations/diagnostics.dot
@@ -9,7 +9,7 @@ digraph "GET /home - 0" {
 }
 
 digraph "GET /home - 1" {
-    0 [ label = "app::pre() -> pavex::middleware::Processing"]
+    0 [ label = "app::pre() -> pavex::middleware::Processing<pavex::response::Response>"]
 }
 
 digraph "GET /home - 2" {
@@ -31,7 +31,7 @@ digraph "* /home - 0" {
 }
 
 digraph "* /home - 1" {
-    0 [ label = "app::pre() -> pavex::middleware::Processing"]
+    0 [ label = "app::pre() -> pavex::middleware::Processing<pavex::response::Response>"]
 }
 
 digraph "* /home - 2" {

--- a/libs/pavex_cli/tests/ui_tests/blueprint/prebuilts/prebuilt_works/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/prebuilts/prebuilt_works/expectations/app.rs
@@ -9,17 +9,20 @@ struct ServerState {
 pub struct ApplicationState {
     s0: app::A,
     s1: app::C<'static>,
-    s2: app::B<alloc::string::String>,
+    s2: alloc::vec::Vec<alloc::string::String>,
+    s3: app::B<alloc::string::String>,
 }
 pub async fn build_application_state(
     v0: app::A,
     v1: app::C<'static>,
-    v2: app::B<alloc::string::String>,
+    v2: alloc::vec::Vec<alloc::string::String>,
+    v3: app::B<alloc::string::String>,
 ) -> crate::ApplicationState {
     crate::ApplicationState {
         s0: v0,
         s1: v1,
         s2: v2,
+        s3: v3,
     }
 }
 pub fn run(
@@ -68,7 +71,8 @@ async fn route_request(
                     route_0::entrypoint(
                             &server_state.application_state.s0,
                             server_state.application_state.s1.clone(),
-                            &server_state.application_state.s2,
+                            server_state.application_state.s2.clone(),
+                            &server_state.application_state.s3,
                         )
                         .await
                 }
@@ -88,41 +92,46 @@ pub mod route_0 {
     pub async fn entrypoint<'a, 'b>(
         s_0: &'a app::A,
         s_1: app::C<'static>,
-        s_2: &'b app::B<alloc::string::String>,
+        s_2: alloc::vec::Vec<alloc::string::String>,
+        s_3: &'b app::B<alloc::string::String>,
     ) -> pavex::response::Response {
-        let response = wrapping_0(s_0, s_1, s_2).await;
+        let response = wrapping_0(s_0, s_1, s_2, s_3).await;
         response
     }
     async fn stage_1<'a, 'b>(
         s_0: &'a app::B<alloc::string::String>,
         s_1: app::C<'static>,
-        s_2: &'b app::A,
+        s_2: alloc::vec::Vec<alloc::string::String>,
+        s_3: &'b app::A,
     ) -> pavex::response::Response {
-        let response = handler(s_0, s_1, s_2).await;
+        let response = handler(s_0, s_1, s_2, s_3).await;
         response
     }
     async fn wrapping_0(
         v0: &app::A,
         v1: app::C<'static>,
-        v2: &app::B<alloc::string::String>,
+        v2: alloc::vec::Vec<alloc::string::String>,
+        v3: &app::B<alloc::string::String>,
     ) -> pavex::response::Response {
-        let v3 = crate::route_0::Next0 {
-            s_0: v2,
+        let v4 = crate::route_0::Next0 {
+            s_0: v3,
             s_1: v1,
-            s_2: v0,
+            s_2: v2,
+            s_3: v0,
             next: stage_1,
         };
-        let v4 = pavex::middleware::Next::new(v3);
-        let v5 = pavex::middleware::wrap_noop(v4).await;
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v5)
+        let v5 = pavex::middleware::Next::new(v4);
+        let v6 = pavex::middleware::wrap_noop(v5).await;
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v6)
     }
     async fn handler(
         v0: &app::B<alloc::string::String>,
         v1: app::C<'static>,
-        v2: &app::A,
+        v2: alloc::vec::Vec<alloc::string::String>,
+        v3: &app::A,
     ) -> pavex::response::Response {
-        let v3 = app::handler(v2, v0, v1);
-        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v3)
+        let v4 = app::handler(v3, v0, v1, v2);
+        <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
     }
     struct Next0<'a, 'b, T>
     where
@@ -130,8 +139,14 @@ pub mod route_0 {
     {
         s_0: &'a app::B<alloc::string::String>,
         s_1: app::C<'static>,
-        s_2: &'b app::A,
-        next: fn(&'a app::B<alloc::string::String>, app::C<'static>, &'b app::A) -> T,
+        s_2: alloc::vec::Vec<alloc::string::String>,
+        s_3: &'b app::A,
+        next: fn(
+            &'a app::B<alloc::string::String>,
+            app::C<'static>,
+            alloc::vec::Vec<alloc::string::String>,
+            &'b app::A,
+        ) -> T,
     }
     impl<'a, 'b, T> std::future::IntoFuture for Next0<'a, 'b, T>
     where
@@ -140,7 +155,7 @@ pub mod route_0 {
         type Output = pavex::response::Response;
         type IntoFuture = T;
         fn into_future(self) -> Self::IntoFuture {
-            (self.next)(self.s_0, self.s_1, self.s_2)
+            (self.next)(self.s_0, self.s_1, self.s_2, self.s_3)
         }
     }
 }

--- a/libs/pavex_cli/tests/ui_tests/blueprint/prebuilts/prebuilt_works/expectations/diagnostics.dot
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/prebuilts/prebuilt_works/expectations/diagnostics.dot
@@ -1,29 +1,33 @@
 digraph "GET / - 0" {
     0 [ label = "pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_0::Next0<'a, 'b>>) -> pavex::response::Response"]
     1 [ label = "pavex::middleware::Next::new(crate::route_0::Next0<'a, 'b>) -> pavex::middleware::Next<crate::route_0::Next0<'a, 'b>>"]
-    2 [ label = "crate::route_0::Next0(&'a app::B<alloc::string::String>, app::C<'static>, &'b app::A) -> crate::route_0::Next0<'a, 'b>"]
+    2 [ label = "crate::route_0::Next0(&'a app::B<alloc::string::String>, app::C<'static>, alloc::vec::Vec<alloc::string::String>, &'b app::A) -> crate::route_0::Next0<'a, 'b>"]
     3 [ label = "&app::A"]
     4 [ label = "app::C<'static>"]
-    6 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
-    7 [ label = "&app::B<alloc::string::String>"]
+    5 [ label = "alloc::vec::Vec<alloc::string::String>"]
+    7 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    8 [ label = "&app::B<alloc::string::String>"]
     1 -> 0 [ ]
     2 -> 1 [ ]
+    5 -> 2 [ ]
     4 -> 2 [ ]
     3 -> 2 [ ]
-    0 -> 6 [ ]
-    7 -> 2 [ ]
+    0 -> 7 [ ]
+    8 -> 2 [ ]
 }
 
 digraph "GET / - 1" {
-    0 [ label = "app::handler(&app::A, &app::B<alloc::string::String>, app::C<'static>) -> pavex::response::Response"]
+    0 [ label = "app::handler(&app::A, &app::B<alloc::string::String>, app::C<'static>, alloc::vec::Vec<alloc::string::String>) -> pavex::response::Response"]
     1 [ label = "&app::B<alloc::string::String>"]
     3 [ label = "app::C<'static>"]
-    4 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
-    5 [ label = "&app::A"]
+    4 [ label = "alloc::vec::Vec<alloc::string::String>"]
+    5 [ label = "<pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    6 [ label = "&app::A"]
+    4 -> 0 [ ]
     3 -> 0 [ ]
     1 -> 0 [ ]
-    0 -> 4 [ ]
-    5 -> 0 [ ]
+    0 -> 5 [ ]
+    6 -> 0 [ ]
 }
 
 digraph "* / - 0" {
@@ -47,10 +51,12 @@ digraph "* / - 1" {
 }
 
 digraph app_state {
-    0 [ label = "crate::ApplicationState(app::A, app::C<'static>, app::B<alloc::string::String>) -> crate::ApplicationState"]
+    0 [ label = "crate::ApplicationState(app::A, app::C<'static>, alloc::vec::Vec<alloc::string::String>, app::B<alloc::string::String>) -> crate::ApplicationState"]
     1 [ label = "app::A"]
     2 [ label = "app::C<'static>"]
-    3 [ label = "app::B<alloc::string::String>"]
+    3 [ label = "alloc::vec::Vec<alloc::string::String>"]
+    4 [ label = "app::B<alloc::string::String>"]
+    4 -> 0 [ ]
     3 -> 0 [ ]
     2 -> 0 [ ]
     1 -> 0 [ ]

--- a/libs/pavex_cli/tests/ui_tests/blueprint/prebuilts/prebuilt_works/lib.rs
+++ b/libs/pavex_cli/tests/ui_tests/blueprint/prebuilts/prebuilt_works/lib.rs
@@ -11,7 +11,7 @@ pub struct B<T>(T);
 #[derive(Clone)]
 pub struct C<'a>(&'a str);
 
-pub fn handler(a: &A, b: &B<String>, c: C<'static>) -> Response {
+pub fn handler(a: &A, b: &B<String>, c: C<'static>, d: Vec<String>) -> Response {
     todo!()
 }
 
@@ -20,6 +20,8 @@ pub fn blueprint() -> Blueprint {
     bp.prebuilt(t!(crate::A));
     bp.prebuilt(t!(crate::B<std::string::String>));
     bp.prebuilt(t!(crate::C<'static>)).clone_if_necessary();
+    bp.prebuilt(t!(std::vec::Vec<std::string::String>))
+        .clone_if_necessary();
     bp.route(GET, "/", f!(crate::handler));
     bp
 }

--- a/libs/pavex_cli/tests/ui_tests/middlewares/middlewares_execution_order/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/middlewares/middlewares_execution_order/expectations/app.rs
@@ -203,7 +203,9 @@ pub mod route_1 {
         let v3 = app::first(v0, v2).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v3)
     }
-    async fn pre_processing_0(v0: &app::Spy) -> pavex::middleware::Processing {
+    async fn pre_processing_0(
+        v0: &app::Spy,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::first_pre(v0).await
     }
     async fn wrapping_2(v0: &app::Spy) -> pavex::response::Response {
@@ -222,7 +224,9 @@ pub mod route_1 {
         let v2 = app::first_post(v1, v0).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    async fn pre_processing_1(v0: &app::Spy) -> pavex::middleware::Processing {
+    async fn pre_processing_1(
+        v0: &app::Spy,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::second_pre(v0).await
     }
     async fn handler(v0: &app::Spy) -> pavex::response::Response {
@@ -331,7 +335,9 @@ pub mod route_2 {
         let v3 = app::first(v0, v2).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v3)
     }
-    async fn pre_processing_0(v0: &app::Spy) -> pavex::middleware::Processing {
+    async fn pre_processing_0(
+        v0: &app::Spy,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::early_return_pre(v0).await
     }
     async fn wrapping_2(v0: &app::Spy) -> pavex::response::Response {
@@ -350,7 +356,9 @@ pub mod route_2 {
         let v2 = app::first_post(v1, v0).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v2)
     }
-    async fn pre_processing_1(v0: &app::Spy) -> pavex::middleware::Processing {
+    async fn pre_processing_1(
+        v0: &app::Spy,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::second_pre(v0).await
     }
     async fn handler(v0: &app::Spy) -> pavex::response::Response {
@@ -451,7 +459,9 @@ pub mod route_3 {
         let v3 = app::first(v0, v2).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v3)
     }
-    async fn pre_processing_0(v0: &app::Spy) -> pavex::middleware::Processing {
+    async fn pre_processing_0(
+        v0: &app::Spy,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::first_pre(v0).await
     }
     async fn handler(v0: &app::Spy) -> pavex::response::Response {
@@ -552,10 +562,14 @@ pub mod route_4 {
         let v3 = app::second(v0, v2).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v3)
     }
-    async fn pre_processing_0(v0: &app::Spy) -> pavex::middleware::Processing {
+    async fn pre_processing_0(
+        v0: &app::Spy,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::first_pre(v0).await
     }
-    async fn pre_processing_1(v0: &app::Spy) -> pavex::middleware::Processing {
+    async fn pre_processing_1(
+        v0: &app::Spy,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::second_pre(v0).await
     }
     async fn handler(v0: &app::Spy) -> pavex::response::Response {

--- a/libs/pavex_cli/tests/ui_tests/middlewares/middlewares_execution_order/expectations/diagnostics.dot
+++ b/libs/pavex_cli/tests/ui_tests/middlewares/middlewares_execution_order/expectations/diagnostics.dot
@@ -24,7 +24,7 @@ digraph "GET /after_handler - 1" {
 }
 
 digraph "GET /after_handler - 2" {
-    0 [ label = "app::first_pre(&app::Spy) -> pavex::middleware::Processing"]
+    0 [ label = "app::first_pre(&app::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::Spy"]
     2 -> 0 [ ]
 }
@@ -93,7 +93,7 @@ digraph "GET /early_return - 1" {
 }
 
 digraph "GET /early_return - 2" {
-    0 [ label = "app::early_return_pre(&app::Spy) -> pavex::middleware::Processing"]
+    0 [ label = "app::early_return_pre(&app::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::Spy"]
     2 -> 0 [ ]
 }
@@ -122,7 +122,7 @@ digraph "GET /early_return - 4" {
 }
 
 digraph "GET /early_return - 5" {
-    0 [ label = "app::second_pre(&app::Spy) -> pavex::middleware::Processing"]
+    0 [ label = "app::second_pre(&app::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::Spy"]
     2 -> 0 [ ]
 }
@@ -191,7 +191,7 @@ digraph "GET /nested - 1" {
 }
 
 digraph "GET /nested - 2" {
-    0 [ label = "app::first_pre(&app::Spy) -> pavex::middleware::Processing"]
+    0 [ label = "app::first_pre(&app::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::Spy"]
     2 -> 0 [ ]
 }
@@ -220,7 +220,7 @@ digraph "GET /nested - 4" {
 }
 
 digraph "GET /nested - 5" {
-    0 [ label = "app::second_pre(&app::Spy) -> pavex::middleware::Processing"]
+    0 [ label = "app::second_pre(&app::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::Spy"]
     2 -> 0 [ ]
 }
@@ -302,13 +302,13 @@ digraph "GET /top_level - 2" {
 }
 
 digraph "GET /top_level - 3" {
-    0 [ label = "app::first_pre(&app::Spy) -> pavex::middleware::Processing"]
+    0 [ label = "app::first_pre(&app::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::Spy"]
     2 -> 0 [ ]
 }
 
 digraph "GET /top_level - 4" {
-    0 [ label = "app::second_pre(&app::Spy) -> pavex::middleware::Processing"]
+    0 [ label = "app::second_pre(&app::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::Spy"]
     2 -> 0 [ ]
 }

--- a/libs/pavex_cli/tests/ui_tests/middlewares/request_scoped_state_is_shared_correctly_among_middlewares/expectations/app.rs
+++ b/libs/pavex_cli/tests/ui_tests/middlewares/request_scoped_state_is_shared_correctly_among_middlewares/expectations/app.rs
@@ -93,7 +93,9 @@ pub mod route_0 {
         let v3 = pavex::middleware::wrap_noop(v2).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v3)
     }
-    async fn pre_processing_0(v0: &app::A) -> pavex::middleware::Processing {
+    async fn pre_processing_0(
+        v0: &app::A,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::pre(v0)
     }
     async fn wrapping_1(v0: &app::A) -> pavex::response::Response {
@@ -186,7 +188,9 @@ pub mod route_1 {
         let v4 = pavex::middleware::wrap_noop(v3).await;
         <pavex::response::Response as pavex::response::IntoResponse>::into_response(v4)
     }
-    async fn pre_processing_0(v0: &app::A) -> pavex::middleware::Processing {
+    async fn pre_processing_0(
+        v0: &app::A,
+    ) -> pavex::middleware::Processing<pavex::response::Response> {
         app::pre(v0)
     }
     async fn wrapping_1(

--- a/libs/pavex_cli/tests/ui_tests/middlewares/request_scoped_state_is_shared_correctly_among_middlewares/expectations/diagnostics.dot
+++ b/libs/pavex_cli/tests/ui_tests/middlewares/request_scoped_state_is_shared_correctly_among_middlewares/expectations/diagnostics.dot
@@ -11,7 +11,7 @@ digraph "GET /home - 0" {
 }
 
 digraph "GET /home - 1" {
-    0 [ label = "app::pre(&app::A) -> pavex::middleware::Processing"]
+    0 [ label = "app::pre(&app::A) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::A"]
     2 -> 0 [ ]
 }
@@ -59,7 +59,7 @@ digraph "* /home - 0" {
 }
 
 digraph "* /home - 1" {
-    0 [ label = "app::pre(&app::A) -> pavex::middleware::Processing"]
+    0 [ label = "app::pre(&app::A) -> pavex::middleware::Processing<pavex::response::Response>"]
     2 [ label = "&app::A"]
     2 -> 0 [ ]
 }


### PR DESCRIPTION
We make default generic arguments explicit.
But there is an issue: `Vec<T, alloc::alloc::Global` and `Vec<T>` are the same type, but the former spelling is only allowed on `nightly`, while the latter works on stable; to avoid the issue, we special-case `alloc::alloc::Global`.