### PR TITLE
refactor: Update graceful shutdown timeout deserialization to use `unsigned_duration::required`.

### DIFF
--- a/compiler/pavexc_cli/template/app/src/configuration.rs.liquid
+++ b/compiler/pavexc_cli/template/app/src/configuration.rs.liquid
@@ -40,24 +40,8 @@ pub struct ServerConfig {
     /// E.g. `1 minute` for a 1 minute timeout.
     ///
     /// Set the `PX_SERVER__GRACEFUL_SHUTDOWN_TIMEOUT` environment variable to override its value.
-    #[serde(deserialize_with = "deserialize_shutdown")]
+    #[serde(with = "pavex::time::fmt::serde::unsigned_duration::required")]
     pub graceful_shutdown_timeout: std::time::Duration,
-}
-
-fn deserialize_shutdown<'de, D>(deserializer: D) -> Result<std::time::Duration, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::Deserialize as _;
-
-    let duration = pavex::time::SignedDuration::deserialize(deserializer)?;
-    if duration.is_negative() {
-        Err(serde::de::Error::custom(
-            "graceful shutdown timeout must be positive",
-        ))
-    } else {
-        duration.try_into().map_err(serde::de::Error::custom)
-    }
 }
 
 impl ServerConfig {

--- a/docs/tutorials/quickstart/project/app/src/configuration.rs
+++ b/docs/tutorials/quickstart/project/app/src/configuration.rs
@@ -25,24 +25,8 @@ pub struct ServerConfig {
     /// E.g. `1 minute` for a 1 minute timeout.
     ///
     /// Set the `PX_SERVER__GRACEFUL_SHUTDOWN_TIMEOUT` environment variable to override its value.
-    #[serde(deserialize_with = "deserialize_shutdown")]
+    #[serde(with = "pavex::time::fmt::serde::unsigned_duration::required")]
     pub graceful_shutdown_timeout: std::time::Duration,
-}
-
-fn deserialize_shutdown<'de, D>(deserializer: D) -> Result<std::time::Duration, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::Deserialize as _;
-
-    let duration = pavex::time::SignedDuration::deserialize(deserializer)?;
-    if duration.is_negative() {
-        Err(serde::de::Error::custom(
-            "graceful shutdown timeout must be positive",
-        ))
-    } else {
-        duration.try_into().map_err(serde::de::Error::custom)
-    }
 }
 
 impl ServerConfig {

--- a/examples/realworld/app/src/configuration.rs
+++ b/examples/realworld/app/src/configuration.rs
@@ -26,24 +26,8 @@ pub struct ServerConfig {
     /// E.g. `1 minute` for a 1 minute timeout.
     ///
     /// Set the `PX_SERVER__GRACEFUL_SHUTDOWN_TIMEOUT` environment variable to override its value.
-    #[serde(deserialize_with = "deserialize_shutdown")]
+    #[serde(with = "pavex::time::fmt::serde::unsigned_duration::required")]
     pub graceful_shutdown_timeout: std::time::Duration,
-}
-
-fn deserialize_shutdown<'de, D>(deserializer: D) -> Result<std::time::Duration, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::Deserialize as _;
-
-    let duration = pavex::time::SignedDuration::deserialize(deserializer)?;
-    if duration.is_negative() {
-        Err(serde::de::Error::custom(
-            "graceful shutdown timeout must be positive",
-        ))
-    } else {
-        duration.try_into().map_err(serde::de::Error::custom)
-    }
 }
 
 impl ServerConfig {

--- a/examples/starter/app/src/configuration.rs
+++ b/examples/starter/app/src/configuration.rs
@@ -37,24 +37,8 @@ pub struct ServerConfig {
     /// E.g. `1 minute` for a 1 minute timeout.
     ///
     /// Set the `PX_SERVER__GRACEFUL_SHUTDOWN_TIMEOUT` environment variable to override its value.
-    #[serde(deserialize_with = "deserialize_shutdown")]
+    #[serde(with = "pavex::time::fmt::serde::unsigned_duration::required")]
     pub graceful_shutdown_timeout: std::time::Duration,
-}
-
-fn deserialize_shutdown<'de, D>(deserializer: D) -> Result<std::time::Duration, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::Deserialize as _;
-
-    let duration = pavex::time::SignedDuration::deserialize(deserializer)?;
-    if duration.is_negative() {
-        Err(serde::de::Error::custom(
-            "graceful shutdown timeout must be positive",
-        ))
-    } else {
-        duration.try_into().map_err(serde::de::Error::custom)
-    }
 }
 
 impl ServerConfig {


### PR DESCRIPTION
Support for `serde` helpers for serializing and deserializing `std::time::Duration` were added as of (https://github.com/BurntSushi/jiff/pull/445)