### PR TITLE
feat: Don't require native libraries to decompress archives from GitHub.

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,13 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "x86_64-pc-windows-msvc",
+]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Skip checking whether the specified configuration files are up to date

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -353,27 +353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,8 +421,6 @@ version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -600,12 +577,6 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1786,15 +1757,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,6 +2402,7 @@ dependencies = [
  "guppy",
  "hex",
  "http",
+ "itertools 0.14.0",
  "jsonwebtoken",
  "libc",
  "miette",
@@ -2782,16 +2745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,7 +2973,6 @@ dependencies = [
  "base64 0.22.1",
  "bitflags 2.8.0",
  "byteorder",
- "cc",
  "clap",
  "clap_builder",
  "console",
@@ -5266,20 +5218,6 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerovec"
@@ -5309,27 +5247,17 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
- "aes",
  "arbitrary",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",
  "displaydoc",
  "flate2",
- "hmac",
  "indexmap",
  "lzma-rs",
  "memchr",
- "pbkdf2",
- "rand",
- "sha1",
  "thiserror 2.0.11",
- "time",
- "zeroize",
  "zopfli",
- "zstd",
 ]
 
 [[package]]
@@ -5344,32 +5272,4 @@ dependencies = [
  "log",
  "once_cell",
  "simd-adler32",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -133,8 +133,11 @@ uuid = "1"
 walkdir = "2.5.0"
 windows-sys = "0.59.0"
 xdg-home = "1.3.0"
-xz2 = "0.1.7"
-zip = "2"
+# The `static` feature ensures that we won't accidentally link to the system
+# version of the library, thus requiring the user to have the library preinstalled
+# on their system at runtime.
+xz2 = { version = "0.1", features = ["static"] }
+zip = { version = "2", default-features = false }
 owo-colors = "4.1.0"
 async-trait = "0.1"
 humantime-serde = "1"

--- a/libs/pavex_cli/Cargo.toml
+++ b/libs/pavex_cli/Cargo.toml
@@ -41,7 +41,7 @@ guppy = { workspace = true }
 supports-color = { workspace = true }
 xdg-home = { workspace = true }
 sha2 = { workspace = true }
-zip = { workspace = true }
+zip = { workspace = true, features = ["deflate", "deflate64", "lzma"] }
 xz2 = { workspace = true }
 tar = { workspace = true }
 bytes = { workspace = true }
@@ -77,3 +77,4 @@ px_workspace_hack = { version = "0.1", path = "../px_workspace_hack" }
 pavex_test_runner = { path = "../pavex_test_runner" }
 # Enable more expensive debug assertions when building for testing purposes
 pavexc = { path = "../pavexc", features = ["debug_assertions"] }
+itertools = { workspace = true }

--- a/libs/pavex_cli/tests/dependency_tree.rs
+++ b/libs/pavex_cli/tests/dependency_tree.rs
@@ -1,0 +1,59 @@
+use std::collections::BTreeSet;
+
+use guppy::graph::DependencyDirection;
+use itertools::Itertools;
+
+#[test]
+pub fn allowed_sys_crates() {
+    let package_graph = guppy::MetadataCommand::new()
+        .build_graph()
+        .expect("failed to build package graph");
+
+    let cli_ids: Vec<_> = package_graph
+        .package_ids()
+        .filter(|id| {
+            let name = package_graph.metadata(id).unwrap().name();
+            name == "pavex_cli" || name == "pavexc_cli"
+        })
+        .cloned()
+        .collect();
+    assert_eq!(cli_ids.len(), 2);
+
+    let dependencies = package_graph
+        .query_directed(&cli_ids, DependencyDirection::Forward)
+        .expect("Failed to compute CLI dependencies");
+    let mut native_dependencies = BTreeSet::new();
+    for metadata in dependencies
+        // Don't check dependencies that were brought in via the workspace hack crate.
+        // Those don't affect the final release artifact.
+        .resolve_with_fn(|_, link| link.resolved_name() != "px_workspace_hack")
+        .packages(DependencyDirection::Forward)
+    {
+        if metadata.links().is_some() {
+            native_dependencies.insert(metadata.id().to_owned());
+        }
+    }
+
+    let allowed_sys_crates = BTreeSet::from([
+        "windows-sys",
+        "libsqlite3-sys",
+        // We use the `static` feature of `lzma-sys` to avoid linking to the system LZMA library.
+        "lzma-sys",
+        // Various crates in the ecosystem are not proper "*-sys" crates, but they still
+        // rely on the "link" field of `Cargo.toml` to leverage some of its properties.
+        // We need to allow them as well.
+        "prettyplease",
+        "rayon-core",
+        "ring",
+        "wasm-bindgen-shared",
+    ]);
+    for native_dep in native_dependencies {
+        let metadata = package_graph.metadata(&native_dep).unwrap();
+        assert!(
+            allowed_sys_crates.contains(metadata.name()),
+            "`{}` brings in a native dependency to one of Pavex's CLIs, but it's not in the allowlist of sys crates: {}",
+            metadata.name(),
+            allowed_sys_crates.iter().join(", ")
+        );
+    }
+}

--- a/libs/px_workspace_hack/Cargo.toml
+++ b/libs/px_workspace_hack/Cargo.toml
@@ -70,14 +70,13 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
 uuid = { version = "1", features = ["fast-rng", "serde", "v4", "v7"] }
-zeroize = { version = "1", features = ["zeroize_derive"] }
+zeroize = { version = "1" }
 
 [build-dependencies]
 aho-corasick = { version = "1" }
 base64 = { version = "0.22" }
 bitflags = { version = "2", default-features = false, features = ["serde"] }
 byteorder = { version = "1" }
-cc = { version = "1", default-features = false, features = ["parallel"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
 console = { version = "0.15" }
@@ -130,6 +129,6 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
 uuid = { version = "1", features = ["fast-rng", "serde", "v4", "v7"] }
-zeroize = { version = "1", features = ["zeroize_derive"] }
+zeroize = { version = "1" }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
Use Rust-native decompression crates to avoid install issues related to missing system dependencies on the user's host.