### PR TITLE
fix: Compare path length before iterating in lock step over their segments.

### DIFF
--- a/libs/pavexc/src/language/resolved_path.rs
+++ b/libs/pavexc/src/language/resolved_path.rs
@@ -351,7 +351,7 @@ impl PartialEq for ResolvedPath {
             package_id: other_package_id,
         } = other;
         let is_equal = package_id == other_package_id
-            && segments.len() == segments.len()
+            && segments.len() == other_segments.len()
             && qualified_self == other_qualified_self;
         if is_equal {
             // We want to ignore the first segment of the path, because dependencies can be


### PR DESCRIPTION
Fixes a (rare) panic in project generation.

See [this run](https://github.com/LukeMathWalker/pavex/actions/runs/13474322246/job/37651593168) as an example of the failure.