### PR TITLE
chore: release v0.1.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.71](https://github.com/LukeMathWalker/pavex/compare/0.1.70...0.1.71) - 2025-02-01
+
+
+### ⛰️ Features
+- Inform the user when generating JSON docs for crates in the workspace (by @LukeMathWalker) - #430
+- Strive to use the path with the smallest number of segments in the generated code (by @LukeMathWalker) - #430
+- All ApplicationState fields should be public to allow manipulation of the state ahead of request serving. This is particularly important for end-to-end tests. (by @LukeMathWalker) - #430
+- Assign unique and intelligible field names to the singletons stored inside ApplicationState (by @LukeMathWalker) - #430
+
+
+
+### 🐛 Bug Fixes
+- Don't confuse the JSON docs for different versions of the same crate. Be defensive against cargo's broken caching strategy. (by @LukeMathWalker) - #430
+
+
+
+
+### Contributors
+
+* @LukeMathWalker
+
 ## [0.1.70](https://github.com/LukeMathWalker/pavex/compare/0.1.69...0.1.70) - 2025-01-24
 
 

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "generate_from_path"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "pavex"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "biscotti",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_bp_schema"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "pavex_reflection",
  "px_workspace_hack",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_client"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "pavex",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_deps"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "cargo-like-utils",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_flock"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_cli_shell"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "cargo-like-utils",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_macros"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "pavex",
  "proc-macro2",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_miette"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "miette",
  "owo-colors",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_reflection"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "px_workspace_hack",
  "serde",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_session"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_session_memory_store"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "async-trait",
  "pavex_session",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_session_sqlx"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_test_runner"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "pavex_tracing"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "pavex",
  "px_workspace_hack",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "pavexc"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "pavexc_cli"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "better-panic",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "pavexc_cli_client"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "pavex",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "pavexc_rustdoc_types"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "px_workspace_hack",
  "rustc-hash",
@@ -2801,7 +2801,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "persist_if_changed"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "fs-err",

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 repository = "https://github.com/LukeMathWalker/pavex"
 homepage = "https://pavex.dev"
 license = "Apache-2.0"
-version = "0.1.70"
+version = "0.1.71"
 
 [workspace.dependencies]
 vergen-gitcl = { version = "1.0.5", features = ["build"] }

--- a/libs/pavex/Cargo.toml
+++ b/libs/pavex/Cargo.toml
@@ -33,15 +33,15 @@ futures-util = { workspace = true }
 mime = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-pavex_macros = { path = "../pavex_macros", version = "0.1.70" }
+pavex_macros = { path = "../pavex_macros", version = "0.1.71" }
 paste = { workspace = true }
 tracing = { workspace = true }
 http-body-util = { workspace = true }
 pin-project-lite = { workspace = true }
 ubyte = { workspace = true, features = ["serde"] }
-pavex_bp_schema = { path = "../pavex_bp_schema", version = "=0.1.70" }
-pavex_reflection = { path = "../pavex_reflection", version = "=0.1.70" }
-persist_if_changed = { path = "../persist_if_changed", version = "0.1.70" }
+pavex_bp_schema = { path = "../pavex_bp_schema", version = "=0.1.71" }
+pavex_reflection = { path = "../pavex_reflection", version = "=0.1.71" }
+persist_if_changed = { path = "../persist_if_changed", version = "0.1.71" }
 
 # Route parameters
 matchit = { workspace = true }

--- a/libs/pavex_bp_schema/Cargo.toml
+++ b/libs/pavex_bp_schema/Cargo.toml
@@ -9,5 +9,5 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-pavex_reflection = { path = "../pavex_reflection", version = "=0.1.70" }
+pavex_reflection = { path = "../pavex_reflection", version = "=0.1.71" }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -20,11 +20,11 @@ vergen-gitcl = { workspace = true }
 anyhow = { workspace = true }
 
 [dependencies]
-pavexc_cli_client = { path = "../pavexc_cli_client", version = "0.1.70" }
-pavex_cli_deps = { path = "../pavex_cli_deps", version = "0.1.70" }
-pavex_cli_shell = { path = "../pavex_cli_shell", version = "0.1.70" }
-pavex_cli_flock = { path = "../pavex_cli_flock", version = "0.1.70" }
-pavex_miette = { path = "../pavex_miette", version = "0.1.70" }
+pavexc_cli_client = { path = "../pavexc_cli_client", version = "0.1.71" }
+pavex_cli_deps = { path = "../pavex_cli_deps", version = "0.1.71" }
+pavex_cli_shell = { path = "../pavex_cli_shell", version = "0.1.71" }
+pavex_cli_flock = { path = "../pavex_cli_flock", version = "0.1.71" }
+pavex_miette = { path = "../pavex_miette", version = "0.1.71" }
 tracing_log_error = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 miette = { workspace = true }

--- a/libs/pavex_cli_client/Cargo.toml
+++ b/libs/pavex_cli_client/Cargo.toml
@@ -9,6 +9,6 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-pavex = { path = "../pavex", version = "0.1.70" }
+pavex = { path = "../pavex", version = "0.1.71" }
 thiserror = { workspace = true }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }

--- a/libs/pavex_cli_deps/Cargo.toml
+++ b/libs/pavex_cli_deps/Cargo.toml
@@ -9,6 +9,6 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-pavex_cli_shell = { path = "../pavex_cli_shell", version = "0.1.70" }
+pavex_cli_shell = { path = "../pavex_cli_shell", version = "0.1.71" }
 cargo-like-utils = { workspace = true }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }

--- a/libs/pavex_cli_flock/Cargo.toml
+++ b/libs/pavex_cli_flock/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-pavex_cli_shell = { path = "../pavex_cli_shell", version = "0.1.70" }
+pavex_cli_shell = { path = "../pavex_cli_shell", version = "0.1.71" }
 tracing = { workspace = true }
 libc = { workspace = true }
 fs-err = { workspace = true }

--- a/libs/pavex_session/Cargo.toml
+++ b/libs/pavex_session/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-pavex = { version = "0.1.70", path = "../pavex", default-features = false, features = [
+pavex = { version = "0.1.71", path = "../pavex", default-features = false, features = [
     "cookie",
 ] }
-pavex_tracing = { version = "0.1.70", path = "../pavex_tracing" }
+pavex_tracing = { version = "0.1.71", path = "../pavex_tracing" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/libs/pavex_session_memory_store/Cargo.toml
+++ b/libs/pavex_session_memory_store/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-pavex_session = { version = "0.1.70", path = "../pavex_session" }
+pavex_session = { version = "0.1.71", path = "../pavex_session" }
 time = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 async-trait = { workspace = true }

--- a/libs/pavex_session_sqlx/Cargo.toml
+++ b/libs/pavex_session_sqlx/Cargo.toml
@@ -16,7 +16,7 @@ postgres = ["sqlx/postgres"]
 all-features = true
 
 [dependencies]
-pavex_session = { version = "0.1.70", path = "../pavex_session" }
+pavex_session = { version = "0.1.71", path = "../pavex_session" }
 time = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 async-trait = { workspace = true }

--- a/libs/pavex_test_runner/Cargo.toml
+++ b/libs/pavex_test_runner/Cargo.toml
@@ -31,7 +31,7 @@ walkdir = { workspace = true }
 serde_json = { workspace = true }
 itertools = { workspace = true }
 sha2 = { workspace = true }
-persist_if_changed = { path = "../persist_if_changed", version = "0.1.70" }
+persist_if_changed = { path = "../persist_if_changed", version = "0.1.71" }
 object-pool = { workspace = true }
 num_cpus = { workspace = true }
 globwalk = { workspace = true }

--- a/libs/pavex_tracing/Cargo.toml
+++ b/libs/pavex_tracing/Cargo.toml
@@ -12,5 +12,5 @@ readme = "README.md"
 [dependencies]
 tracing = { workspace = true, features = ["std"] }
 tracing_log_error = { workspace = true }
-pavex = { version = "0.1.70", path = "../pavex" }
+pavex = { version = "0.1.71", path = "../pavex" }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }

--- a/libs/pavexc/Cargo.toml
+++ b/libs/pavexc/Cargo.toml
@@ -19,10 +19,10 @@ anyhow = { workspace = true }
 debug_assertions = []
 
 [dependencies]
-pavex = { path = "../pavex", version = "0.1.70" }
-pavex_bp_schema = { path = "../pavex_bp_schema", version = "=0.1.70" }
-pavex_cli_shell = { path = "../pavex_cli_shell", version = "=0.1.70" }
-rustdoc_types = { path = "../pavexc_rustdoc_types", version = "=0.1.70", package = "pavexc_rustdoc_types" }
+pavex = { path = "../pavex", version = "0.1.71" }
+pavex_bp_schema = { path = "../pavex_bp_schema", version = "=0.1.71" }
+pavex_cli_shell = { path = "../pavex_cli_shell", version = "=0.1.71" }
+rustdoc_types = { path = "../pavexc_rustdoc_types", version = "=0.1.71", package = "pavexc_rustdoc_types" }
 cargo-like-utils = { workspace = true }
 tracing_log_error = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits", "visit"] }
@@ -53,7 +53,7 @@ once_cell = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true, features = ["serde"] }
 semver = { workspace = true }
-persist_if_changed = { path = "../persist_if_changed", version = "0.1.70" }
+persist_if_changed = { path = "../persist_if_changed", version = "0.1.71" }
 matchit = { workspace = true }
 relative-path = { workspace = true }
 camino = { workspace = true }

--- a/libs/pavexc_cli/Cargo.toml
+++ b/libs/pavexc_cli/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true, features = ["derive", "env"] }
-pavexc = { path = "../pavexc", version = "0.1.70" }
-pavexc_cli_client = { path = "../pavexc_cli_client", version = "0.1.70" }
-pavex_cli_deps = { path = "../pavex_cli_deps", version = "0.1.70" }
-pavex_cli_shell = { path = "../pavex_cli_shell", version = "0.1.70" }
+pavexc = { path = "../pavexc", version = "0.1.71" }
+pavexc_cli_client = { path = "../pavexc_cli_client", version = "0.1.71" }
+pavex_cli_deps = { path = "../pavex_cli_deps", version = "0.1.71" }
+pavex_cli_shell = { path = "../pavex_cli_shell", version = "0.1.71" }
 tracing_log_error = { workspace = true }
 cargo-like-utils = { workspace = true }
-pavex_miette = { path = "../pavex_miette", version = "0.1.70" }
+pavex_miette = { path = "../pavex_miette", version = "0.1.71" }
 liquid-core = { workspace = true }
 miette = { workspace = true }
 fs-err = { workspace = true }
@@ -36,7 +36,7 @@ supports-color = { workspace = true }
 include_dir = { workspace = true }
 path-absolutize = { workspace = true }
 ron = { workspace = true }
-generate_from_path = { path = "../generate_from_path", version = "0.1.70" }
+generate_from_path = { path = "../generate_from_path", version = "0.1.71" }
 tempfile = { workspace = true }
 better-panic = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/libs/pavexc_cli_client/Cargo.toml
+++ b/libs/pavexc_cli_client/Cargo.toml
@@ -9,6 +9,6 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-pavex = { path = "../pavex", version = "0.1.70" }
+pavex = { path = "../pavex", version = "0.1.71" }
 thiserror = { workspace = true }
 px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }


### PR DESCRIPTION
## 🤖 New release
* `pavex`: 0.1.70 -> 0.1.71
* `pavex_bp_schema`: 0.1.70 -> 0.1.71
* `pavex_reflection`: 0.1.70 -> 0.1.71
* `pavex_macros`: 0.1.70 -> 0.1.71
* `persist_if_changed`: 0.1.70 -> 0.1.71
* `pavex_tracing`: 0.1.70 -> 0.1.71
* `pavex_cli`: 0.1.70 -> 0.1.71
* `pavex_cli_deps`: 0.1.70 -> 0.1.71
* `pavex_cli_shell`: 0.1.70 -> 0.1.71
* `pavex_cli_flock`: 0.1.70 -> 0.1.71
* `pavex_miette`: 0.1.70 -> 0.1.71
* `pavexc_cli_client`: 0.1.70 -> 0.1.71
* `pavexc`: 0.1.70 -> 0.1.71
* `pavexc_rustdoc_types`: 0.1.70 -> 0.1.71
* `pavex_cli_client`: 0.1.70 -> 0.1.71
* `pavex_session`: 0.1.70 -> 0.1.71
* `pavex_session_memory_store`: 0.1.70 -> 0.1.71
* `pavex_session_sqlx`: 0.1.70 -> 0.1.71
* `pavexc_cli`: 0.1.70 -> 0.1.71
* `generate_from_path`: 0.1.70 -> 0.1.71

<details><summary><i><b>Changelog</b></i></summary><p>

## `pavex`
<blockquote>

## [0.1.71](https://github.com/LukeMathWalker/pavex/compare/0.1.70...0.1.71) - 2025-02-01

### ⛰️ Features
- Inform the user when generating JSON docs for crates in the workspace (by @LukeMathWalker) - #430
- Strive to use the path with the smallest number of segments in the generated code (by @LukeMathWalker) - #430
- All ApplicationState fields should be public to allow manipulation of the state ahead of request serving. This is particularly important for end-to-end tests. (by @LukeMathWalker) - #430
- Assign unique and intelligible field names to the singletons stored inside ApplicationState (by @LukeMathWalker) - #430



### 🐛 Bug Fixes
- Don't confuse the JSON docs for different versions of the same crate. Be defensive against cargo's broken caching strategy. (by @LukeMathWalker) - #430




### Contributors

* @LukeMathWalker
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).