### PR TITLE
Execute post-processing middlewares when a pre-processing middleware returns early or fails

### DIFF
--- a/doc_examples/guide/middleware/pre/project-basic.snap
+++ b/doc_examples/guide/middleware/pre/project-basic.snap
@@ -1,40 +1,19 @@
 ```rust title="src/core/mw.rs"
-use pavex::http::{HeaderValue, header::LOCATION};
+use pavex::http::{header::LOCATION, HeaderValue};
 use pavex::middleware::Processing;
 use pavex::request::RequestHead;
 use pavex::response::Response;
 
 /// If the request path ends with a `/`,
 /// redirect to the same path without the trailing `/`.
-pub fn redirect_to_normalized(request_head: &RequestHead) -> Processing
-{
+pub fn redirect_to_normalized(request_head: &RequestHead) -> Processing {
     let Some(normalized_path) = request_head.target.path().strip_suffix('/') else {
         // No need to redirect, we continue processing the request.
         return Processing::Continue;
     };
     let location = HeaderValue::from_str(normalized_path).unwrap();
     let redirect = Response::temporary_redirect().insert_header(LOCATION, location);
-    // Short-circuit the request processing pipeline and return the redirect response
-    // to the client without invoking downstream middlewares and the request handler.
+    // Short-circuit the request processing pipeline and return a redirect response
     Processing::EarlyReturn(redirect)
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ```

--- a/doc_examples/guide/middleware/pre/project/src/core/mw.rs
+++ b/doc_examples/guide/middleware/pre/project/src/core/mw.rs
@@ -1,38 +1,17 @@
-use pavex::http::{HeaderValue, header::LOCATION};
+use pavex::http::{header::LOCATION, HeaderValue};
 use pavex::middleware::Processing;
 use pavex::request::RequestHead;
 use pavex::response::Response;
 
 /// If the request path ends with a `/`,
 /// redirect to the same path without the trailing `/`.
-pub fn redirect_to_normalized(request_head: &RequestHead) -> Processing
-{
+pub fn redirect_to_normalized(request_head: &RequestHead) -> Processing {
     let Some(normalized_path) = request_head.target.path().strip_suffix('/') else {
         // No need to redirect, we continue processing the request.
         return Processing::Continue;
     };
     let location = HeaderValue::from_str(normalized_path).unwrap();
     let redirect = Response::temporary_redirect().insert_header(LOCATION, location);
-    // Short-circuit the request processing pipeline and return the redirect response
-    // to the client without invoking downstream middlewares and the request handler.
+    // Short-circuit the request processing pipeline and return a redirect response
     Processing::EarlyReturn(redirect)
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/docs/guide/middleware/pre_processing.md
+++ b/docs/guide/middleware/pre_processing.md
@@ -35,7 +35,11 @@ Pre-processing middlewares must return [`Processing`][Processing].
 [`Processing`][Processing] is an enum with two variants:
 
 - [`Processing::Continue`][Processing::Continue]: the middleware has finished its work and the request processing pipeline should continue as usual.
-- [`Processing::EarlyReturn(T)`][Processing::EarlyReturn]: the rest of the request processing pipeline should be skipped. `T` will be converted into a response and sent back to the client.
+- [`Processing::EarlyReturn(T)`][Processing::EarlyReturn]: the remaining pre-processing and wrapping middlewares won't be invoked, nor will the request handler. 
+  `T` will be converted into a response, fed to the [post-processing middlewares][post-processing] (if there are any) and then sent back to the client.
+  
+Check out the [execution order guide](execution_order.md#pre-and-post-early-return) for more details on how the different types of middlewares interact
+with each other.
 
 `T`, the type inside [`Processing::EarlyReturn`][Processing::EarlyReturn], must implement the
 [`IntoResponse`][IntoResponse] trait.
@@ -102,3 +106,4 @@ using Pavex's first-party extractors.
 [Processing]: ../../api_reference/pavex/middleware/enum.Processing.html
 [Processing::Continue]: ../../api_reference/pavex/middleware/enum.Processing.html#variant.Continue
 [Processing::EarlyReturn]: ../../api_reference/pavex/middleware/enum.Processing.html#variant.EarlyReturn
+[post-processing]: post_processing.md

--- a/libs/ui_tests/blueprint/common/components_can_fail/expectations/app.rs
+++ b/libs/ui_tests/blueprint/common/components_can_fail/expectations/app.rs
@@ -118,10 +118,12 @@ pub mod route_0 {
         s_0: pavex::request::RequestHead,
         s_1: &'a app::HttpClient,
     ) -> pavex::response::Response {
-        if let Some(response) = pre_processing_0().await.into_response() {
-            return response;
-        }
-        let response = handler(s_0, s_1).await;
+        let response = 'incoming: {
+            if let Some(response) = pre_processing_0().await.into_response() {
+                break 'incoming response;
+            }
+            handler(s_0, s_1).await
+        };
         let response = post_processing_0(response).await;
         response
     }
@@ -304,10 +306,12 @@ pub mod route_1 {
     async fn stage_2<'a>(
         s_0: &'a pavex::router::AllowedMethods,
     ) -> pavex::response::Response {
-        if let Some(response) = pre_processing_0().await.into_response() {
-            return response;
-        }
-        let response = handler(s_0).await;
+        let response = 'incoming: {
+            if let Some(response) = pre_processing_0().await.into_response() {
+                break 'incoming response;
+            }
+            handler(s_0).await
+        };
         let response = post_processing_0(response).await;
         response
     }

--- a/libs/ui_tests/blueprint/pre_processing_middlewares/pre_process_without_wrapping/expectations/app.rs
+++ b/libs/ui_tests/blueprint/pre_processing_middlewares/pre_process_without_wrapping/expectations/app.rs
@@ -84,10 +84,12 @@ pub mod route_0 {
         response
     }
     async fn stage_1() -> pavex::response::Response {
-        if let Some(response) = pre_processing_0().await.into_response() {
-            return response;
-        }
-        let response = handler().await;
+        let response = 'incoming: {
+            if let Some(response) = pre_processing_0().await.into_response() {
+                break 'incoming response;
+            }
+            handler().await
+        };
         response
     }
     async fn wrapping_0() -> pavex::response::Response {
@@ -134,10 +136,12 @@ pub mod route_1 {
     async fn stage_1<'a>(
         s_0: &'a pavex::router::AllowedMethods,
     ) -> pavex::response::Response {
-        if let Some(response) = pre_processing_0().await.into_response() {
-            return response;
-        }
-        let response = handler(s_0).await;
+        let response = 'incoming: {
+            if let Some(response) = pre_processing_0().await.into_response() {
+                break 'incoming response;
+            }
+            handler(s_0).await
+        };
         response
     }
     async fn wrapping_0(

--- a/libs/ui_tests/middlewares/middlewares_execution_order/diagnostics.dot
+++ b/libs/ui_tests/middlewares/middlewares_execution_order/diagnostics.dot
@@ -96,7 +96,7 @@ digraph "GET /nested - 7" {
     4 -> 0 [ ]
 }
 
-digraph "GET /early_return - 0" {
+digraph "GET /failing_pre - 0" {
     0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_2::Next0<'a>>) -> pavex::response::Response"]
     1 [ label = "2| pavex::middleware::Next::new(crate::route_2::Next0<'a>) -> pavex::middleware::Next<crate::route_2::Next0<'a>>"]
     2 [ label = "1| crate::route_2::Next0(&'a app_e628417e::Spy) -> crate::route_2::Next0<'a>"]
@@ -108,10 +108,100 @@ digraph "GET /early_return - 0" {
     5 -> 2 [ ]
 }
 
-digraph "GET /early_return - 1" {
+digraph "GET /failing_pre - 1" {
     0 [ label = "3| app_e628417e::first(&app_e628417e::Spy, pavex::middleware::Next<crate::route_2::Next1<'a>>) -> pavex::response::Response"]
     2 [ label = "2| pavex::middleware::Next::new(crate::route_2::Next1<'a>) -> pavex::middleware::Next<crate::route_2::Next1<'a>>"]
     3 [ label = "1| crate::route_2::Next1(&'a app_e628417e::Spy) -> crate::route_2::Next1<'a>"]
+    4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    5 [ label = "0| &app_e628417e::Spy"]
+    2 -> 0 [ ]
+    3 -> 2 [ ]
+    0 -> 4 [ ]
+    5 -> 0 [ ]
+    5 -> 3 [ ]
+}
+
+digraph "GET /failing_pre - 2" {
+    0 [ label = "1| app_e628417e::failing_pre_(&app_e628417e::Spy) -> core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, pavex::Error>"]
+    2 [ label = "7| core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, pavex::Error> -> pavex::middleware::Processing<pavex::response::Response>"]
+    3 [ label = "3| core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, pavex::Error> -> pavex::Error"]
+    4 [ label = "4| app_e628417e::e500(&pavex::Error) -> pavex::response::Response"]
+    5 [ label = "5| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    6 [ label = "6| pavex::middleware::Processing::EarlyReturn(pavex::response::Response) -> pavex::middleware::Processing<pavex::response::Response>"]
+    7 [ label = "2| `match`"]
+    8 [ label = "0| &app_e628417e::Spy"]
+    7 -> 2 [ ]
+    7 -> 3 [ ]
+    3 -> 4 [ label = "&"]
+    4 -> 5 [ ]
+    5 -> 6 [ ]
+    0 -> 7 [ ]
+    8 -> 0 [ ]
+}
+
+digraph "GET /failing_pre - 3" {
+    0 [ label = "3| app_e628417e::second(&app_e628417e::Spy, pavex::middleware::Next<crate::route_2::Next2<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_2::Next2<'a>) -> pavex::middleware::Next<crate::route_2::Next2<'a>>"]
+    3 [ label = "1| crate::route_2::Next2(&'a app_e628417e::Spy) -> crate::route_2::Next2<'a>"]
+    4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    5 [ label = "0| &app_e628417e::Spy"]
+    2 -> 0 [ ]
+    3 -> 2 [ ]
+    0 -> 4 [ ]
+    5 -> 0 [ ]
+    5 -> 3 [ ]
+}
+
+digraph "GET /failing_pre - 4" {
+    0 [ label = "1| app_e628417e::second_pre(&app_e628417e::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
+    2 [ label = "0| &app_e628417e::Spy"]
+    2 -> 0 [ ]
+}
+
+digraph "GET /failing_pre - 5" {
+    0 [ label = "1| app_e628417e::handler(&app_e628417e::Spy) -> pavex::response::Response"]
+    2 [ label = "2| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    3 [ label = "0| &app_e628417e::Spy"]
+    0 -> 2 [ ]
+    3 -> 0 [ ]
+}
+
+digraph "GET /failing_pre - 6" {
+    0 [ label = "2| app_e628417e::second_post(&app_e628417e::Spy, pavex::response::Response) -> pavex::response::Response"]
+    2 [ label = "0| pavex::response::Response"]
+    3 [ label = "3| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    4 [ label = "1| &app_e628417e::Spy"]
+    2 -> 0 [ ]
+    0 -> 3 [ ]
+    4 -> 0 [ ]
+}
+
+digraph "GET /failing_pre - 7" {
+    0 [ label = "2| app_e628417e::first_post(&app_e628417e::Spy, pavex::response::Response) -> pavex::response::Response"]
+    2 [ label = "0| pavex::response::Response"]
+    3 [ label = "3| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    4 [ label = "1| &app_e628417e::Spy"]
+    2 -> 0 [ ]
+    0 -> 3 [ ]
+    4 -> 0 [ ]
+}
+
+digraph "GET /early_return - 0" {
+    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_3::Next0<'a>>) -> pavex::response::Response"]
+    1 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next0<'a>) -> pavex::middleware::Next<crate::route_3::Next0<'a>>"]
+    2 [ label = "1| crate::route_3::Next0(&'a app_e628417e::Spy) -> crate::route_3::Next0<'a>"]
+    4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    5 [ label = "0| &app_e628417e::Spy"]
+    1 -> 0 [ ]
+    2 -> 1 [ ]
+    0 -> 4 [ ]
+    5 -> 2 [ ]
+}
+
+digraph "GET /early_return - 1" {
+    0 [ label = "3| app_e628417e::first(&app_e628417e::Spy, pavex::middleware::Next<crate::route_3::Next1<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next1<'a>) -> pavex::middleware::Next<crate::route_3::Next1<'a>>"]
+    3 [ label = "1| crate::route_3::Next1(&'a app_e628417e::Spy) -> crate::route_3::Next1<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app_e628417e::Spy"]
     2 -> 0 [ ]
@@ -128,9 +218,9 @@ digraph "GET /early_return - 2" {
 }
 
 digraph "GET /early_return - 3" {
-    0 [ label = "3| app_e628417e::second(&app_e628417e::Spy, pavex::middleware::Next<crate::route_2::Next2<'a>>) -> pavex::response::Response"]
-    2 [ label = "2| pavex::middleware::Next::new(crate::route_2::Next2<'a>) -> pavex::middleware::Next<crate::route_2::Next2<'a>>"]
-    3 [ label = "1| crate::route_2::Next2(&'a app_e628417e::Spy) -> crate::route_2::Next2<'a>"]
+    0 [ label = "3| app_e628417e::second(&app_e628417e::Spy, pavex::middleware::Next<crate::route_3::Next2<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next2<'a>) -> pavex::middleware::Next<crate::route_3::Next2<'a>>"]
+    3 [ label = "1| crate::route_3::Next2(&'a app_e628417e::Spy) -> crate::route_3::Next2<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app_e628417e::Spy"]
     2 -> 0 [ ]
@@ -175,9 +265,9 @@ digraph "GET /early_return - 7" {
 }
 
 digraph "GET /after_handler - 0" {
-    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_3::Next0<'a>>) -> pavex::response::Response"]
-    1 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next0<'a>) -> pavex::middleware::Next<crate::route_3::Next0<'a>>"]
-    2 [ label = "1| crate::route_3::Next0(&'a app_e628417e::Spy) -> crate::route_3::Next0<'a>"]
+    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_4::Next0<'a>>) -> pavex::response::Response"]
+    1 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next0<'a>) -> pavex::middleware::Next<crate::route_4::Next0<'a>>"]
+    2 [ label = "1| crate::route_4::Next0(&'a app_e628417e::Spy) -> crate::route_4::Next0<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app_e628417e::Spy"]
     1 -> 0 [ ]
@@ -187,9 +277,9 @@ digraph "GET /after_handler - 0" {
 }
 
 digraph "GET /after_handler - 1" {
-    0 [ label = "3| app_e628417e::first(&app_e628417e::Spy, pavex::middleware::Next<crate::route_3::Next1<'a>>) -> pavex::response::Response"]
-    2 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next1<'a>) -> pavex::middleware::Next<crate::route_3::Next1<'a>>"]
-    3 [ label = "1| crate::route_3::Next1(&'a app_e628417e::Spy) -> crate::route_3::Next1<'a>"]
+    0 [ label = "3| app_e628417e::first(&app_e628417e::Spy, pavex::middleware::Next<crate::route_4::Next1<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next1<'a>) -> pavex::middleware::Next<crate::route_4::Next1<'a>>"]
+    3 [ label = "1| crate::route_4::Next1(&'a app_e628417e::Spy) -> crate::route_4::Next1<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app_e628417e::Spy"]
     2 -> 0 [ ]
@@ -224,9 +314,9 @@ digraph "GET /after_handler - 4" {
 }
 
 digraph "GET /top_level - 0" {
-    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_4::Next0<'a>>) -> pavex::response::Response"]
-    1 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next0<'a>) -> pavex::middleware::Next<crate::route_4::Next0<'a>>"]
-    2 [ label = "1| crate::route_4::Next0(&'a app_e628417e::Spy) -> crate::route_4::Next0<'a>"]
+    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_5::Next0<'a>>) -> pavex::response::Response"]
+    1 [ label = "2| pavex::middleware::Next::new(crate::route_5::Next0<'a>) -> pavex::middleware::Next<crate::route_5::Next0<'a>>"]
+    2 [ label = "1| crate::route_5::Next0(&'a app_e628417e::Spy) -> crate::route_5::Next0<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app_e628417e::Spy"]
     1 -> 0 [ ]
@@ -236,9 +326,9 @@ digraph "GET /top_level - 0" {
 }
 
 digraph "GET /top_level - 1" {
-    0 [ label = "3| app_e628417e::first(&app_e628417e::Spy, pavex::middleware::Next<crate::route_4::Next1<'a>>) -> pavex::response::Response"]
-    2 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next1<'a>) -> pavex::middleware::Next<crate::route_4::Next1<'a>>"]
-    3 [ label = "1| crate::route_4::Next1(&'a app_e628417e::Spy) -> crate::route_4::Next1<'a>"]
+    0 [ label = "3| app_e628417e::first(&app_e628417e::Spy, pavex::middleware::Next<crate::route_5::Next1<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_5::Next1<'a>) -> pavex::middleware::Next<crate::route_5::Next1<'a>>"]
+    3 [ label = "1| crate::route_5::Next1(&'a app_e628417e::Spy) -> crate::route_5::Next1<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app_e628417e::Spy"]
     2 -> 0 [ ]
@@ -249,9 +339,9 @@ digraph "GET /top_level - 1" {
 }
 
 digraph "GET /top_level - 2" {
-    0 [ label = "3| app_e628417e::second(&app_e628417e::Spy, pavex::middleware::Next<crate::route_4::Next2<'a>>) -> pavex::response::Response"]
-    2 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next2<'a>) -> pavex::middleware::Next<crate::route_4::Next2<'a>>"]
-    3 [ label = "1| crate::route_4::Next2(&'a app_e628417e::Spy) -> crate::route_4::Next2<'a>"]
+    0 [ label = "3| app_e628417e::second(&app_e628417e::Spy, pavex::middleware::Next<crate::route_5::Next2<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_5::Next2<'a>) -> pavex::middleware::Next<crate::route_5::Next2<'a>>"]
+    3 [ label = "1| crate::route_5::Next2(&'a app_e628417e::Spy) -> crate::route_5::Next2<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app_e628417e::Spy"]
     2 -> 0 [ ]

--- a/libs/ui_tests/middlewares/middlewares_execution_order/expectations/diagnostics.dot
+++ b/libs/ui_tests/middlewares/middlewares_execution_order/expectations/diagnostics.dot
@@ -96,7 +96,7 @@ digraph "GET /nested - 7" {
     4 -> 0 [ ]
 }
 
-digraph "GET /early_return - 0" {
+digraph "GET /failing_pre - 0" {
     0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_2::Next0<'a>>) -> pavex::response::Response"]
     1 [ label = "2| pavex::middleware::Next::new(crate::route_2::Next0<'a>) -> pavex::middleware::Next<crate::route_2::Next0<'a>>"]
     2 [ label = "1| crate::route_2::Next0(&'a app::Spy) -> crate::route_2::Next0<'a>"]
@@ -108,10 +108,100 @@ digraph "GET /early_return - 0" {
     5 -> 2 [ ]
 }
 
-digraph "GET /early_return - 1" {
+digraph "GET /failing_pre - 1" {
     0 [ label = "3| app::first(&app::Spy, pavex::middleware::Next<crate::route_2::Next1<'a>>) -> pavex::response::Response"]
     2 [ label = "2| pavex::middleware::Next::new(crate::route_2::Next1<'a>) -> pavex::middleware::Next<crate::route_2::Next1<'a>>"]
     3 [ label = "1| crate::route_2::Next1(&'a app::Spy) -> crate::route_2::Next1<'a>"]
+    4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    5 [ label = "0| &app::Spy"]
+    2 -> 0 [ ]
+    3 -> 2 [ ]
+    0 -> 4 [ ]
+    5 -> 0 [ ]
+    5 -> 3 [ ]
+}
+
+digraph "GET /failing_pre - 2" {
+    0 [ label = "1| app::failing_pre_(&app::Spy) -> core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, pavex::Error>"]
+    2 [ label = "7| core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, pavex::Error> -> pavex::middleware::Processing<pavex::response::Response>"]
+    3 [ label = "3| core::prelude::rust_2015::Result<pavex::middleware::Processing<pavex::response::Response>, pavex::Error> -> pavex::Error"]
+    4 [ label = "4| app::e500(&pavex::Error) -> pavex::response::Response"]
+    5 [ label = "5| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    6 [ label = "6| pavex::middleware::Processing::EarlyReturn(pavex::response::Response) -> pavex::middleware::Processing<pavex::response::Response>"]
+    7 [ label = "2| `match`"]
+    8 [ label = "0| &app::Spy"]
+    7 -> 2 [ ]
+    7 -> 3 [ ]
+    3 -> 4 [ label = "&"]
+    4 -> 5 [ ]
+    5 -> 6 [ ]
+    0 -> 7 [ ]
+    8 -> 0 [ ]
+}
+
+digraph "GET /failing_pre - 3" {
+    0 [ label = "3| app::second(&app::Spy, pavex::middleware::Next<crate::route_2::Next2<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_2::Next2<'a>) -> pavex::middleware::Next<crate::route_2::Next2<'a>>"]
+    3 [ label = "1| crate::route_2::Next2(&'a app::Spy) -> crate::route_2::Next2<'a>"]
+    4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    5 [ label = "0| &app::Spy"]
+    2 -> 0 [ ]
+    3 -> 2 [ ]
+    0 -> 4 [ ]
+    5 -> 0 [ ]
+    5 -> 3 [ ]
+}
+
+digraph "GET /failing_pre - 4" {
+    0 [ label = "1| app::second_pre(&app::Spy) -> pavex::middleware::Processing<pavex::response::Response>"]
+    2 [ label = "0| &app::Spy"]
+    2 -> 0 [ ]
+}
+
+digraph "GET /failing_pre - 5" {
+    0 [ label = "1| app::handler(&app::Spy) -> pavex::response::Response"]
+    2 [ label = "2| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    3 [ label = "0| &app::Spy"]
+    0 -> 2 [ ]
+    3 -> 0 [ ]
+}
+
+digraph "GET /failing_pre - 6" {
+    0 [ label = "2| app::second_post(&app::Spy, pavex::response::Response) -> pavex::response::Response"]
+    2 [ label = "0| pavex::response::Response"]
+    3 [ label = "3| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    4 [ label = "1| &app::Spy"]
+    2 -> 0 [ ]
+    0 -> 3 [ ]
+    4 -> 0 [ ]
+}
+
+digraph "GET /failing_pre - 7" {
+    0 [ label = "2| app::first_post(&app::Spy, pavex::response::Response) -> pavex::response::Response"]
+    2 [ label = "0| pavex::response::Response"]
+    3 [ label = "3| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    4 [ label = "1| &app::Spy"]
+    2 -> 0 [ ]
+    0 -> 3 [ ]
+    4 -> 0 [ ]
+}
+
+digraph "GET /early_return - 0" {
+    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_3::Next0<'a>>) -> pavex::response::Response"]
+    1 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next0<'a>) -> pavex::middleware::Next<crate::route_3::Next0<'a>>"]
+    2 [ label = "1| crate::route_3::Next0(&'a app::Spy) -> crate::route_3::Next0<'a>"]
+    4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
+    5 [ label = "0| &app::Spy"]
+    1 -> 0 [ ]
+    2 -> 1 [ ]
+    0 -> 4 [ ]
+    5 -> 2 [ ]
+}
+
+digraph "GET /early_return - 1" {
+    0 [ label = "3| app::first(&app::Spy, pavex::middleware::Next<crate::route_3::Next1<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next1<'a>) -> pavex::middleware::Next<crate::route_3::Next1<'a>>"]
+    3 [ label = "1| crate::route_3::Next1(&'a app::Spy) -> crate::route_3::Next1<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app::Spy"]
     2 -> 0 [ ]
@@ -128,9 +218,9 @@ digraph "GET /early_return - 2" {
 }
 
 digraph "GET /early_return - 3" {
-    0 [ label = "3| app::second(&app::Spy, pavex::middleware::Next<crate::route_2::Next2<'a>>) -> pavex::response::Response"]
-    2 [ label = "2| pavex::middleware::Next::new(crate::route_2::Next2<'a>) -> pavex::middleware::Next<crate::route_2::Next2<'a>>"]
-    3 [ label = "1| crate::route_2::Next2(&'a app::Spy) -> crate::route_2::Next2<'a>"]
+    0 [ label = "3| app::second(&app::Spy, pavex::middleware::Next<crate::route_3::Next2<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next2<'a>) -> pavex::middleware::Next<crate::route_3::Next2<'a>>"]
+    3 [ label = "1| crate::route_3::Next2(&'a app::Spy) -> crate::route_3::Next2<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app::Spy"]
     2 -> 0 [ ]
@@ -175,9 +265,9 @@ digraph "GET /early_return - 7" {
 }
 
 digraph "GET /after_handler - 0" {
-    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_3::Next0<'a>>) -> pavex::response::Response"]
-    1 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next0<'a>) -> pavex::middleware::Next<crate::route_3::Next0<'a>>"]
-    2 [ label = "1| crate::route_3::Next0(&'a app::Spy) -> crate::route_3::Next0<'a>"]
+    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_4::Next0<'a>>) -> pavex::response::Response"]
+    1 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next0<'a>) -> pavex::middleware::Next<crate::route_4::Next0<'a>>"]
+    2 [ label = "1| crate::route_4::Next0(&'a app::Spy) -> crate::route_4::Next0<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app::Spy"]
     1 -> 0 [ ]
@@ -187,9 +277,9 @@ digraph "GET /after_handler - 0" {
 }
 
 digraph "GET /after_handler - 1" {
-    0 [ label = "3| app::first(&app::Spy, pavex::middleware::Next<crate::route_3::Next1<'a>>) -> pavex::response::Response"]
-    2 [ label = "2| pavex::middleware::Next::new(crate::route_3::Next1<'a>) -> pavex::middleware::Next<crate::route_3::Next1<'a>>"]
-    3 [ label = "1| crate::route_3::Next1(&'a app::Spy) -> crate::route_3::Next1<'a>"]
+    0 [ label = "3| app::first(&app::Spy, pavex::middleware::Next<crate::route_4::Next1<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next1<'a>) -> pavex::middleware::Next<crate::route_4::Next1<'a>>"]
+    3 [ label = "1| crate::route_4::Next1(&'a app::Spy) -> crate::route_4::Next1<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app::Spy"]
     2 -> 0 [ ]
@@ -224,9 +314,9 @@ digraph "GET /after_handler - 4" {
 }
 
 digraph "GET /top_level - 0" {
-    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_4::Next0<'a>>) -> pavex::response::Response"]
-    1 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next0<'a>) -> pavex::middleware::Next<crate::route_4::Next0<'a>>"]
-    2 [ label = "1| crate::route_4::Next0(&'a app::Spy) -> crate::route_4::Next0<'a>"]
+    0 [ label = "3| pavex::middleware::wrap_noop(pavex::middleware::Next<crate::route_5::Next0<'a>>) -> pavex::response::Response"]
+    1 [ label = "2| pavex::middleware::Next::new(crate::route_5::Next0<'a>) -> pavex::middleware::Next<crate::route_5::Next0<'a>>"]
+    2 [ label = "1| crate::route_5::Next0(&'a app::Spy) -> crate::route_5::Next0<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app::Spy"]
     1 -> 0 [ ]
@@ -236,9 +326,9 @@ digraph "GET /top_level - 0" {
 }
 
 digraph "GET /top_level - 1" {
-    0 [ label = "3| app::first(&app::Spy, pavex::middleware::Next<crate::route_4::Next1<'a>>) -> pavex::response::Response"]
-    2 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next1<'a>) -> pavex::middleware::Next<crate::route_4::Next1<'a>>"]
-    3 [ label = "1| crate::route_4::Next1(&'a app::Spy) -> crate::route_4::Next1<'a>"]
+    0 [ label = "3| app::first(&app::Spy, pavex::middleware::Next<crate::route_5::Next1<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_5::Next1<'a>) -> pavex::middleware::Next<crate::route_5::Next1<'a>>"]
+    3 [ label = "1| crate::route_5::Next1(&'a app::Spy) -> crate::route_5::Next1<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app::Spy"]
     2 -> 0 [ ]
@@ -249,9 +339,9 @@ digraph "GET /top_level - 1" {
 }
 
 digraph "GET /top_level - 2" {
-    0 [ label = "3| app::second(&app::Spy, pavex::middleware::Next<crate::route_4::Next2<'a>>) -> pavex::response::Response"]
-    2 [ label = "2| pavex::middleware::Next::new(crate::route_4::Next2<'a>) -> pavex::middleware::Next<crate::route_4::Next2<'a>>"]
-    3 [ label = "1| crate::route_4::Next2(&'a app::Spy) -> crate::route_4::Next2<'a>"]
+    0 [ label = "3| app::second(&app::Spy, pavex::middleware::Next<crate::route_5::Next2<'a>>) -> pavex::response::Response"]
+    2 [ label = "2| pavex::middleware::Next::new(crate::route_5::Next2<'a>) -> pavex::middleware::Next<crate::route_5::Next2<'a>>"]
+    3 [ label = "1| crate::route_5::Next2(&'a app::Spy) -> crate::route_5::Next2<'a>"]
     4 [ label = "4| <pavex::response::Response as pavex::response::IntoResponse>::into_response(pavex::response::Response) -> pavex::response::Response"]
     5 [ label = "0| &app::Spy"]
     2 -> 0 [ ]

--- a/libs/ui_tests/middlewares/request_scoped_state_is_shared_correctly_among_middlewares/expectations/app.rs
+++ b/libs/ui_tests/middlewares/request_scoped_state_is_shared_correctly_among_middlewares/expectations/app.rs
@@ -84,10 +84,12 @@ pub mod route_0 {
         response
     }
     async fn stage_1(s_0: app::A) -> pavex::response::Response {
-        if let Some(response) = pre_processing_0(&s_0).await.into_response() {
-            return response;
-        }
-        let response = wrapping_1(&s_0).await;
+        let response = 'incoming: {
+            if let Some(response) = pre_processing_0(&s_0).await.into_response() {
+                break 'incoming response;
+            }
+            wrapping_1(&s_0).await
+        };
         let response = post_processing_0(response, s_0).await;
         response
     }
@@ -174,10 +176,12 @@ pub mod route_1 {
         s_0: &'a pavex::router::AllowedMethods,
         s_1: app::A,
     ) -> pavex::response::Response {
-        if let Some(response) = pre_processing_0(&s_1).await.into_response() {
-            return response;
-        }
-        let response = wrapping_1(s_0, &s_1).await;
+        let response = 'incoming: {
+            if let Some(response) = pre_processing_0(&s_1).await.into_response() {
+                break 'incoming response;
+            }
+            wrapping_1(s_0, &s_1).await
+        };
         let response = post_processing_0(response, s_1).await;
         response
     }


### PR DESCRIPTION
This was an oversight.
Considering what post-processing middlewares are used for (e.g. logging response data, injecting headers, etc.) it's much more useful to have them being invoked rather than skipped when something fails on the way in.