### PR TITLE
add nightly Rust to gh workflow for starter project

### DIFF
--- a/examples/starter/.github/workflows/general.yml
+++ b/examples/starter/.github/workflows/general.yml
@@ -72,11 +72,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install Rust stable toolchain
+      - name: Install Rust stable and nightly toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.6.0
         with:
           rustflags: ""
           cache: false
+          toolchain: nightly,stable
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
The github workflow `Freshness` in `general.yml` of the starter project fails without Rust nightly