### PR TITLE
Handle ItemEnum kind case where function is a method

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ We contributors to Pavex:
 * Jan Ehrhardt (@jehrhardt)
 * Lukas Slanius (@bosukas)
 * Ben Wishovich (@benwis)
+* Donmai (@donmai-me)

--- a/libs/pavexc/src/rustdoc/queries.rs
+++ b/libs/pavexc/src/rustdoc/queries.rs
@@ -1114,8 +1114,16 @@ impl RustdocKindExt for ItemEnum {
             ItemEnum::StructField(_) => "a struct field",
             ItemEnum::Enum(_) => "an enum",
             ItemEnum::Variant(_) => "an enum variant",
-            // TODO: this could also be a method! How do we find out?
-            ItemEnum::Function(_) => "a function",
+            ItemEnum::Function(func) => {
+                let mut func_kind = "a function";
+                if let Some((param, _)) = func.decl.inputs.first() {
+                    if param == "self" {
+                        func_kind = "a method";
+                    }
+                }
+
+                func_kind
+            }
             ItemEnum::Trait(_) => "a trait",
             ItemEnum::TraitAlias(_) => "a trait alias",
             ItemEnum::Impl(_) => "an impl block",


### PR DESCRIPTION
While reading how Pavex works I found this todo that's low hanging. Using the fact that `self` is a reserved keyword and only appears as the first parameter in a method. 

Hope it's ok that I don't put my real name in CONTRIBUTORS.md. Love your book btw thanks!