### PR TITLE
chore: add note on ui tests to contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,13 @@ In a nutshell:
 - if the test is expected to pass, we check the generated code and the graph diagnostics;
 - if the test is expected to fail, we check `stderr` to verify the quality of the error message returned to users.
 
+UI tests are located in `libs/ui_tests` and need to invoke `pavexc`.
+For initial setup, it is therefore advised to run:
+
+```bash
+cargo build --bin pavexc && cargo test
+```
+
 ## Test runtime environment
 
 For each test, a runtime environment is created as a sub-folder of `ui_test_envs`, which is in turn generated at the root of Pavex's workspace.\


### PR DESCRIPTION
Not sure about the seemingly conflicting sentences:
> All tests are located in `libs/pavex_cli/tests` and are launched using a custom test runner that you can find in `libs/pavex_test_runner`.

and

> UI tests are located in `libs/ui_tests` and need to invoke `pavexc`.

Maybe we should reword the first one as 'All tests are collected via `libs/pavex_cli/tests`'?

Also happy to close, the hint would have saved me some time, though :)