### PR TITLE
Enforce `Send`-ness for `SessionStore` methods

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -447,15 +447,15 @@ jobs:
     - name: Run tests
       working-directory: libs
       run: |
-        cargo test --no-run
-        cargo test --workspace --exclude="pavex_cli"
+        cargo test --all-features --no-run
+        cargo test --all-features --workspace --exclude="pavex_cli"
     - name: Run UI tests
       env:
         PAVEX_TEST_CLI_PATH: /home/runner/.cargo/bin/pavex
         PAVEXC_TEST_CLI_PATH: /home/runner/.cargo/bin/pavexc
       working-directory: libs
       run: |
-        cargo test --package pavex_cli
+        cargo test --all-features --package pavex_cli
     - uses: ./.github/actions/finalize-check
       if: ${{ always() && github.event_name != 'push' }}
       with:
@@ -606,15 +606,15 @@ jobs:
     - name: Run tests
       working-directory: libs
       run: |
-        cargo test --no-run
-        cargo test --workspace --exclude="pavex_cli"
+        cargo test --all-features --no-run
+        cargo test --all-features --workspace --exclude="pavex_cli"
     - name: Run UI tests
       env:
         PAVEX_TEST_CLI_PATH: /Users/runner/.cargo/bin/pavex
         PAVEXC_TEST_CLI_PATH: /Users/runner/.cargo/bin/pavexc
       working-directory: libs
       run: |
-        cargo test --package pavex_cli
+        cargo test --all-features --package pavex_cli
     - uses: ./.github/actions/finalize-check
       if: ${{ always() && github.event_name != 'push' }}
       with:
@@ -759,15 +759,15 @@ jobs:
     - name: Run tests
       working-directory: libs
       run: |
-        cargo test --no-run
-        cargo test --workspace --exclude="pavex_cli"
+        cargo test --all-features --no-run
+        cargo test --all-features --workspace --exclude="pavex_cli"
     - name: Run UI tests
       env:
         PAVEX_TEST_CLI_PATH: C:\Users\runneradmin\.cargo\bin\pavex.exe
         PAVEXC_TEST_CLI_PATH: C:\Users\runneradmin\.cargo\bin\pavexc.exe
       working-directory: libs
       run: |
-        cargo test --package pavex_cli
+        cargo test --all-features --package pavex_cli
     - uses: ./.github/actions/finalize-check
       if: ${{ always() && github.event_name != 'push' }}
       with:

--- a/ci_utils/templates/job_steps/tests.jinja
+++ b/ci_utils/templates/job_steps/tests.jinja
@@ -10,13 +10,13 @@
 - name: Run tests
   working-directory: libs
   run: |
-    cargo test --no-run
-    cargo test --workspace --exclude="pavex_cli"
+    cargo test --all-features --no-run
+    cargo test --all-features --workspace --exclude="pavex_cli"
 - name: Run UI tests
   env:
     PAVEX_TEST_CLI_PATH: << pavex_path(target) >>
     PAVEXC_TEST_CLI_PATH: << pavexc_path(target) >>
   working-directory: libs
   run: |
-    cargo test --package pavex_cli
+    cargo test --all-features --package pavex_cli
 <%- endblock %>

--- a/libs/pavex_session/src/store_.rs
+++ b/libs/pavex_session/src/store_.rs
@@ -91,7 +91,7 @@ impl SessionStore {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 /// The interface of a session storage backend.
 pub trait SessionStorageBackend: std::fmt::Debug + Send + Sync {
     /// Creates a new session record in the store using the provided ID.

--- a/libs/pavex_session/tests/session/fixtures.rs
+++ b/libs/pavex_session/tests/session/fixtures.rs
@@ -134,7 +134,7 @@ pub struct CallInformation {
     oplog: Vec<String>,
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl<B: SessionStorageBackend> SessionStorageBackend for SpyBackend<B> {
     async fn create(
         &self,

--- a/libs/pavex_session_memory_store/src/lib.rs
+++ b/libs/pavex_session_memory_store/src/lib.rs
@@ -88,7 +88,7 @@ impl InMemorySessionStore {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl SessionStorageBackend for InMemorySessionStore {
     /// Creates a new session record in the store using the provided ID.
     #[tracing::instrument(name = "Create server-side session record", level = tracing::Level::TRACE, skip_all)]

--- a/libs/pavex_session_sqlx/src/postgres.rs
+++ b/libs/pavex_session_sqlx/src/postgres.rs
@@ -89,7 +89,7 @@ END $$;"
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl SessionStorageBackend for PostgresSessionStore {
     /// Creates a new session record in the store using the provided ID.
     #[tracing::instrument(name = "Create server-side session record", level = tracing::Level::INFO, skip_all)]


### PR DESCRIPTION
We gain very little by allowing methods to be non-`Send` futures when the store itself is already required to be `Send` and `Sync`.