### PR TITLE
chore: release v0.1.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,33 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.70](https://github.com/LukeMathWalker/pavex/compare/0.1.69...0.1.70) - 2025-01-24
+
+
+### 🐛 Bug Fixes
+- Don't install the current nightly when checking the freshness of a project. Pavex will install the specific nightly version it requires when it initializes (by @LukeMathWalker)
+- Use the new install URL in the starter project template (#425) (by @LukeMathWalker) - #425
+
+
+
+### 🫧 Polishing
+- Use 'tracing_log_error::log_error!' in the project template to ensure consistent error logging (by @LukeMathWalker) - #427
+
+
+
+
+### Contributors
+
+* @LukeMathWalker
+* @pavex-releaser[bot]
+* @github-actions[bot]
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "generate_from_path"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "fs-err 3.0.0",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "pavex"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "biscotti",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "pavex_reflection",
  "px_workspace_hack",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "pavex",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_deps"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "cargo-like-utils",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "pavex",
  "proc-macro2",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_miette"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "miette",
  "owo-colors",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "px_workspace_hack",
  "serde",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_session"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_session_memory_store"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "async-trait",
  "pavex_session",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_session_sqlx"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_test_runner"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_tracing"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "pavex",
  "px_workspace_hack",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "pavexc"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "pavexc_cli"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "better-panic",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "pavexc_cli_client"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "pavex",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "pavexc_rustdoc_types"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "px_workspace_hack",
  "rustc-hash",
@@ -2778,7 +2778,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "persist_if_changed"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "fs-err 3.0.0",

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 repository = "https://github.com/LukeMathWalker/pavex"
 homepage = "https://pavex.dev"
 license = "Apache-2.0"
-version = "0.1.69"
+version = "0.1.70"
 
 [workspace.dependencies]
 vergen-gitcl = { version = "1.0.5", features = ["build"] }

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -33,15 +33,15 @@ futures-util = { workspace = true }
 mime = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-pavex_macros = { path = "../pavex_macros", version = "0.1.69" }
+pavex_macros = { path = "../pavex_macros", version = "0.1.70" }
 paste = { workspace = true }
 tracing = { workspace = true }
 http-body-util = { workspace = true }
 pin-project-lite = { workspace = true }
 ubyte = { workspace = true, features = ["serde"] }
-pavex_bp_schema = { path = "../pavex_bp_schema", version = "=0.1.69" }
-pavex_reflection = { path = "../pavex_reflection", version = "=0.1.69" }
-persist_if_changed = { path = "../persist_if_changed", version = "0.1.69" }
+pavex_bp_schema = { path = "../pavex_bp_schema", version = "=0.1.70" }
+pavex_reflection = { path = "../pavex_reflection", version = "=0.1.70" }
+persist_if_changed = { path = "../persist_if_changed", version = "0.1.70" }
 
 # Route parameters
 matchit = { workspace = true }

--- a/libs/pavex_bp_schema/Cargo.toml
+++ b/libs/pavex_bp_schema/Cargo.toml
@@ -9,5 +9,5 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-pavex_reflection = { path = "../pavex_reflection", version = "=0.1.69" }
+pavex_reflection = { path = "../pavex_reflection", version = "=0.1.70" }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -20,9 +20,9 @@ vergen-gitcl = { workspace = true }
 anyhow = { workspace = true }
 
 [dependencies]
-pavexc_cli_client = { path = "../pavexc_cli_client", version = "0.1.69" }
-pavex_cli_deps = { path = "../pavex_cli_deps", version = "0.1.69" }
-pavex_miette = { path = "../pavex_miette", version = "0.1.69" }
+pavexc_cli_client = { path = "../pavexc_cli_client", version = "0.1.70" }
+pavex_cli_deps = { path = "../pavex_cli_deps", version = "0.1.70" }
+pavex_miette = { path = "../pavex_miette", version = "0.1.70" }
 tracing_log_error = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 miette = { workspace = true }

--- a/libs/pavex_cli_client/Cargo.toml
+++ b/libs/pavex_cli_client/Cargo.toml
@@ -9,6 +9,6 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-pavex = { path = "../pavex", version = "0.1.69" }
+pavex = { path = "../pavex", version = "0.1.70" }
 thiserror = { workspace = true }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }

--- a/libs/pavex_session/Cargo.toml
+++ b/libs/pavex_session/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-pavex = { version = "0.1.69", path = "../pavex", default-features = false, features = [
+pavex = { version = "0.1.70", path = "../pavex", default-features = false, features = [
     "cookie",
 ] }
-pavex_tracing = { version = "0.1.69", path = "../pavex_tracing" }
+pavex_tracing = { version = "0.1.70", path = "../pavex_tracing" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/libs/pavex_session_memory_store/Cargo.toml
+++ b/libs/pavex_session_memory_store/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-pavex_session = { version = "0.1.69", path = "../pavex_session" }
+pavex_session = { version = "0.1.70", path = "../pavex_session" }
 time = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 async-trait = { workspace = true }

--- a/libs/pavex_session_sqlx/Cargo.toml
+++ b/libs/pavex_session_sqlx/Cargo.toml
@@ -16,7 +16,7 @@ postgres = ["sqlx/postgres"]
 all-features = true
 
 [dependencies]
-pavex_session = { version = "0.1.69", path = "../pavex_session" }
+pavex_session = { version = "0.1.70", path = "../pavex_session" }
 time = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 async-trait = { workspace = true }

--- a/libs/pavex_test_runner/Cargo.toml
+++ b/libs/pavex_test_runner/Cargo.toml
@@ -31,7 +31,7 @@ walkdir = { workspace = true }
 serde_json = { workspace = true }
 itertools = { workspace = true }
 sha2 = { workspace = true }
-persist_if_changed = { path = "../persist_if_changed", version = "0.1.69" }
+persist_if_changed = { path = "../persist_if_changed", version = "0.1.70" }
 object-pool = { workspace = true }
 num_cpus = { workspace = true }
 globwalk = { workspace = true }

--- a/libs/pavex_tracing/Cargo.toml
+++ b/libs/pavex_tracing/Cargo.toml
@@ -12,5 +12,5 @@ readme = "README.md"
 [dependencies]
 tracing = { workspace = true, features = ["std"] }
 tracing_log_error = { workspace = true }
-pavex = { version = "0.1.69", path = "../pavex" }
+pavex = { version = "0.1.70", path = "../pavex" }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }

--- a/libs/pavexc/Cargo.toml
+++ b/libs/pavexc/Cargo.toml
@@ -19,9 +19,9 @@ anyhow = { workspace = true }
 debug_assertions = []
 
 [dependencies]
-pavex = { path = "../pavex", version = "0.1.69" }
-pavex_bp_schema = { path = "../pavex_bp_schema", version = "=0.1.69" }
-rustdoc_types = { path = "../pavexc_rustdoc_types", version = "=0.1.69", package = "pavexc_rustdoc_types" }
+pavex = { path = "../pavex", version = "0.1.70" }
+pavex_bp_schema = { path = "../pavex_bp_schema", version = "=0.1.70" }
+rustdoc_types = { path = "../pavexc_rustdoc_types", version = "=0.1.70", package = "pavexc_rustdoc_types" }
 tracing_log_error = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits", "visit"] }
 serde = { workspace = true, features = ["derive"] }
@@ -51,7 +51,7 @@ once_cell = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true, features = ["serde"] }
 semver = { workspace = true }
-persist_if_changed = { path = "../persist_if_changed", version = "0.1.69" }
+persist_if_changed = { path = "../persist_if_changed", version = "0.1.70" }
 matchit = { workspace = true }
 relative-path = { workspace = true }
 camino = { workspace = true }

--- a/libs/pavexc_cli/Cargo.toml
+++ b/libs/pavexc_cli/Cargo.toml
@@ -14,12 +14,12 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true, features = ["derive", "env"] }
-pavexc = { path = "../pavexc", version = "0.1.69" }
-pavexc_cli_client = { path = "../pavexc_cli_client", version = "0.1.69" }
-pavex_cli_deps = { path = "../pavex_cli_deps", version = "0.1.69" }
+pavexc = { path = "../pavexc", version = "0.1.70" }
+pavexc_cli_client = { path = "../pavexc_cli_client", version = "0.1.70" }
+pavex_cli_deps = { path = "../pavex_cli_deps", version = "0.1.70" }
 tracing_log_error = { workspace = true }
 cargo-like-utils = { workspace = true }
-pavex_miette = { path = "../pavex_miette", version = "0.1.69" }
+pavex_miette = { path = "../pavex_miette", version = "0.1.70" }
 liquid-core = { workspace = true }
 miette = { workspace = true }
 fs-err = { workspace = true }
@@ -35,7 +35,7 @@ supports-color = { workspace = true }
 include_dir = { workspace = true }
 path-absolutize = { workspace = true }
 ron = { workspace = true }
-generate_from_path = { path = "../generate_from_path", version = "0.1.69" }
+generate_from_path = { path = "../generate_from_path", version = "0.1.70" }
 tempfile = { workspace = true }
 better-panic = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/libs/pavexc_cli_client/Cargo.toml
+++ b/libs/pavexc_cli_client/Cargo.toml
@@ -9,6 +9,6 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-pavex = { path = "../pavex", version = "0.1.69" }
+pavex = { path = "../pavex", version = "0.1.70" }
 thiserror = { workspace = true }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }


### PR DESCRIPTION
## 🤖 New release
* `pavex`: 0.1.69 -> 0.1.70
* `pavex_bp_schema`: 0.1.69 -> 0.1.70
* `pavex_reflection`: 0.1.69 -> 0.1.70
* `pavex_macros`: 0.1.69 -> 0.1.70
* `persist_if_changed`: 0.1.69 -> 0.1.70
* `pavex_tracing`: 0.1.69 -> 0.1.70
* `pavex_cli`: 0.1.69 -> 0.1.70
* `pavex_cli_deps`: 0.1.69 -> 0.1.70
* `pavex_miette`: 0.1.69 -> 0.1.70
* `pavexc_cli_client`: 0.1.69 -> 0.1.70
* `pavexc`: 0.1.69 -> 0.1.70
* `pavexc_rustdoc_types`: 0.1.69 -> 0.1.70
* `pavex_cli_client`: 0.1.69 -> 0.1.70
* `pavex_session`: 0.1.69 -> 0.1.70
* `pavex_session_memory_store`: 0.1.69 -> 0.1.70
* `pavex_session_sqlx`: 0.1.69 -> 0.1.70
* `pavexc_cli`: 0.1.69 -> 0.1.70
* `generate_from_path`: 0.1.69 -> 0.1.70

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).