### PR TITLE
fix: Always check if pavexc dependencies are installed

### DIFF
--- a/examples/starter/Dockerfile
+++ b/examples/starter/Dockerfile
@@ -23,7 +23,7 @@ RUN cargo build --release --package server --bin server
 FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 COPY --from=builder /app/target/release/server bin
-COPY server/configuration configuration
+COPY configuration configuration
 ENV PX_PROFILE=production
 # Enable backtraces to simplify debugging
 # production panics.

--- a/libs/pavexc_cli/template/Dockerfile
+++ b/libs/pavexc_cli/template/Dockerfile
@@ -23,7 +23,7 @@ RUN cargo build --release --package server --bin server
 FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 COPY --from=builder /app/target/release/server bin
-COPY server/configuration configuration
+COPY configuration configuration
 ENV PX_PROFILE=production
 # Enable backtraces to simplify debugging
 # production panics.


### PR DESCRIPTION
The check used to be run on installation, but this causes issues with CI caching: if the binary is restored from a cache in a new runner, the environment hasn't gone through the setup but the flow won't trigger since the binary is already where we expect it to be.

We now run the setup flow unconditionally.

Fixes #474 